### PR TITLE
api: add/remove user metadata on node

### DIFF
--- a/api/user_metadata.go
+++ b/api/user_metadata.go
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package api
+
+import (
+	"fmt"
+
+	"github.com/nu7hatch/gouuid"
+
+	"github.com/skydive-project/skydive/topology/graph"
+)
+
+//UserMetadata describes a user metadata
+type UserMetadata struct {
+	UUID         string
+	GremlinQuery string `valid:"isGremlinExpr"`
+	Key          string `valid:"nonzero"`
+	Value        string `valid:"nonzero"`
+}
+
+//UserMetadataResourceHandler describes a user metadata resource handler
+type UserMetadataResourceHandler struct {
+}
+
+//UserMetadataAPIHandler based on BasicAPIHandler
+type UserMetadataAPIHandler struct {
+	BasicAPIHandler
+	Graph *graph.Graph
+}
+
+//NewUserMetadata creates a new user metadata
+func NewUserMetadata(query string, key string, value string) *UserMetadata {
+	id, _ := uuid.NewV4()
+
+	return &UserMetadata{
+		UUID:         id.String(),
+		GremlinQuery: query,
+		Key:          key,
+		Value:        value,
+	}
+}
+
+//New creates a new user metadata resource
+func (m *UserMetadataResourceHandler) New() Resource {
+	id, _ := uuid.NewV4()
+
+	return &UserMetadata{
+		UUID: id.String(),
+	}
+}
+
+//Name return "usermetadata"
+func (m *UserMetadataResourceHandler) Name() string {
+	return "usermetadata"
+}
+
+//ID returns the user metadata identifier
+func (m *UserMetadata) ID() string {
+	return m.UUID
+}
+
+//SetID set a new identifier for this user metadata
+func (m *UserMetadata) SetID(id string) {
+	m.UUID = id
+}
+
+//Create tests that whether the resource is duplicate or unique
+func (m *UserMetadataAPIHandler) Create(r Resource) error {
+	umd := r.(*UserMetadata)
+	resources := m.BasicAPIHandler.Index()
+	for _, resource := range resources {
+		u := resource.(*UserMetadata)
+		if u.GremlinQuery == umd.GremlinQuery && umd.Key == u.Key && umd.Value == u.Value {
+			return fmt.Errorf("Duplicate user metadata, uuid=%s", u.UUID)
+		} else if u.GremlinQuery == umd.GremlinQuery && umd.Key == u.Key && umd.Value != u.Value {
+			u.Value = umd.Value
+			return m.BasicAPIHandler.Create(u)
+		}
+	}
+
+	return m.BasicAPIHandler.Create(r)
+}
+
+//RegisterUserMetadataAPI registers a new user metadata api handler
+func RegisterUserMetadataAPI(apiServer *Server, g *graph.Graph) (*UserMetadataAPIHandler, error) {
+	userMetadataAPIHandler := &UserMetadataAPIHandler{
+		BasicAPIHandler: BasicAPIHandler{
+			ResourceHandler: &UserMetadataResourceHandler{},
+			EtcdKeyAPI:      apiServer.EtcdKeyAPI,
+		},
+		Graph: g,
+	}
+	if err := apiServer.RegisterAPIHandler(userMetadataAPIHandler); err != nil {
+		return nil, err
+	}
+	return userMetadataAPIHandler, nil
+}

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -59,4 +59,5 @@ func init() {
 	Client.AddCommand(client.PcapCmd)
 	Client.AddCommand(client.ShellCmd)
 	Client.AddCommand(client.TopologyCmd)
+	Client.AddCommand(client.UserMetadataCmd)
 }

--- a/cmd/client/user_metadata.go
+++ b/cmd/client/user_metadata.go
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package client
+
+import (
+	"os"
+
+	"github.com/skydive-project/skydive/api"
+	"github.com/skydive-project/skydive/logging"
+	"github.com/skydive-project/skydive/validator"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	key   string
+	value string
+)
+
+//UserMetadataCmd skydive user-metadata root command
+var UserMetadataCmd = &cobra.Command{
+	Use:          "user-metadata",
+	Short:        "Manage user metadata",
+	Long:         "Manage user metadata",
+	SilenceUsage: false,
+}
+
+//AddMetadata skydive user-metadata add command
+var AddMetadata = &cobra.Command{
+	Use:          "add",
+	Short:        "add user metadata",
+	Long:         "add user metadata",
+	SilenceUsage: false,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if gremlinQuery == "" || key == "" || value == "" {
+			logging.GetLogger().Error("All parameters are mantatory")
+			os.Exit(1)
+		}
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := api.NewCrudClientFromConfig(&AuthenticationOpts)
+		if err != nil {
+			logging.GetLogger().Critical(err)
+			os.Exit(1)
+		}
+		metadata := api.NewUserMetadata(gremlinQuery, key, value)
+
+		if err := validator.Validate(metadata); err != nil {
+			logging.GetLogger().Error(err)
+			os.Exit(1)
+		}
+
+		if err := client.Create("usermetadata", &metadata); err != nil {
+			logging.GetLogger().Error(err)
+			os.Exit(1)
+		}
+		printJSON(metadata)
+	},
+}
+
+//DeleteMetadata skydive user-metadata delete command
+var DeleteMetadata = &cobra.Command{
+	Use:          "delete",
+	Short:        "delete user metadata",
+	Long:         "delete user metadata",
+	SilenceUsage: false,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			cmd.Usage()
+			os.Exit(1)
+		}
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := api.NewCrudClientFromConfig(&AuthenticationOpts)
+		if err != nil {
+			logging.GetLogger().Critical(err)
+			os.Exit(1)
+		}
+
+		if err := client.Delete("usermetadata", args[0]); err != nil {
+			logging.GetLogger().Error(err)
+		}
+	},
+}
+
+//UserMetadataList skydive user-metadata list command
+var UserMetadataList = &cobra.Command{
+	Use:          "list",
+	Short:        "List user metadata",
+	Long:         "List user metadata",
+	SilenceUsage: false,
+	Run: func(cmd *cobra.Command, args []string) {
+		var metadata map[string]api.UserMetadata
+		client, err := api.NewCrudClientFromConfig(&AuthenticationOpts)
+		if err != nil {
+			logging.GetLogger().Critical(err)
+			os.Exit(1)
+		}
+
+		if err := client.List("usermetadata", &metadata); err != nil {
+			logging.GetLogger().Error(err)
+			os.Exit(1)
+		}
+		printJSON(metadata)
+	},
+}
+
+func addUserMetadataFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&gremlinQuery, "gremlin", "", "", "Node gremlin expression")
+	cmd.Flags().StringVarP(&key, "key", "", "", "Metadata key")
+	cmd.Flags().StringVarP(&value, "value", "", "", "Metadata value")
+}
+
+func init() {
+	UserMetadataCmd.AddCommand(AddMetadata)
+	UserMetadataCmd.AddCommand(DeleteMetadata)
+	UserMetadataCmd.AddCommand(UserMetadataList)
+
+	addUserMetadataFlags(AddMetadata)
+}

--- a/tests/topology_test.go
+++ b/tests/topology_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/skydive-project/skydive/api"
 	"github.com/skydive-project/skydive/common"
 	"github.com/skydive-project/skydive/config"
 	shttp "github.com/skydive-project/skydive/http"
@@ -831,6 +832,48 @@ func TestQueryMetadata(t *testing.T) {
 				return err
 			}
 
+			return nil
+		},
+	}
+
+	RunTest(t, test)
+}
+
+//TestUserMetadata tests user metadata functionality
+func TestUserMetadata(t *testing.T) {
+	test := &Test{
+		setupCmds: []helper.Cmd{
+			{"ovs-vsctl add-br br-umd", true},
+		},
+
+		tearDownCmds: []helper.Cmd{
+			{"ovs-vsctl del-br br-umd", true},
+		},
+
+		check: func(c *TestContext) error {
+			gh := c.gh
+
+			prefix := "g"
+			if !c.time.IsZero() {
+				prefix += fmt.Sprintf(".Context(%d)", common.UnixMillis(c.time))
+			}
+
+			umd := api.NewUserMetadata("G.V().Has('Name', 'br-umd', 'Type', 'ovsbridge')", "testKey", "testValue")
+
+			c.client.Create("usermetadata", &umd)
+
+			_, err := gh.GetNode(prefix + ".V().Has('UserMetadata.testKey', 'testValue')")
+			if err != nil {
+				c.client.Delete("usermetadata", umd.ID())
+				return err
+			}
+
+			c.client.Delete("usermetadata", umd.ID())
+
+			node, err := gh.GetNode(prefix + ".V().Has('UserMetadata.testKey', 'testValue')")
+			if err != nil && err.Error() != "No result found" {
+				return fmt.Errorf("User Metadata not deleted on Node: %v", node)
+			}
 			return nil
 		},
 	}

--- a/topology/enhancers/user_metadata.go
+++ b/topology/enhancers/user_metadata.go
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package metadata
+
+import (
+	"sync"
+
+	"github.com/skydive-project/skydive/api"
+	"github.com/skydive-project/skydive/logging"
+	"github.com/skydive-project/skydive/topology"
+	"github.com/skydive-project/skydive/topology/graph"
+)
+
+//UserMetadataManager describes user metadata manager
+type UserMetadataManager struct {
+	sync.RWMutex
+	graph.DefaultGraphListener
+	graph           *graph.Graph
+	metadataHandler *api.UserMetadataAPIHandler
+	metadata        map[string]*api.UserMetadata
+	watcher         api.StoppableWatcher
+}
+
+//OnNodeAdded event
+func (u *UserMetadataManager) OnNodeAdded(n *graph.Node) {
+	u.nodeEvent()
+}
+
+//OnNodeUpdated event
+func (u *UserMetadataManager) OnNodeUpdated(n *graph.Node) {
+	u.nodeEvent()
+}
+
+func (u *UserMetadataManager) nodeEvent() {
+	for _, m := range u.metadata {
+		u.addUserMetadata(m)
+	}
+}
+
+func (u *UserMetadataManager) applyGremlinExpr(query string) []interface{} {
+	res, err := topology.ExecuteGremlinQuery(u.graph, query)
+	if err != nil {
+		logging.GetLogger().Errorf("Gremlin error: %s", err.Error())
+		return nil
+	}
+	return res.Values()
+}
+
+func (u *UserMetadataManager) addUserMetadata(umd *api.UserMetadata) {
+	u.Lock()
+	u.metadata[umd.UUID] = umd
+	u.Unlock()
+
+	nodes := u.applyGremlinExpr(umd.GremlinQuery)
+	for _, node := range nodes {
+		switch node.(type) {
+		case *graph.Node:
+			u.graph.AddMetadata(node, "UserMetadata."+umd.Key, umd.Value)
+		default:
+			continue
+		}
+	}
+}
+
+func (u *UserMetadataManager) deleteUserMetadata(umd *api.UserMetadata) {
+	nodes := u.applyGremlinExpr(umd.GremlinQuery)
+	for _, node := range nodes {
+		switch node.(type) {
+		case *graph.Node:
+			u.graph.DelMetadata(node, "UserMetadata."+umd.Key)
+		default:
+			continue
+		}
+	}
+	u.Lock()
+	delete(u.metadata, umd.UUID)
+	u.Unlock()
+}
+
+func (u *UserMetadataManager) onAPIWatcherEvent(action string, id string, resource api.Resource) {
+	metadata := resource.(*api.UserMetadata)
+	switch action {
+	case "init", "create", "set", "update":
+		u.graph.Lock()
+		u.addUserMetadata(metadata)
+		u.graph.Unlock()
+	case "delete":
+		u.graph.Lock()
+		u.deleteUserMetadata(metadata)
+		u.graph.Unlock()
+
+	}
+}
+
+//Start starts user metadata manager
+func (u *UserMetadataManager) Start() {
+	u.watcher = u.metadataHandler.AsyncWatch(u.onAPIWatcherEvent)
+	u.graph.AddEventListener(u)
+}
+
+//Stop stops user metadata manager
+func (u *UserMetadataManager) Stop() {
+	u.watcher.Stop()
+	u.graph.RemoveEventListener(u)
+}
+
+//NewUserMetadataManager creates a new user metadata manager
+func NewUserMetadataManager(g *graph.Graph, u *api.UserMetadataAPIHandler) *UserMetadataManager {
+	resources := u.Index()
+	metadata := make(map[string]*api.UserMetadata)
+	for _, resource := range resources {
+		metadata[resource.ID()] = resource.(*api.UserMetadata)
+	}
+
+	umm := &UserMetadataManager{
+		graph:           g,
+		metadataHandler: u,
+		metadata:        metadata,
+	}
+	return umm
+}


### PR DESCRIPTION
User able to add and remove user metadata on node

ex-query: 1.skydive client user-metadata add --gremlin='g.v()' --key userkey --value userdata
2.skydive client user-metadata delete <UUID>