### PR TITLE
openflow: Openflow rules must be removed when bridge disapear

### DIFF
--- a/tests/openflow_test.go
+++ b/tests/openflow_test.go
@@ -96,3 +96,25 @@ func TestSuperimposedOFRule(t *testing.T) {
 		},
 		[]int{1, 0, 1, 1})
 }
+
+func TestDelRuleWithBridge(t *testing.T) {
+	setupCmds := []helper.Cmd{
+		{"ovs-vsctl add-br br-test1", true},
+		{"ovs-vsctl add-port br-test1 intf1 -- set interface intf1 type=internal", true},
+		{"ovs-vsctl add-port br-test1 intf2 -- set interface intf2 type=internal", true},
+		{"sleep 1", true},
+		{"ovs-ofctl add-flow br-test1 table=0,priority=1,actions=resubmit(,1)", true},
+		{"sleep 1", true},
+		{"ovs-vsctl del-br br-test1", true},
+	}
+
+	test := &Test{
+		setupCmds: setupCmds,
+
+		tearDownCmds: []helper.Cmd{},
+
+		check: func(c *TestContext) error { return verify(c, []int{0}) },
+	}
+
+	RunTest(t, test)
+}

--- a/topology/probes/ovsdb.go
+++ b/topology/probes/ovsdb.go
@@ -135,11 +135,11 @@ func (o *OvsdbProbe) OnOvsBridgeDel(monitor *ovsdb.OvsMonitor, uuid string, row 
 	defer o.Graph.Unlock()
 
 	bridge := o.Graph.LookupFirstNode(graph.Metadata{"UUID": uuid})
+	if o.OvsOfProbe != nil {
+		o.OvsOfProbe.OnOvsBridgeDel(uuid, bridge)
+	}
 	if bridge != nil {
 		o.Graph.DelNode(bridge)
-	}
-	if o.OvsOfProbe != nil {
-		o.OvsOfProbe.OnOvsBridgeDel(uuid, row)
 	}
 }
 


### PR DESCRIPTION
When a bridge is closed, ovs-ofctl monitor receives the events that rules are removed but the probe fails to identify the priority of the rules and
does not remove them. So it is necessary to remove all rules from the graph.

closes #413