### PR TITLE
ovsdb: link orphan ovs internal interface to bridge

### DIFF
--- a/topology/probes/netlink.go
+++ b/topology/probes/netlink.go
@@ -256,9 +256,7 @@ func (u *NetNsNetLinkProbe) addOvsLinkToTopology(link netlink.Link, m graph.Meta
 		intf = u.Graph.NewNode(graph.GenID(), m)
 	}
 
-	if !topology.HaveOwnershipLink(u.Graph, u.Root, intf, nil) {
-		topology.AddOwnershipLink(u.Graph, u.Root, intf, nil)
-	}
+	topology.AddOwnershipLink(u.Graph, u.Root, intf, nil)
 
 	return intf
 }

--- a/topology/probes/ovsdb.go
+++ b/topology/probes/ovsdb.go
@@ -64,7 +64,7 @@ func isOvsLogicalInterface(intf *graph.Node) bool {
 	case "gre", "vxlan", "geneve", "patch":
 		return true
 	}
-	return false
+	return true
 }
 
 // OnOvsBridgeUpdate event
@@ -105,7 +105,7 @@ func (o *OvsdbProbe) OnOvsBridgeAdd(monitor *ovsdb.OvsMonitor, uuid string, row 
 				// internal ovs interface that have to be linked to the bridge as they
 				// are just logical interface.
 				if intf, ok := o.portToIntf[uuid]; ok && isOvsLogicalInterface(intf) {
-					if !topology.HaveOwnershipLink(o.Graph, bridge, intf, nil) {
+					if !topology.IsOwnershipLinked(o.Graph, intf) {
 						topology.AddOwnershipLink(o.Graph, bridge, intf, nil)
 					}
 				}
@@ -283,7 +283,7 @@ func (o *OvsdbProbe) OnOvsInterfaceAdd(monitor *ovsdb.OvsMonitor, uuid string, r
 
 		puuid, _ := port.GetFieldString("UUID")
 		if brige, ok := o.portToBridge[puuid]; ok && isOvsLogicalInterface(intf) {
-			if !topology.HaveOwnershipLink(o.Graph, brige, intf, nil) {
+			if !topology.IsOwnershipLinked(o.Graph, intf) {
 				topology.AddOwnershipLink(o.Graph, brige, intf, nil)
 			}
 		}
@@ -408,7 +408,7 @@ func (o *OvsdbProbe) OnOvsPortAdd(monitor *ovsdb.OvsMonitor, uuid string, row *l
 		}
 
 		if intf, ok := o.portToIntf[uuid]; ok && isOvsLogicalInterface(intf) {
-			if !topology.HaveOwnershipLink(o.Graph, bridge, intf, nil) {
+			if !topology.IsOwnershipLinked(o.Graph, intf) {
 				topology.AddOwnershipLink(o.Graph, bridge, intf, nil)
 			}
 		}

--- a/topology/topology.go
+++ b/topology/topology.go
@@ -137,7 +137,7 @@ func BuildHostNodeTIDMap(nodes []*graph.Node) HostNodeTIDMap {
 	return hnmap
 }
 
-// HaveOwnershipLink returns true parent and child have the same ownership
+// HaveOwnershipLink returns true if parent and child have an ownership link
 func HaveOwnershipLink(g *graph.Graph, parent *graph.Node, child *graph.Node, metadata graph.Metadata) bool {
 	// do not add or change original metadata
 	m := metadata.Clone()
@@ -146,7 +146,13 @@ func HaveOwnershipLink(g *graph.Graph, parent *graph.Node, child *graph.Node, me
 	return g.AreLinked(parent, child, m)
 }
 
-// AddOwnershipLink Link the parent and the child node, the child can have only one parent, previous will be overwritten
+// IsOwnershipLinked checks whether the node as an OwnershipLink
+func IsOwnershipLinked(g *graph.Graph, node *graph.Node) bool {
+	edges := g.GetNodeEdges(node, graph.Metadata{"RelationType": OwnershipLink})
+	return len(edges) != 0
+}
+
+// AddOwnershipLink Link between the parent and the child node, the child can have only one parent, previous will be overwritten
 func AddOwnershipLink(g *graph.Graph, parent *graph.Node, child *graph.Node, metadata graph.Metadata) *graph.Edge {
 	// a child node can only have one parent of type ownership, so delete the previous link
 	for _, e := range g.GetNodeEdges(child, graph.Metadata{"RelationType": OwnershipLink}) {


### PR DESCRIPTION
This occurs when an internal interface is pushed into
a namespace and the namespace is not seen by the netns
probe. In that case the netlink probe is not linking
the interface to the namespace. As the interface
can't be linked to the namespace this patch link it
to the ovs bridge.