### PR TITLE
ui: expand all childs in a group

### DIFF
--- a/statics/css/skydive.css
+++ b/statics/css/skydive.css
@@ -190,7 +190,7 @@ li.capture-item {
   padding-bottom: 5px;
 }
 
-.capture-action {
+.capture-action, .node-action {
   float: right;
   cursor: pointer;
   font-size: 1.2em;

--- a/statics/js/components/graph-layout.js
+++ b/statics/js/components/graph-layout.js
@@ -809,6 +809,42 @@ TopologyGraphLayout.prototype = {
     this.showNode(n);
   },
 
+  uncollapseGroupTree: function(group) {
+    this.delCollapseLinks(group);
+
+    var i;
+    for (i = group._memberArray.length -1; i >= 0; i--) {
+      this.uncollapseNode(group._memberArray[i], group);
+    }
+    group.collapsed = false;
+
+    var children = group.children;
+    for (i in children) {
+      this.uncollapseGroupTree(children[i]);
+    }
+    this.g.select("#node-" + group.owner.id)
+      .attr('collapsed', group.collapsed)
+      .select('image.collapsexpand')
+      .attr('xlink:href', this.collapseImg);
+  },
+
+  collapseGroupTree: function(group) {
+    var i, children = group.children;
+    for (i in children) {
+      if (children[i].collapsed) this.collapseGroupTree(children[i]);
+    }
+
+    for (i = group.memberArray.length - 1; i >= 0; i--) {
+      this.collapseNode(group.memberArray[i], group);
+    }
+    group.collapsed = true;
+
+    this.g.select("#node-" + group.owner.id)
+      .attr('collapsed', group.collapsed)
+      .select('image.collapsexpand')
+      .attr('xlink:href', this.collapseImg);
+  },
+
   uncollapseGroup: function(group) {
     this.delCollapseLinks(group);
 
@@ -828,6 +864,17 @@ TopologyGraphLayout.prototype = {
       .attr('collapsed', group.collapsed)
       .select('image.collapsexpand')
       .attr('xlink:href', this.collapseImg);
+  },
+
+  toggleExpandAll: function(d) {
+    if (d.isGroupOwner()) {
+      if(!d.group.collapsed) {
+        this.collapseGroupTree(d.group);
+      } else {
+        this.uncollapseGroupTree(d.group);
+      }
+    }
+    this.update();
   },
 
   collapseByNode: function(d) {

--- a/statics/js/components/topology.js
+++ b/statics/js/components/topology.js
@@ -29,6 +29,14 @@ var TopologyComponent = {
                   title="Reset" @click="zoomReset">Reset</button>\
           <button id="expand-collapse" type="button" class="btn btn-primary" \
                   @click="toggleCollapse">{{collapsed ? "Expand" : "Collapse"}}</button>\
+          <button v-if="currentNode != null" id="expand-all" type="button" class="btn btn-primary" \
+                  title="Expand/Collapse Current Node Tree" @click="toggleExpandAll(currentNode)">\
+            <span>\
+              <i class="fa" \
+                      :class="{\'fa-expand\': currentNode.group.collapsed, \'fa-compress\': !currentNode.group.collapsed}">\
+              </i>\
+            </span>\
+          </button>\
         </div>\
       </div>\
       <div id="right-panel" class="col-sm-5 fill info">\
@@ -49,7 +57,12 @@ var TopologyComponent = {
             <span v-if="time" class="label center-block node-time">\
               Interface state at {{timeHuman}}\
             </span>\
-            <h1>metadatas<span class="pull-right">(id: {{currentNode.id}})</span></h1>\
+            <h1>metadatas<span class="pull-right">(id: {{currentNode.id}})\
+	      <i class="node-action fa"\
+	         title="Expand/Collapse Node"\
+		 :class="{\'fa-expand\': currentNode.group.collapsed, \'fa-compress\': !currentNode.group.collapsed}"\
+		 @click="toggleExpandAll(currentNode)"></i></span>\
+	    </h1>\
             <div id="metadata-panel" class="sub-left-panel">\
               <object-detail :object="currentNodeMetadata"></object-detail>\
             </div>\
@@ -259,6 +272,10 @@ var TopologyComponent = {
     expand: function() {
       this.collapsed = false;
       this.layout.collapse(this.collapsed);
+    },
+
+    toggleExpandAll: function(node) {
+      this.layout.toggleExpandAll(node);
     },
 
     extractMetadata: function(metadata, exclude) {


### PR DESCRIPTION
added a dedicated button for node to expand
and collapse all the child groups in the node group.