### PR TITLE
Build : move bash-completion out of build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,6 @@ all: install
 	go-bindata ${GO_BINDATA_FLAGS} -nometadata -o statics/bindata.go -pkg=statics -ignore=bindata.go statics/* statics/css/images/* statics/js/vendor/* statics/js/components/*
 	gofmt -w -s statics/bindata.go
 
-skydive-bash-completion.sh: .proto govendor cmd/completion/completion.go
-	go run cmd/completion/completion.go
-
 .compile:
 	${GOPATH}/bin/govendor install ${GOFLAGS} ${VERBOSE_FLAGS} +local
 
@@ -130,7 +127,7 @@ builddep:
 	go get github.com/golang/protobuf/protoc-gen-go
 	go get github.com/jteeuwen/go-bindata/...
 
-genlocalfiles: .proto .bindata skydive-bash-completion.sh
+genlocalfiles: .proto .bindata
 
 clean: test.functionals.cleanup
 	grep path vendor/vendor.json | perl -pe 's|.*": "(.*?)".*|\1|g' | xargs -n 1 go clean -i >/dev/null 2>&1 || true

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -66,4 +66,5 @@ func init() {
 	RootCmd.AddCommand(Analyzer)
 	RootCmd.AddCommand(Client)
 	RootCmd.AddCommand(AllInOne)
+	RootCmd.AddCommand(BashCompletion)
 }

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -20,10 +20,22 @@
  *
  */
 
-package main
+package cmd
 
-import "github.com/skydive-project/skydive/cmd"
+import (
+	"fmt"
 
-func main() {
-	cmd.RootCmd.GenBashCompletionFile("skydive-bash-completion.sh")
+	"github.com/spf13/cobra"
+)
+
+// BashCompletion skydive root command
+var BashCompletion = &cobra.Command{
+	Use:          "bash-completion",
+	Short:        "generate bash completion helper",
+	Long:         "generate bash completion helper (skydive-bash-completion.sh)",
+	SilenceUsage: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		RootCmd.GenBashCompletionFile("skydive-bash-completion.sh")
+		fmt.Println("skydive-bash-completion.sh has been generated")
+	},
 }

--- a/contrib/packaging/rpm/skydive.spec
+++ b/contrib/packaging/rpm/skydive.spec
@@ -84,7 +84,7 @@ flows informations will be captured.
 export GOPATH=%{_builddir}/skydive-%{source}
 export GO15VENDOREXPERIMENT=1
 %gobuild -o bin/skydive %{import_path}
-go run cmd/completion/completion.go
+bin/skydive bash-completion
 
 %install
 export GOPATH=%{_builddir}/skydive-%{source}


### PR DESCRIPTION
skydive-bash-completion.sh is embedded inside skydive binary, via skydive
bash-completion command.

Signed-off-by: Nicolas PLANEL <nplanel@redhat.com>