### PR TITLE
Fix: Add ability to SubGraph to receive output of ShortestPath

### DIFF
--- a/topology/graph/traversal/traversal_parser.go
+++ b/topology/graph/traversal/traversal_parser.go
@@ -549,6 +549,8 @@ func (s *GremlinTraversalStepSubGraph) Exec(last GraphTraversalStep) (GraphTrave
 		return last.(*GraphTraversalE).SubGraph(s.Params...), nil
 	case *GraphTraversalV:
 		return last.(*GraphTraversalV).SubGraph(s.Params...), nil
+	case *GraphTraversalShortestPath:
+		return last.(*GraphTraversalShortestPath).SubGraph(s.Params...), nil
 	}
 
 	return nil, ErrExecutionError

--- a/topology/graph/traversal/traversal_test.go
+++ b/topology/graph/traversal/traversal_test.go
@@ -637,6 +637,13 @@ func TestTraversalParser(t *testing.T) {
 	}
 
 	// next traversal test
+	query = `G.V().Has("Value", 2).ShortestPathTo(Metadata("Value", 4)).SubGraph().V()`
+	res = execTraversalQuery(t, g, query)
+	if len(res.Values()) != 3 {
+		t.Fatalf("Should return 3 nodes, returned: %v", res.Values())
+	}
+
+	// next traversal test
 	query = `G.V().Has("IPV4", Ipv4Range("192.168.0.0/24"))`
 	res = execTraversalQuery(t, g, query)
 	if len(res.Values()) != 1 {


### PR DESCRIPTION
Small change to add ability for SubGraph() to work on the output
of ShortestPathTo that returns list of lists

To check the functionality run:
g.V().Has("Name", "port1").ShortestPathTo(Metadata("Name", "port2"))
as a filter or find

Bug Fix: #556