### PR TITLE
make: 'make install' works when 'skydive' is a symlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ static: govendor genlocalfiles
 	test -f /etc/debian_version && govendor install -tags netgo --ldflags '-extldflags "-static /usr/lib/x86_64-linux-gnu/libz.a /usr/lib/x86_64-linux-gnu/liblzma.a /usr/lib/x86_64-linux-gnu/libicuuc.a /usr/lib/x86_64-linux-gnu/libicudata.a /usr/lib/x86_64-linux-gnu/libxml2.a /usr/lib/x86_64-linux-gnu/libc.a /usr/lib/x86_64-linux-gnu/libdl.a /usr/lib/x86_64-linux-gnu/libpthread.a /usr/lib/x86_64-linux-gnu/libc++.a /usr/lib/x86_64-linux-gnu/libm.a"' ${VERBOSE_FLAGS} +local || true
 
 contribs:
-	$(MAKE) -C contrib/snort
+	$(MAKE) -C ${PWD}/contrib/snort
 
 dpdk.build:
 ifeq ($(WITH_DPDK), true)


### PR DESCRIPTION
to reproduce the issue which was addressed you need to:

$ cd $GOPATH
$ cd src/github.com/skydive-project
$ git clone git@github.com/skydive-project/skydive.git skydive-label
$ ln -s skydive-label skydive
$ cd skydive
$ make clean
$ make static
$ make install <==== this step failed and is addressed by this fix
