### PR TITLE
ui: set selectedNode to null when deleted

### DIFF
--- a/statics/js/components/graph-layout.js
+++ b/statics/js/components/graph-layout.js
@@ -416,6 +416,8 @@ TopologyGraphLayout.prototype = {
   },
 
   delNode: function(node) {
+    if (this.selectedNode === node) this.selectedNode = null;
+
     delete this.nodes[node.id];
     delete this._nodes[node.id];
 


### PR DESCRIPTION
Thix fixes an issue when we have a node
selected which is deleted. In that case
the next call the selectNode will raise
an exception.