### PR TITLE
graph: replace timestamp mechanism by archive mechanism

### DIFF
--- a/analyzer/topology_server.go
+++ b/analyzer/topology_server.go
@@ -135,38 +135,26 @@ func (t *TopologyServer) OnGraphMessage(c *shttp.WSClient, msg shttp.WSMessage, 
 		r := obj.(*graph.SyncReplyMsg)
 		for _, n := range r.Nodes {
 			if t.Graph.GetNode(n.ID) == nil {
-				t.Graph.AddNode(n)
+				t.Graph.NodeAdded(n)
 			}
 		}
 		for _, e := range r.Edges {
 			if t.Graph.GetEdge(e.ID) == nil {
-				t.Graph.AddEdge(e)
+				t.Graph.EdgeAdded(e)
 			}
 		}
 	case graph.NodeUpdatedMsgType:
-		n := obj.(*graph.Node)
-		if node := t.Graph.GetNode(n.ID); node != nil {
-			t.Graph.SetMetadata(node, n.Metadata())
-		}
+		t.Graph.NodeUpdated(obj.(*graph.Node))
 	case graph.NodeDeletedMsgType:
-		t.Graph.DelNode(obj.(*graph.Node))
+		t.Graph.NodeDeleted(obj.(*graph.Node))
 	case graph.NodeAddedMsgType:
-		n := obj.(*graph.Node)
-		if t.Graph.GetNode(n.ID) == nil {
-			t.Graph.AddNode(n)
-		}
+		t.Graph.NodeAdded(obj.(*graph.Node))
 	case graph.EdgeUpdatedMsgType:
-		e := obj.(*graph.Edge)
-		if edge := t.Graph.GetEdge(e.ID); edge != nil {
-			t.Graph.SetMetadata(edge, e.Metadata())
-		}
+		t.Graph.EdgeUpdated(obj.(*graph.Edge))
 	case graph.EdgeDeletedMsgType:
-		t.Graph.DelEdge(obj.(*graph.Edge))
+		t.Graph.EdgeDeleted(obj.(*graph.Edge))
 	case graph.EdgeAddedMsgType:
-		e := obj.(*graph.Edge)
-		if t.Graph.GetEdge(e.ID) == nil {
-			t.Graph.AddEdge(e)
-		}
+		t.Graph.EdgeAdded(obj.(*graph.Edge))
 	}
 }
 

--- a/api/topology.go
+++ b/api/topology.go
@@ -69,6 +69,10 @@ func (t *TopologyAPI) graphToDot(w http.ResponseWriter, g *graph.Graph) {
 	for _, e := range g.GetEdges(nil) {
 		parent := nodeMap[e.GetParent()]
 		child := nodeMap[e.GetChild()]
+		if parent == nil || child == nil {
+			continue
+		}
+
 		childName, _ := child.GetFieldString("Name")
 		parentName, _ := parent.GetFieldString("Name")
 		relationType, _ := e.GetFieldString("RelationType")

--- a/flow/storage/elasticsearch/elasticsearch.go
+++ b/flow/storage/elasticsearch/elasticsearch.go
@@ -27,7 +27,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/lebauce/elastigo/lib"
+	"github.com/mattbaird/elastigo/lib"
 	"github.com/mitchellh/mapstructure"
 	"github.com/skydive-project/skydive/common"
 	"github.com/skydive-project/skydive/filters"

--- a/storage/elasticsearch/client.go
+++ b/storage/elasticsearch/client.go
@@ -33,14 +33,31 @@ import (
 	"sync/atomic"
 	"time"
 
-	elastigo "github.com/lebauce/elastigo/lib"
+	elastigo "github.com/mattbaird/elastigo/lib"
 
 	"github.com/skydive-project/skydive/config"
 	"github.com/skydive-project/skydive/filters"
 	"github.com/skydive-project/skydive/logging"
 )
 
-const indexVersion = 5
+const indexVersion = 6
+
+type ElasticSearchClientInterface interface {
+	FormatFilter(filter *filters.Filter, mapKey string) map[string]interface{}
+	Index(obj string, id string, data interface{}) error
+	BulkIndex(obj string, id string, data interface{}) error
+	IndexChild(obj string, parent string, id string, data interface{}) error
+	BulkIndexChild(obj string, parent string, id string, data interface{}) error
+	Update(obj string, id string, data interface{}) error
+	BulkUpdate(obj string, id string, data interface{}) error
+	UpdateWithPartialDoc(obj string, id string, data interface{}) error
+	BulkUpdateWithPartialDoc(obj string, id string, data interface{}) error
+	Get(obj string, id string) (elastigo.BaseResponse, error)
+	Delete(obj string, id string) (elastigo.BaseResponse, error)
+	BulkDelete(obj string, id string)
+	Search(obj string, query string) (elastigo.SearchResult, error)
+	Start(mappings []map[string][]byte)
+}
 
 type ElasticSearchClient struct {
 	connection *elastigo.Conn

--- a/storage/orientdb/client.go
+++ b/storage/orientdb/client.go
@@ -43,6 +43,27 @@ type Result struct {
 	Result interface{} `json:"result"`
 }
 
+type ClientInterface interface {
+	Request(method string, url string, body io.Reader) (*http.Response, error)
+	DeleteDocument(id string) error
+	GetDocument(id string) (Document, error)
+	CreateDocument(doc Document) (Document, error)
+	Upsert(doc Document, key string) (Document, error)
+	GetDocumentClass(name string) (*DocumentClass, error)
+	AlterProperty(className string, prop Property) error
+	CreateProperty(className string, prop Property) error
+	CreateClass(class ClassDefinition) error
+	CreateIndex(className string, index Index) error
+	CreateDocumentClass(class ClassDefinition) error
+	DeleteDocumentClass(name string) error
+	GetDatabase() (Document, error)
+	CreateDatabase() (Document, error)
+	Sql(query string, result interface{}) error
+	Search(query string) ([]Document, error)
+	Query(obj string, query *filters.SearchQuery, result interface{}) error
+	Connect() error
+}
+
 type Client struct {
 	url           string
 	authenticated bool

--- a/topology/graph/cachedbackend.go
+++ b/topology/graph/cachedbackend.go
@@ -24,7 +24,6 @@ package graph
 
 import (
 	"sync/atomic"
-	"time"
 
 	"github.com/skydive-project/skydive/common"
 )
@@ -45,31 +44,31 @@ func (c *CachedBackend) SetMode(mode int) {
 	c.cacheMode.Store(mode)
 }
 
-func (c *CachedBackend) AddNode(n *Node) bool {
+func (c *CachedBackend) NodeAdded(n *Node) bool {
 	mode := c.cacheMode.Load()
 
 	r := false
 	if mode != PERSISTENT_ONLY_MODE {
-		r = c.memory.AddNode(n)
+		r = c.memory.NodeAdded(n)
 	}
 
 	if mode != CACHE_ONLY_MODE {
-		r = c.persistent.AddNode(n)
+		r = c.persistent.NodeAdded(n)
 	}
 
 	return r
 }
 
-func (c *CachedBackend) DelNode(n *Node) bool {
+func (c *CachedBackend) NodeDeleted(n *Node) bool {
 	mode := c.cacheMode.Load()
 
 	r := false
 	if mode != PERSISTENT_ONLY_MODE {
-		r = c.memory.DelNode(n)
+		r = c.memory.NodeDeleted(n)
 	}
 
 	if mode != CACHE_ONLY_MODE {
-		r = c.persistent.DelNode(n)
+		r = c.persistent.NodeDeleted(n)
 	}
 
 	return r
@@ -103,31 +102,31 @@ func (c *CachedBackend) GetNodeEdges(n *Node, t *common.TimeSlice, m Metadata) (
 	return edges
 }
 
-func (c *CachedBackend) AddEdge(e *Edge) bool {
+func (c *CachedBackend) EdgeAdded(e *Edge) bool {
 	mode := c.cacheMode.Load()
 
 	r := false
 	if mode != PERSISTENT_ONLY_MODE {
-		r = c.memory.AddEdge(e)
+		r = c.memory.EdgeAdded(e)
 	}
 
 	if mode != CACHE_ONLY_MODE {
-		r = c.persistent.AddEdge(e)
+		r = c.persistent.EdgeAdded(e)
 	}
 
 	return r
 }
 
-func (c *CachedBackend) DelEdge(e *Edge) bool {
+func (c *CachedBackend) EdgeDeleted(e *Edge) bool {
 	mode := c.cacheMode.Load()
 
 	r := false
 	if mode != PERSISTENT_ONLY_MODE {
-		r = c.memory.DelEdge(e)
+		r = c.memory.EdgeDeleted(e)
 	}
 
 	if mode != CACHE_ONLY_MODE {
-		r = c.persistent.DelEdge(e)
+		r = c.persistent.EdgeDeleted(e)
 	}
 
 	return r
@@ -161,31 +160,16 @@ func (c *CachedBackend) GetEdgeNodes(e *Edge, t *common.TimeSlice, parentMetadat
 	return nil, nil
 }
 
-func (c *CachedBackend) AddMetadata(i interface{}, k string, v interface{}, t time.Time) bool {
+func (c *CachedBackend) MetadataUpdated(i interface{}) bool {
 	mode := c.cacheMode.Load()
 
 	r := false
 	if mode != CACHE_ONLY_MODE {
-		r = c.persistent.AddMetadata(i, k, v, t)
+		r = c.persistent.MetadataUpdated(i)
 	}
 
 	if mode != PERSISTENT_ONLY_MODE {
-		r = c.memory.AddMetadata(i, k, v, t)
-	}
-
-	return r
-}
-
-func (c *CachedBackend) SetMetadata(i interface{}, metadata Metadata, t time.Time) bool {
-	mode := c.cacheMode.Load()
-
-	r := false
-	if mode != CACHE_ONLY_MODE {
-		r = c.persistent.SetMetadata(i, metadata, t)
-	}
-
-	if mode != PERSISTENT_ONLY_MODE {
-		r = c.memory.SetMetadata(i, metadata, t)
+		r = c.memory.MetadataUpdated(i)
 	}
 
 	return r

--- a/topology/graph/elasticsearch_test.go
+++ b/topology/graph/elasticsearch_test.go
@@ -1,0 +1,462 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package graph
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	elastigo "github.com/mattbaird/elastigo/lib"
+
+	"github.com/skydive-project/skydive/common"
+	"github.com/skydive-project/skydive/filters"
+	"github.com/skydive-project/skydive/storage/elasticsearch"
+)
+
+type revisionArray []interface{}
+
+func (a revisionArray) Len() int {
+	return len(a)
+}
+func (a revisionArray) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+func (a revisionArray) Less(i, j int) bool {
+	e := a[i].(map[string]interface{})
+	f := a[j].(map[string]interface{})
+
+	v1, v2 := e["Revision"].(int64), f["Revision"].(int64)
+
+	return v1 < v2
+}
+
+type fakeElasticsearchClient struct {
+	revisions    map[string]interface{}
+	searches     []string
+	searchResult elastigo.SearchResult
+}
+
+func (f *fakeElasticsearchClient) getRevisions() []interface{} {
+	v := make(revisionArray, 0, len(f.revisions))
+
+	for _, value := range f.revisions {
+		v = append(v, value)
+	}
+
+	sort.Sort(v)
+
+	return []interface{}(v)
+}
+
+func (f *fakeElasticsearchClient) resetRevisions() {
+	f.revisions = make(map[string]interface{})
+}
+
+func (f *fakeElasticsearchClient) FormatFilter(filter *filters.Filter, mapKey string) map[string]interface{} {
+	es := &elasticsearch.ElasticSearchClient{}
+	return es.FormatFilter(filter, mapKey)
+}
+
+func (f *fakeElasticsearchClient) Index(obj string, id string, data interface{}) error {
+	f.revisions[id] = data
+	return nil
+}
+func (f *fakeElasticsearchClient) BulkIndex(obj string, id string, data interface{}) error {
+	f.revisions[id] = data
+	return nil
+}
+func (f *fakeElasticsearchClient) IndexChild(obj string, parent string, id string, data interface{}) error {
+	return nil
+}
+func (f *fakeElasticsearchClient) BulkIndexChild(obj string, parent string, id string, data interface{}) error {
+	return nil
+}
+func (f *fakeElasticsearchClient) Update(obj string, id string, data interface{}) error {
+	return nil
+}
+func (f *fakeElasticsearchClient) BulkUpdate(obj string, id string, data interface{}) error {
+	return nil
+}
+func (f *fakeElasticsearchClient) UpdateWithPartialDoc(obj string, id string, data interface{}) error {
+	return nil
+}
+func (f *fakeElasticsearchClient) BulkUpdateWithPartialDoc(obj string, id string, data interface{}) error {
+	if revision, ok := f.revisions[id]; ok {
+		m := revision.(map[string]interface{})
+		for k, v := range data.(map[string]interface{}) {
+			m[k] = v
+		}
+	}
+	return nil
+}
+func (f *fakeElasticsearchClient) Get(obj string, id string) (elastigo.BaseResponse, error) {
+	return elastigo.BaseResponse{}, nil
+}
+func (f *fakeElasticsearchClient) Delete(obj string, id string) (elastigo.BaseResponse, error) {
+	return elastigo.BaseResponse{}, nil
+}
+func (f *fakeElasticsearchClient) BulkDelete(obj string, id string) {
+}
+func (f *fakeElasticsearchClient) Search(obj string, query string) (elastigo.SearchResult, error) {
+	f.searches = append(f.searches, query)
+	return f.searchResult, nil
+}
+func (f *fakeElasticsearchClient) Start(mappings []map[string][]byte) {
+}
+
+func newElasticsearchGraph(t *testing.T) (*Graph, *fakeElasticsearchClient) {
+	client := &fakeElasticsearchClient{
+		revisions: make(map[string]interface{}),
+	}
+	b, err := newElasticSearchBackend(client)
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	return NewGraphFromConfig(b), client
+}
+
+// test history when doing local modification
+func TestElasticsearchLocal(t *testing.T) {
+	g, client := newElasticsearchGraph(t)
+
+	node := g.newNode("aaa", Metadata{"MTU": 1500}, time.Unix(1, 0), "host1")
+	g.addMetadata(node, "MTU", 1510, time.Unix(2, 0))
+
+	expected := []interface{}{
+		map[string]interface{}{
+			"ArchivedAt": int64(2000),
+			"CreatedAt":  int64(1000),
+			"Host":       "host1",
+			"ID":         "aaa",
+			"Metadata": Metadata{
+				"MTU": 1500,
+			},
+			"Revision":  int64(1),
+			"UpdatedAt": int64(1000),
+		},
+		map[string]interface{}{
+			"CreatedAt": int64(1000),
+			"Host":      "host1",
+			"ID":        "aaa",
+			"Metadata": Metadata{
+				"MTU": 1510,
+			},
+			"Revision":  int64(2),
+			"UpdatedAt": int64(2000),
+		},
+	}
+
+	if !reflect.DeepEqual(client.getRevisions(), expected) {
+		t.Fatalf("Expected elasticsearch records not found: \nexpected: %v\ngot: %v", expected, client.getRevisions())
+	}
+
+	g.addMetadata(node, "MTU", 1520, time.Unix(3, 0))
+
+	expected = []interface{}{
+		map[string]interface{}{
+			"ArchivedAt": int64(2000),
+			"UpdatedAt":  int64(1000),
+			"CreatedAt":  int64(1000),
+			"Host":       "host1",
+			"ID":         "aaa",
+			"Metadata": Metadata{
+				"MTU": 1500,
+			},
+			"Revision": int64(1),
+		},
+		map[string]interface{}{
+			"ArchivedAt": int64(3000),
+			"UpdatedAt":  int64(2000),
+			"CreatedAt":  int64(1000),
+			"Host":       "host1",
+			"ID":         "aaa",
+			"Metadata": Metadata{
+				"MTU": 1510,
+			},
+			"Revision": int64(2),
+		},
+		map[string]interface{}{
+			"UpdatedAt": int64(3000),
+			"CreatedAt": int64(1000),
+			"Host":      "host1",
+			"ID":        "aaa",
+			"Metadata": Metadata{
+				"MTU": 1520,
+			},
+			"Revision": int64(3),
+		},
+	}
+
+	if !reflect.DeepEqual(client.getRevisions(), expected) {
+		t.Fatalf("Expected elasticsearch records not found: \nexpected: %v\ngot: %v", expected, client.getRevisions())
+	}
+
+	client.searches = []string{}
+
+	g.delNode(node, time.Unix(4, 0))
+
+	expected = []interface{}{
+		map[string]interface{}{
+			"ArchivedAt": int64(2000),
+			"UpdatedAt":  int64(1000),
+			"CreatedAt":  int64(1000),
+			"Host":       "host1",
+			"ID":         "aaa",
+			"Metadata": Metadata{
+				"MTU": 1500,
+			},
+			"Revision": int64(1),
+		},
+		map[string]interface{}{
+			"ArchivedAt": int64(3000),
+			"UpdatedAt":  int64(2000),
+			"CreatedAt":  int64(1000),
+			"Host":       "host1",
+			"ID":         "aaa",
+			"Metadata": Metadata{
+				"MTU": 1510,
+			},
+			"Revision": int64(2),
+		},
+		map[string]interface{}{
+			"ArchivedAt": int64(4000),
+			"DeletedAt":  int64(4000),
+			"UpdatedAt":  int64(3000),
+			"CreatedAt":  int64(1000),
+			"Host":       "host1",
+			"ID":         "aaa",
+			"Metadata": Metadata{
+				"MTU": 1520,
+			},
+			"Revision": int64(3),
+		},
+	}
+
+	if !reflect.DeepEqual(client.getRevisions(), expected) {
+		t.Fatalf("Expected elasticsearch records not found: \nexpected: %v\ngot: %v", expected, client.getRevisions())
+	}
+
+	var searchEdge interface{}
+	json.Unmarshal([]byte(client.searches[0]), &searchEdge)
+
+	searchExpected := map[string]interface{}{
+		"size": float64(10000),
+		"sort": map[string]interface{}{
+			"Revision": map[string]interface{}{
+				"order":         "asc",
+				"unmapped_type": "date",
+			},
+		},
+		"query": map[string]interface{}{
+			"bool": map[string]interface{}{
+				"must": []interface{}{
+					map[string]interface{}{
+						"bool": map[string]interface{}{
+							"must_not": map[string]interface{}{
+								"exists": map[string]interface{}{
+									"field": "ArchivedAt",
+								},
+							},
+						},
+					},
+					map[string]interface{}{
+						"bool": map[string]interface{}{
+							"should": []interface{}{
+								map[string]interface{}{
+									"term": map[string]interface{}{
+										"Parent": "aaa",
+									},
+								},
+								map[string]interface{}{
+									"term": map[string]interface{}{
+										"Child": "aaa",
+									},
+								},
+							},
+						},
+					},
+					map[string]interface{}{
+						"bool": map[string]interface{}{
+							"must": []interface{}{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(searchExpected, searchEdge) {
+		t.Fatalf("Expected elasticsearch records not found: \nexpected: %s\ngot: %s", spew.Sdump(searchEdge), spew.Sdump(searchExpected))
+	}
+
+	client.resetRevisions()
+
+	node1 := newNode("aaa", Metadata{"MTU": 1500}, time.Unix(1, 0), "host1")
+	node2 := newNode("bbb", Metadata{"MTU": 1500}, time.Unix(1, 0), "host1")
+
+	edge := g.newEdge("eee", node1, node2, Metadata{"Name": "eee"}, time.Unix(1, 0), "host1")
+	g.addMetadata(edge, "Type", "veth", time.Unix(2, 0))
+
+	expected = []interface{}{
+		map[string]interface{}{
+			"ArchivedAt": int64(2000),
+			"CreatedAt":  int64(1000),
+			"Host":       "host1",
+			"ID":         "eee",
+			"Parent":     Identifier("aaa"),
+			"Child":      Identifier("bbb"),
+			"Metadata": Metadata{
+				"Name": "eee",
+			},
+			"Revision":  int64(1),
+			"UpdatedAt": int64(1000),
+		},
+		map[string]interface{}{
+			"CreatedAt": int64(1000),
+			"Host":      "host1",
+			"ID":        "eee",
+			"Parent":    Identifier("aaa"),
+			"Child":     Identifier("bbb"),
+			"Metadata": Metadata{
+				"Name": "eee",
+				"Type": "veth",
+			},
+			"Revision":  int64(2),
+			"UpdatedAt": int64(2000),
+		},
+	}
+
+	if !reflect.DeepEqual(client.getRevisions(), expected) {
+		t.Fatalf("Expected elasticsearch records not found: \nexpected: %v\ngot: %v", expected, client.getRevisions())
+	}
+}
+
+// test history when doing local modification
+func TestElasticsearchForwarded(t *testing.T) {
+	g, client := newElasticsearchGraph(t)
+	mg := newGraph(t)
+
+	node := mg.NewNode("aaa", nil, "host1")
+	g.NodeAdded(node)
+	updatedAt1 := node.updatedAt
+
+	expected := []interface{}{
+		map[string]interface{}{
+			"UpdatedAt": common.UnixMillis(updatedAt1),
+			"CreatedAt": common.UnixMillis(node.createdAt),
+			"Host":      "host1",
+			"ID":        "aaa",
+			"Metadata":  Metadata{},
+			"Revision":  int64(1),
+		},
+	}
+
+	if !reflect.DeepEqual(client.getRevisions(), expected) {
+		t.Fatalf("Expected elasticsearch records not found: \nexpected: %v\ngot: %v", expected, client.getRevisions())
+	}
+
+	mg.AddMetadata(node, "MTU", 1500)
+	updatedAt2 := node.updatedAt
+
+	client.searchResult.Hits.Hits = []elastigo.Hit{
+		elastigo.Hit{Source: node.JsonRawMessage()},
+	}
+	g.NodeUpdated(node)
+
+	expected = []interface{}{
+		map[string]interface{}{
+			"ArchivedAt": common.UnixMillis(updatedAt2),
+			"UpdatedAt":  common.UnixMillis(updatedAt1),
+			"CreatedAt":  common.UnixMillis(node.createdAt),
+			"Host":       "host1",
+			"ID":         "aaa",
+			"Metadata":   Metadata{},
+			"Revision":   int64(1),
+		},
+		map[string]interface{}{
+			"UpdatedAt": common.UnixMillis(updatedAt2),
+			"CreatedAt": common.UnixMillis(node.createdAt),
+			"Host":      "host1",
+			"ID":        "aaa",
+			"Metadata": Metadata{
+				"MTU": 1500,
+			},
+			"Revision": int64(2),
+		},
+	}
+
+	if !reflect.DeepEqual(client.getRevisions(), expected) {
+		t.Fatalf("Expected elasticsearch records not found: \nexpected: %v\ngot: %v", expected, client.getRevisions())
+	}
+
+	mg.AddMetadata(node, "MTU", 1510)
+	updatedAt3 := node.updatedAt
+
+	client.searchResult.Hits.Hits = []elastigo.Hit{
+		elastigo.Hit{Source: node.JsonRawMessage()},
+	}
+	g.NodeUpdated(node)
+
+	expected = []interface{}{
+		map[string]interface{}{
+			"ArchivedAt": common.UnixMillis(updatedAt2),
+			"UpdatedAt":  common.UnixMillis(updatedAt1),
+			"CreatedAt":  common.UnixMillis(node.createdAt),
+			"Host":       "host1",
+			"ID":         "aaa",
+			"Metadata":   Metadata{},
+			"Revision":   int64(1),
+		},
+		map[string]interface{}{
+			"ArchivedAt": common.UnixMillis(updatedAt3),
+			"UpdatedAt":  common.UnixMillis(updatedAt2),
+			"CreatedAt":  common.UnixMillis(node.createdAt),
+			"Host":       "host1",
+			"ID":         "aaa",
+			"Metadata": Metadata{
+				"MTU": 1500,
+			},
+			"Revision": int64(2),
+		},
+		map[string]interface{}{
+			"UpdatedAt": common.UnixMillis(updatedAt3),
+			"CreatedAt": common.UnixMillis(node.createdAt),
+			"Host":      "host1",
+			"ID":        "aaa",
+			"Metadata": Metadata{
+				"MTU": 1510,
+			},
+			"Revision": int64(3),
+		},
+	}
+
+	if !reflect.DeepEqual(client.getRevisions(), expected) {
+		t.Fatalf("Expected elasticsearch records not found: \nexpected: %v\ngot: %v", expected, client.getRevisions())
+	}
+}

--- a/topology/graph/memory.go
+++ b/topology/graph/memory.go
@@ -24,7 +24,6 @@ package graph
 
 import (
 	"errors"
-	"time"
 
 	"github.com/skydive-project/skydive/common"
 )
@@ -43,15 +42,11 @@ type MemoryBackend struct {
 	edges map[Identifier]*MemoryBackendEdge
 }
 
-func (m *MemoryBackend) SetMetadata(i interface{}, meta Metadata, t time.Time) bool {
+func (m *MemoryBackend) MetadataUpdated(i interface{}) bool {
 	return true
 }
 
-func (m *MemoryBackend) AddMetadata(i interface{}, k string, v interface{}, t time.Time) bool {
-	return true
-}
-
-func (m *MemoryBackend) AddEdge(e *Edge) bool {
+func (m *MemoryBackend) EdgeAdded(e *Edge) bool {
 	edge := &MemoryBackendEdge{
 		Edge: e,
 	}
@@ -98,7 +93,7 @@ func (m *MemoryBackend) GetEdgeNodes(e *Edge, t *common.TimeSlice, parentMetadat
 	return []*Node{parent.Node}, []*Node{child.Node}
 }
 
-func (m *MemoryBackend) AddNode(n *Node) bool {
+func (m *MemoryBackend) NodeAdded(n *Node) bool {
 	m.nodes[n.ID] = &MemoryBackendNode{
 		Node:  n,
 		edges: make(map[Identifier]*MemoryBackendEdge),
@@ -128,7 +123,7 @@ func (m *MemoryBackend) GetNodeEdges(n *Node, t *common.TimeSlice, meta Metadata
 	return edges
 }
 
-func (m *MemoryBackend) DelEdge(e *Edge) bool {
+func (m *MemoryBackend) EdgeDeleted(e *Edge) bool {
 	if _, ok := m.edges[e.ID]; !ok {
 		return false
 	}
@@ -146,7 +141,7 @@ func (m *MemoryBackend) DelEdge(e *Edge) bool {
 	return true
 }
 
-func (m *MemoryBackend) DelNode(n *Node) bool {
+func (m *MemoryBackend) NodeDeleted(n *Node) bool {
 	delete(m.nodes, n.ID)
 
 	return true

--- a/topology/graph/memory_test.go
+++ b/topology/graph/memory_test.go
@@ -41,7 +41,7 @@ func TestAddEdgeMissingNode(t *testing.T) {
 		},
 	}
 
-	if b.AddEdge(e) {
+	if b.EdgeAdded(e) {
 		t.Error("Edge inserted with missing nodes")
 	}
 }

--- a/topology/graph/message_test.go
+++ b/topology/graph/message_test.go
@@ -30,16 +30,6 @@ import (
 	shttp "github.com/skydive-project/skydive/http"
 )
 
-/*
-type WSMessage struct {
-	Namespace string
-	Type      string
-	UUID      string `json:",omitempty"`
-	Obj       *json.RawMessage
-	Status    int
-}
-*/
-
 func TestNullNodesEdges(t *testing.T) {
 	nodesNull := []byte(`{"Nodes": null}`)
 

--- a/topology/graph/orientdb_test.go
+++ b/topology/graph/orientdb_test.go
@@ -1,0 +1,304 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package graph
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+
+	"github.com/skydive-project/skydive/filters"
+	"github.com/skydive-project/skydive/storage/orientdb"
+)
+
+type op struct {
+	name string
+	data interface{}
+}
+
+type fakeOrientDBClient struct {
+	ops          []op
+	searchResult []orientdb.Document
+}
+
+func (f *fakeOrientDBClient) getOps() []op {
+	return f.ops
+}
+
+func (f *fakeOrientDBClient) Request(method string, url string, body io.Reader) (*http.Response, error) {
+	return nil, nil
+}
+func (f *fakeOrientDBClient) DeleteDocument(id string) error {
+	return nil
+}
+func (f *fakeOrientDBClient) GetDocument(id string) (orientdb.Document, error) {
+	return nil, nil
+}
+func (f *fakeOrientDBClient) CreateDocument(doc orientdb.Document) (orientdb.Document, error) {
+	f.ops = append(f.ops, op{name: "CreateDocument", data: doc})
+	return nil, nil
+}
+func (f *fakeOrientDBClient) Upsert(doc orientdb.Document, key string) (orientdb.Document, error) {
+	return nil, nil
+}
+func (f *fakeOrientDBClient) GetDocumentClass(name string) (*orientdb.DocumentClass, error) {
+	return nil, nil
+}
+func (f *fakeOrientDBClient) AlterProperty(className string, prop orientdb.Property) error {
+	return nil
+}
+func (f *fakeOrientDBClient) CreateProperty(className string, prop orientdb.Property) error {
+	return nil
+}
+func (f *fakeOrientDBClient) CreateClass(class orientdb.ClassDefinition) error {
+	return nil
+}
+func (f *fakeOrientDBClient) CreateIndex(className string, index orientdb.Index) error {
+	return nil
+}
+func (f *fakeOrientDBClient) CreateDocumentClass(class orientdb.ClassDefinition) error {
+	return nil
+}
+func (f *fakeOrientDBClient) DeleteDocumentClass(name string) error {
+	return nil
+}
+func (f *fakeOrientDBClient) GetDatabase() (orientdb.Document, error) {
+	return nil, nil
+}
+func (f *fakeOrientDBClient) CreateDatabase() (orientdb.Document, error) {
+	return nil, nil
+}
+func (f *fakeOrientDBClient) Sql(query string, result interface{}) error {
+	return nil
+}
+func (f *fakeOrientDBClient) Search(query string) ([]orientdb.Document, error) {
+	f.ops = append(f.ops, op{name: "Search", data: query})
+	return f.searchResult, nil
+}
+func (f *fakeOrientDBClient) Query(obj string, query *filters.SearchQuery, result interface{}) error {
+	return nil
+}
+func (f *fakeOrientDBClient) Connect() error {
+	return nil
+}
+
+func newOrientDBGraph(t *testing.T) (*Graph, *fakeOrientDBClient) {
+	client := &fakeOrientDBClient{}
+	b, err := newOrientDBBackend(client)
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	return NewGraphFromConfig(b), client
+}
+
+// test history when doing local modification
+func TestLocalHistory(t *testing.T) {
+	g, client := newOrientDBGraph(t)
+
+	client.searchResult = []orientdb.Document{
+		orientdb.Document{"value": json.Number("1")},
+	}
+
+	node := g.newNode("aaa", Metadata{"MTU": 1500}, time.Unix(1, 0), "host1")
+	g.addMetadata(node, "MTU", 1510, time.Unix(2, 0))
+
+	expected := []op{
+		{
+			name: "CreateDocument",
+			data: orientdb.Document{
+				"UpdatedAt": int64(1000),
+				"CreatedAt": int64(1000),
+				"Revision":  int64(1),
+				"@class":    "Node",
+				"ID":        Identifier("aaa"),
+				"Host":      "host1",
+				"Metadata": Metadata{
+					"MTU": 1500,
+				},
+			},
+		},
+		{
+			name: "Search",
+			data: "UPDATE Node SET ArchivedAt = 2000 WHERE DeletedAt IS NULL AND ArchivedAt IS NULL AND ID = 'aaa'",
+		},
+		{
+			name: "CreateDocument",
+			data: orientdb.Document{
+				"UpdatedAt": int64(2000),
+				"CreatedAt": int64(1000),
+				"Revision":  int64(2),
+				"@class":    "Node",
+				"ID":        Identifier("aaa"),
+				"Host":      "host1",
+				"Metadata": Metadata{
+					"MTU": 1510,
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(client.getOps()[0].data, expected[0].data) {
+		t.Fatalf("Expected orientdb records not found: \nexpected: %s\ngot: %s", spew.Sdump(expected), spew.Sdump(client.getOps()))
+	}
+
+	g.addMetadata(node, "MTU", 1520, time.Unix(3, 0))
+
+	expected = []op{
+		{
+			name: "CreateDocument",
+			data: orientdb.Document{
+				"UpdatedAt": int64(1000),
+				"CreatedAt": int64(1000),
+				"Revision":  int64(1),
+				"@class":    "Node",
+				"ID":        Identifier("aaa"),
+				"Host":      "host1",
+				"Metadata": Metadata{
+					"MTU": 1500,
+				},
+			},
+		},
+		{
+			name: "Search",
+			data: "UPDATE Node SET ArchivedAt = 2000 WHERE DeletedAt IS NULL AND ArchivedAt IS NULL AND ID = 'aaa'",
+		},
+		{
+			name: "CreateDocument",
+			data: orientdb.Document{
+				"UpdatedAt": int64(2000),
+				"CreatedAt": int64(1000),
+				"Revision":  int64(2),
+				"@class":    "Node",
+				"ID":        Identifier("aaa"),
+				"Host":      "host1",
+				"Metadata": Metadata{
+					"MTU": 1510,
+				},
+			},
+		},
+		{
+			name: "Search",
+			data: "UPDATE Node SET ArchivedAt = 3000 WHERE DeletedAt IS NULL AND ArchivedAt IS NULL AND ID = 'aaa'",
+		},
+		{
+			name: "CreateDocument",
+			data: orientdb.Document{
+				"UpdatedAt": int64(3000),
+				"CreatedAt": int64(1000),
+				"Revision":  int64(3),
+				"@class":    "Node",
+				"ID":        Identifier("aaa"),
+				"Host":      "host1",
+				"Metadata": Metadata{
+					"MTU": 1520,
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(client.getOps(), expected) {
+		t.Fatalf("Expected orientdb records not found: \nexpected: %s\ngot: %s", spew.Sdump(expected), spew.Sdump(client.getOps()))
+	}
+
+	client.searchResult = []orientdb.Document{
+		orientdb.Document{"ID": "bbb"},
+	}
+
+	g.delNode(node, time.Unix(4, 0))
+
+	expected = []op{
+		{
+			name: "CreateDocument",
+			data: orientdb.Document{
+				"UpdatedAt": int64(1000),
+				"CreatedAt": int64(1000),
+				"Revision":  int64(1),
+				"@class":    "Node",
+				"ID":        Identifier("aaa"),
+				"Host":      "host1",
+				"Metadata": Metadata{
+					"MTU": 1500,
+				},
+			},
+		},
+		{
+			name: "Search",
+			data: "UPDATE Node SET ArchivedAt = 2000 WHERE DeletedAt IS NULL AND ArchivedAt IS NULL AND ID = 'aaa'",
+		},
+		{
+			name: "CreateDocument",
+			data: orientdb.Document{
+				"UpdatedAt": int64(2000),
+				"CreatedAt": int64(1000),
+				"Revision":  int64(2),
+				"@class":    "Node",
+				"ID":        Identifier("aaa"),
+				"Host":      "host1",
+				"Metadata": Metadata{
+					"MTU": 1510,
+				},
+			},
+		},
+		{
+			name: "Search",
+			data: "UPDATE Node SET ArchivedAt = 3000 WHERE DeletedAt IS NULL AND ArchivedAt IS NULL AND ID = 'aaa'",
+		},
+		{
+			name: "CreateDocument",
+			data: orientdb.Document{
+				"UpdatedAt": int64(3000),
+				"CreatedAt": int64(1000),
+				"Revision":  int64(3),
+				"@class":    "Node",
+				"ID":        Identifier("aaa"),
+				"Host":      "host1",
+				"Metadata": Metadata{
+					"MTU": 1520,
+				},
+			},
+		},
+		{
+			name: "Search",
+			data: "SELECT FROM Link WHERE ArchivedAt is NULL AND (Parent = 'aaa' OR Child = 'aaa')",
+		},
+		{
+			name: "Search",
+			data: "UPDATE Link SET DeletedAt = 4000, ArchivedAt = 4000 WHERE DeletedAt IS NULL AND ArchivedAt IS NULL AND ID = 'bbb'",
+		},
+		{
+			name: "Search",
+			data: "UPDATE Node SET DeletedAt = 4000, ArchivedAt = 4000 WHERE DeletedAt IS NULL AND ArchivedAt IS NULL AND ID = 'aaa'",
+		},
+	}
+
+	if !reflect.DeepEqual(client.getOps(), expected) {
+		t.Fatalf("Expected orientdb records not found: \nexpected: %s\ngot: %s", spew.Sdump(expected), spew.Sdump(client.getOps()))
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -467,6 +467,12 @@
 			"revisionTime": "2016-02-21T03:53:41Z"
 		},
 		{
+			"checksumSHA1": "dvabztWVQX8f6oMLRyv4dLH+TGY=",
+			"path": "github.com/davecgh/go-spew/spew",
+			"revision": "346938d642f2ec3594ed81d874461961cd0faa76",
+			"revisionTime": "2016-10-29T20:57:26Z"
+		},
+		{
 			"checksumSHA1": "f1wARLDzsF/JoyN01yoxXEwFIp8=",
 			"path": "github.com/docker/distribution/digest",
 			"revision": "325b0804fef3a66309d962357aac3c2ce3f4d329",
@@ -934,23 +940,24 @@
 			"revisionTime": "2013-11-06T22:25:44Z"
 		},
 		{
-			"checksumSHA1": "V5VI2dn9Jv7YVhvvFu/GtulBfP4=",
-			"path": "github.com/lebauce/elastigo",
-			"revision": "83f25ddf31290323a0a9dd72117be65a43705f2f",
-			"revisionTime": "2016-10-25T13:05:53Z"
-		},
-		{
-			"checksumSHA1": "YktYtyOpl+XdSqT56DdJ3cy0t+M=",
-			"comment": "v1.0-258-g451c29b",
-			"path": "github.com/lebauce/elastigo/lib",
-			"revision": "83f25ddf31290323a0a9dd72117be65a43705f2f",
-			"revisionTime": "2016-10-25T13:05:53Z"
-		},
-		{
 			"checksumSHA1": "KCgFx/QQG9vUtshnL9aUxeWGFyY=",
 			"comment": "v1.6.0-1-gc81f9d7",
 			"path": "github.com/magiconair/properties",
 			"revision": "c81f9d71af8f8cba1466501d30326b99a4e56c19"
+		},
+		{
+			"checksumSHA1": "1AfJEGDJfegnLKaiGGCHNFAep8Y=",
+			"origin": "github.com/safchain/elastigo",
+			"path": "github.com/mattbaird/elastigo",
+			"revision": "9dc64d2def002a03e8cbe3c4720652a5bc5ff1c0",
+			"revisionTime": "2017-07-05T21:36:00Z"
+		},
+		{
+			"checksumSHA1": "bj9+bd8GDNCZE4ZtiKmoZQedjQc=",
+			"origin": "github.com/safchain/elastigo/lib",
+			"path": "github.com/mattbaird/elastigo/lib",
+			"revision": "9dc64d2def002a03e8cbe3c4720652a5bc5ff1c0",
+			"revisionTime": "2017-07-05T21:36:00Z"
 		},
 		{
 			"checksumSHA1": "DdH3xAkzAWJ4B/LGYJyCeRsly2I=",


### PR DESCRIPTION
This patch aims to fix histo issue introducing a
Revision field and supporting multiple updates
at the same time.

For elasticsearch two updates will be merged.
For orientdb the Revsion field will be used
to ensure to get the right version of an element.

This patch ensures that the timestamp are the ones
set by agents.

This patch ensures also that edges deleted due to
node delete will have the same DeletedAt.