### PR TITLE
flow: introduce flowState and use json omit for raw packet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,9 @@ all: install
 	# if it's a Outer or Inner packet.
 	sed -e 's/ParentUUID\(.*\),omitempty\(.*\)/ParentUUID\1\2/' -e 's/int64\(.*\),omitempty\(.*\)/int64\1\2/' -i flow/flow.pb.go
 	# do not export LastRawPackets used internally
-	sed -e 's/LastRawPackets/lastRawPackets/g' -e 's/GetlastRawPackets/GetLastRawPackets/' -i flow/flow.pb.go
+	sed -e 's/json:"LastRawPackets,omitempty"/json:"-"/g' -i flow/flow.pb.go
+	# add flowState to flow generated struct
+	sed -e 's/type Flow struct {/type Flow struct {\n  state flowState/' -i flow/flow.pb.go
 
 .bindata: builddep
 	go-bindata ${GO_BINDATA_FLAGS} -nometadata -o statics/bindata.go -pkg=statics -ignore=bindata.go statics/* statics/css/images/* statics/js/vendor/* statics/js/components/*

--- a/flow/storage/elasticsearch/elasticsearch.go
+++ b/flow/storage/elasticsearch/elasticsearch.go
@@ -188,7 +188,7 @@ func (c *ElasticSearchStorage) StoreFlows(flows []*flow.Flow) error {
 			logging.GetLogger().Errorf("Error while indexing: %s", err.Error())
 			continue
 		}
-		for _, r := range f.GetLastRawPackets() {
+		for _, r := range f.LastRawPackets {
 			rawpacket := map[string]interface{}{
 				"LinkType":  linkType,
 				"Timestamp": r.Timestamp,

--- a/flow/storage/orientdb/orientdb.go
+++ b/flow/storage/orientdb/orientdb.go
@@ -212,7 +212,7 @@ func (c *OrientDBStorage) StoreFlows(flows []*flow.Flow) error {
 			logging.GetLogger().Errorf("Error while indexing: %s", err.Error())
 			continue
 		}
-		for _, r := range flow.GetLastRawPackets() {
+		for _, r := range flow.LastRawPackets {
 			doc := flowRawPacketToDocument(linkType, r)
 			doc["Flow"] = flowID
 			if _, err = c.client.CreateDocument(doc); err != nil {

--- a/flow/traversal/traversal.go
+++ b/flow/traversal/traversal.go
@@ -614,11 +614,10 @@ func (f *FlowTraversalStep) RawPackets() *RawPacketsTraversalStep {
 				return &RawPacketsTraversalStep{error: err}
 			}
 
-			rawpackets := fl.GetLastRawPackets()
-			if len(rawpackets) > 0 {
+			if len(fl.LastRawPackets) > 0 {
 				rawPackets[fl.UUID] = &flow.RawPackets{
 					LinkType:   linkType,
-					RawPackets: rawpackets,
+					RawPackets: fl.LastRawPackets,
 				}
 			}
 		}


### PR DESCRIPTION
a flowState struct pointer is added to Flow generated struct
which can be used to keep internal flow status within the
flow table.

Metrics now makes use of this.