### PR TITLE
neutron: do not reuse metadata map as value.

### DIFF
--- a/storage/elasticsearch/client.go
+++ b/storage/elasticsearch/client.go
@@ -395,6 +395,8 @@ func NewElasticSearchClient(addr string, port string, maxConns int, retrySeconds
 	if bulkMaxDocs > 0 {
 		indexer.BulkMaxDocs = bulkMaxDocs
 	}
+	// override the default error chan size
+	indexer.ErrorChannel = make(chan *elastigo.ErrorBuffer, 100)
 
 	if bulkMaxDelay > 0 {
 		indexer.BufferDelayMax = time.Duration(bulkMaxDelay) * time.Second


### PR DESCRIPTION
We shouldn't use a map as metadata value or
we shouldn't modify it after commit since
a map is a pointer modifying it can be reported
to the datastore especially in case of bulk
operations.

This patch increases a bit the error chan.