### PR TITLE
opencontrail: don't mix with vgw on devstack

### DIFF
--- a/topology/probes/opencontrail.go
+++ b/topology/probes/opencontrail.go
@@ -25,6 +25,7 @@ package probes
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/skydive-project/skydive/config"
@@ -200,7 +201,7 @@ func (mapper *OpenContrailMapper) nodeUpdater() {
 			return
 		}
 
-		if tp, _ := node.GetFieldString("Type"); tp == "vhost" {
+		if tp, _ := node.GetFieldString("Type"); tp == "vhost" && strings.Contains(name, "vhost") {
 			mapper.onVhostAdded(node, itf)
 		} else {
 			logging.GetLogger().Debugf("Retrieve extIDs for %s", name)


### PR DESCRIPTION
When vgw is used it has also type of vhost and it might be discovered
first in place of vhost0. In that case tap interfaces will not be linked
in the topology.