### PR TITLE
openflow: handles superimposed openflow rules

### DIFF
--- a/tests/openflow_test.go
+++ b/tests/openflow_test.go
@@ -8,81 +8,91 @@ import (
 	"github.com/skydive-project/skydive/tests/helper"
 )
 
-func TestAddOFRule(t *testing.T) {
+type ruleCmd struct {
+	rule string
+	add  bool
+}
+
+func verify(c *TestContext, expected []int) error {
+	for i, e := range expected {
+		gh := c.gh
+		gremlin := "g"
+		if !c.time.IsZero() {
+			gremlin += fmt.Sprintf(".Context(%d)", common.UnixMillis(c.time))
+		}
+
+		gremlin += `.V().Has("Type", "ovsbridge", "Name", "br-test1")`
+		gremlin += fmt.Sprintf(`.Out("Type", "ofrule").Has("actions","resubmit(;%d)")`, i+1)
+		nodes, err := gh.GetNodes(gremlin)
+		if err != nil {
+			return err
+		}
+		l := len(nodes)
+		if l != e {
+			return fmt.Errorf("expected %d rules with 'resubmit(,%d)' but got %d - %v", e, i+1, l, nodes)
+		}
+	}
+	return nil
+}
+
+func makeTest(t *testing.T, rules []ruleCmd, expected []int) {
+	setupCmds := []helper.Cmd{
+		{"ovs-vsctl add-br br-test1", true},
+		{"ovs-vsctl add-port br-test1 intf1 -- set interface intf1 type=internal", true},
+		{"ovs-vsctl add-port br-test1 intf2 -- set interface intf2 type=internal", true},
+	}
+
+	for _, ruleCmd := range rules {
+		var cmd string
+		if ruleCmd.add {
+			cmd = fmt.Sprintf("ovs-ofctl add-flow br-test1 %s", ruleCmd.rule)
+		} else {
+			cmd = fmt.Sprintf("ovs-ofctl del-flows --strict br-test1 %s", ruleCmd.rule)
+		}
+		setupCmds = append(setupCmds, helper.Cmd{Cmd: cmd, Check: true})
+	}
+
 	test := &Test{
-		setupCmds: []helper.Cmd{
-			{"ovs-vsctl add-br br-test1", true},
-			{"ovs-vsctl add-port br-test1 intf1 -- set interface intf1 type=internal", true},
-			{"ovs-vsctl add-port br-test1 intf2 -- set interface intf2 type=internal", true},
-			{"ovs-ofctl add-flow br-test1 table=0,priority=0,in_port=1,actions=drop", true},
-		},
+		setupCmds: setupCmds,
 
 		tearDownCmds: []helper.Cmd{
 			{"ovs-vsctl del-br br-test1", true},
 		},
 
 		check: func(c *TestContext) error {
-			gh := c.gh
-			gremlin := "g"
-			if !c.time.IsZero() {
-				gremlin += fmt.Sprintf(".Context(%d)", common.UnixMillis(c.time))
-			}
-
-			gremlin += `.V().Has("Type", "ovsbridge", "Name", "br-test1")`
-			gremlin += `.Out("Type", "ofrule").Has("actions","drop")`
-
-			nodes, err := gh.GetNodes(gremlin)
-			if err != nil {
-				return err
-			}
-
-			if len(nodes) != 1 {
-				return fmt.Errorf("Expected 1 node, got %+v", nodes)
-			}
-
-			return nil
+			return verify(c, expected)
 		},
 	}
 
 	RunTest(t, test)
 }
 
+func TestAddOFRule(t *testing.T) {
+	makeTest(
+		t,
+		[]ruleCmd{{"table=0,priority=0,in_port=1,actions=resubmit(,1)", true}},
+		[]int{1})
+}
+
 func TestDelOFRule(t *testing.T) {
-	test := &Test{
-		setupCmds: []helper.Cmd{
-			{"ovs-vsctl add-br br-test1", true},
-			{"ovs-vsctl add-port br-test1 intf1 -- set interface intf1 type=internal", true},
-			{"ovs-vsctl add-port br-test1 intf2 -- set interface intf2 type=internal", true},
-			{"ovs-ofctl add-flow br-test1 table=0,priority=0,in_port=1,actions=drop", true},
-			{"ovs-ofctl del-flows br-test1 table=0,in_port=1", true},
+	makeTest(
+		t,
+		[]ruleCmd{
+			{"table=0,priority=0,in_port=1,actions=resubmit(,1)", true},
+			{"table=0,priority=0,in_port=1", false},
 		},
+		[]int{0})
+}
 
-		tearDownCmds: []helper.Cmd{
-			{"ovs-vsctl del-br br-test1", true},
+func TestSuperimposedOFRule(t *testing.T) {
+	makeTest(
+		t,
+		[]ruleCmd{
+			{"table=0,priority=1,actions=resubmit(,1)", true},
+			{"table=0,priority=2,actions=resubmit(,2)", true},
+			{"table=0,priority=0,in_port=1,actions=resubmit(,3)", true},
+			{"table=0,priority=3,actions=resubmit(,4)", true},
+			{"table=0,priority=2", false},
 		},
-
-		check: func(c *TestContext) error {
-			gh := c.gh
-			gremlin := "g"
-			if !c.time.IsZero() {
-				gremlin += fmt.Sprintf(".Context(%d)", common.UnixMillis(c.time))
-			}
-
-			gremlin += `.V().Has("Type", "ovsbridge", "Name", "br-test1")`
-			gremlin += `.Out("Type", "ofrule").Has("actions","drop")`
-
-			nodes, err := gh.GetNodes(gremlin)
-			if err != nil {
-				return err
-			}
-
-			if len(nodes) != 0 {
-				return fmt.Errorf("Expected 1 node, got %+v", nodes)
-			}
-
-			return nil
-		},
-	}
-
-	RunTest(t, test)
+		[]int{1, 0, 1, 1})
 }

--- a/topology/probes/ovs_of_test.go
+++ b/topology/probes/ovs_of_test.go
@@ -54,17 +54,17 @@ func TestParseEvent(t *testing.T) {
 	if event.Bridge != "br" {
 		t.Error("wrong bridge assigned")
 	}
-	if event.Rule.Actions != "" {
+	if event.RawRule.Actions != "" {
 		t.Error("No action here")
 	}
-	if event.Rule.Filter != "dl_src=01:00:00:00:00:00/01:00:00:00:00:00" {
-		t.Errorf("Bad filter: %s", event.Rule.Filter)
+	if event.RawRule.Filter != "dl_src=01:00:00:00:00:00/01:00:00:00:00:00" {
+		t.Errorf("Bad filter: %s", event.RawRule.Filter)
 	}
-	if event.Rule.Cookie != 32 {
+	if event.RawRule.Cookie != 32 {
 		t.Errorf("Bad cookie")
 	}
-	if event.Rule.Table != 21 {
-		t.Errorf("Bad table: %d", event.Rule.Table)
+	if event.RawRule.Table != 21 {
+		t.Errorf("Bad table: %d", event.RawRule.Table)
 	}
 }
 
@@ -74,17 +74,17 @@ func TestParseEventWithAction(t *testing.T) {
 	if err != nil {
 		t.Error("parseEvent should succeed")
 	}
-	if event.Rule.Actions != "resubmit(;1)" {
-		t.Errorf("Bad action: %s", event.Rule.Actions)
+	if event.RawRule.Actions != "resubmit(;1)" {
+		t.Errorf("Bad action: %s", event.RawRule.Actions)
 	}
-	if event.Rule.Filter != "" {
-		t.Errorf("No filter here %s", event.Rule.Filter)
+	if event.RawRule.Filter != "" {
+		t.Errorf("No filter here %s", event.RawRule.Filter)
 	}
-	if event.Rule.Cookie != 32 {
+	if event.RawRule.Cookie != 32 {
 		t.Errorf("Bad cookie")
 	}
-	if event.Rule.Table != 21 {
-		t.Errorf("Bad table: %d", event.Rule.Table)
+	if event.RawRule.Table != 21 {
+		t.Errorf("Bad table: %d", event.RawRule.Table)
 	}
 }
 
@@ -94,17 +94,17 @@ func TestParseEventRemove(t *testing.T) {
 	if err != nil {
 		t.Error("parseEvent should succeed")
 	}
-	if event.Rule.Actions != "" {
+	if event.RawRule.Actions != "" {
 		t.Errorf("No action here")
 	}
-	if event.Rule.Filter != "ip,nw_dst=192.168.0.1" {
-		t.Errorf("Bad filter %s", event.Rule.Filter)
+	if event.RawRule.Filter != "ip,nw_dst=192.168.0.1" {
+		t.Errorf("Bad filter %s", event.RawRule.Filter)
 	}
-	if event.Rule.Cookie != 0 {
+	if event.RawRule.Cookie != 0 {
 		t.Errorf("Bad cookie")
 	}
-	if event.Rule.Table != 66 {
-		t.Errorf("Bad table: %d", event.Rule.Table)
+	if event.RawRule.Table != 66 {
+		t.Errorf("Bad table: %d", event.RawRule.Table)
 	}
 }
 
@@ -250,11 +250,11 @@ func TestCompleteRule(t *testing.T) {
 	executor = ExecuteForTest{Results: []string{"NXST_FLOW reply (xid=0x4):\n cookie=0x20, duration=57227.249s, table=21, n_packets=0, n_bytes=0, idle_age=57227, priority=1,dl_src=01:00:00:00:00:00/01:00:00:00:00:00 actions=drop"}}
 	var line = " event=ADDED table=21 cookie=32 dl_src=01:00:00:00:00:00/01:00:00:00:00:00\n"
 	event, _ := parseEvent(line, "br", "host-br-")
-	err := completeRule(probe, &event)
+	err := completeEvent(probe, &event, "host-br-")
 	if err != nil {
 		t.Error("completeRule: Should not err")
 	}
-	rule := event.Rule
+	rule := event.Rules[0]
 	if rule.Filter != "priority=1,dl_src=01:00:00:00:00:00/01:00:00:00:00:00" || rule.Actions != "drop" {
 		t.Errorf("completeRule: fails action=%s, filter=%s", rule.Actions, rule.Filter)
 	}


### PR DESCRIPTION
Rules can have the same filters (table, cookie, field filter)
but different priorities. They cannot be distinguished by ovs-ofctl monitor
and only dump-flows can discriminate them. The code was failing to
accomodate those rules by trying to be too smart both for adding and
deleting rules. The solution is to create a bucket for all rules with
same filter and associate the UUID obtained by forgetting about the priority.
Updating the content of the bucket is made by comparing the content
of the graph and the result of the query. Usually there is only one
rule in the bucket so performances are good.

closes #367