### PR TITLE
ui: node select should disable after error click

### DIFF
--- a/statics/js/components/node-selector.js
+++ b/statics/js/components/node-selector.js
@@ -46,6 +46,7 @@ Vue.component('node-selector', {
               node = value = e.target.__data__;
             } else {
               self.$error({message: "Capture not allowed on this node"});
+              $(".topology-d3").off('click');
               return;
             }
           } else {


### PR DESCRIPTION
in capture select function should be disabled
after an error click