### PR TITLE
Ignore .vagrant directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ vendor/gopkg.in/
 contrib/packaging/rpm/*.tar.gz
 flow/*.pb.go
 statics/bindata.go
-
+contrib/vagrant/.vagrant/
 .idea


### PR DESCRIPTION
When launching virtual machines through vagrant, vagrant creates a hidden folder containing the state of those machines.

Signed-off-by: Christophe Vanlancker <christophe.vanlancker@inuits.eu>