### PR TITLE
websocket: improve ping mechanism for better disconnection handling

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -122,6 +122,8 @@ func init() {
 	cfg.SetDefault("storage.orientdb.database", "Skydive")
 	cfg.SetDefault("storage.orientdb.username", "root")
 	cfg.SetDefault("storage.orientdb.password", "root")
+
+	cfg.SetDefault("ws_ping_delay", 2)
 	cfg.SetDefault("ws_pong_timeout", 5)
 	cfg.SetDefault("ws_bulk_maxmsgs", 100)
 	cfg.SetDefault("ws_bulk_maxdelay", 1)

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -3,8 +3,10 @@
 # host_id is used to reference the agent by default set to hostname
 # host_id:
 
-# WebSocket Ping/Pong timeout in second
-ws_pong_timeout: 5
+# WebSocket delay between two pings.
+# ws_ping_delay: 2
+# WebSocket Ping/Pong timeout in second.
+# ws_pong_timeout: 5
 # maximum number of topology aggregated messages before sending
 # ws_bulk_maxmsgs: 100
 # duration in seconds before flushing topology aggregated messages


### PR DESCRIPTION
Terminate a connection if ping failed and add parameter to set ping
delay. Now pne can increase pong timeout without increasing the
host_id conflict time as the connection lost will probably detected
while sending ping.