### PR TITLE
websocket: add AddClient for wsIncomerPool to not loose the type

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -175,7 +175,7 @@ func NewAgent() (*Agent, error) {
 		return nil, err
 	}
 
-	wsServer := shttp.NewWSJSONServer(shttp.NewWSServerFromConfig(hserver, "/ws"))
+	wsServer := shttp.NewWSJSONServer(shttp.NewWSServer(hserver, "/ws"))
 
 	tr := traversal.NewGremlinTraversalParser()
 	tr.AddTraversalExtension(topology.NewTopologyTraversalExtension())

--- a/analyzer/flow_server.go
+++ b/analyzer/flow_server.go
@@ -86,7 +86,7 @@ func (c *FlowServerWebSocketConn) OnMessage(client shttp.WSSpeaker, m shttp.WSMe
 // Start a WebSocket flow server
 func (c *FlowServerWebSocketConn) Serve(ch chan *flow.Flow, quit chan struct{}, wg *sync.WaitGroup) {
 	c.ch = ch
-	server := shttp.NewWSServerFromConfig(c.server, "/ws/flow")
+	server := shttp.NewWSServer(c.server, "/ws/flow")
 	server.AddEventHandler(c)
 	go func() {
 		server.Start()

--- a/analyzer/server.go
+++ b/analyzer/server.go
@@ -157,7 +157,7 @@ func NewServerFromConfig() (*Server, error) {
 		return nil, err
 	}
 
-	wsServer := shttp.NewWSJSONServer(shttp.NewWSServerFromConfig(hserver, "/ws"))
+	wsServer := shttp.NewWSJSONServer(shttp.NewWSServer(hserver, "/ws"))
 
 	topologyServer, err := NewTopologyServer(wsServer, NewAnalyzerAuthenticationOpts())
 	if err != nil {

--- a/http/pool.go
+++ b/http/pool.go
@@ -108,6 +108,18 @@ func (s *WSPool) AddClient(c WSSpeaker) error {
 	return nil
 }
 
+// AddClient adds the given WSSpeaker to the wsIncomerPool.
+func (s *wsIncomerPool) AddClient(c WSSpeaker) error {
+	s.Lock()
+	s.speakers = append(s.speakers, c)
+	s.Unlock()
+
+	// This is to call WSSpeakerPool.On{Message,Disconnected}
+	c.AddEventHandler(s)
+
+	return nil
+}
+
 // OnMessage forwards the OnMessage event to event listeners of the pool.
 func (s *WSPool) OnMessage(c WSSpeaker, m WSMessage) {
 	s.eventHandlersLock.RLock()

--- a/http/wsserver.go
+++ b/http/wsserver.go
@@ -104,8 +104,3 @@ func NewWSServer(server *Server, endpoint string) *WSServer {
 	server.HandleFunc(endpoint, s.serveMessages)
 	return s
 }
-
-// NewWSServerFromConfig returns a new WSServer using configuration.
-func NewWSServerFromConfig(server *Server, endpoint string) *WSServer {
-	return NewWSServer(server, endpoint)
-}


### PR DESCRIPTION
Using the same AddClient implementation for WSPool and wsIncomerPool
leads to loose the original while add the listener. Then the on
disconnected callback is not the right one but always the one of
WSPool.

This causes to not disconnect the WebSocket Flow client.