### PR TITLE
epbf: fix build on old distros (using bcc package)

### DIFF
--- a/doc/content/getting-started/install.md
+++ b/doc/content/getting-started/install.md
@@ -21,6 +21,7 @@ Skydive relies on two main components:
 * llvm
 * clang
 * kernel-headers / linux-libc-dev
+* bcc / bcc-devel
 
 ## Install
 

--- a/probe/ebpf/Makefile
+++ b/probe/ebpf/Makefile
@@ -5,7 +5,8 @@ all: flow.o
 
 %.o: %.c
 	$(CLANG) \
-	  -I ../../vendor/github.com/iovisor/gobpf/elf \
+		-I ../../vendor/github.com/iovisor/gobpf/elf \
+		-I /usr/include/bcc/compat \
 		-D__KERNEL__ -D__ASM_SYSREG_H -Wno-unused-value -Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
 		-O2 -emit-llvm -c $< -o -| $(LLC) -march=bpf -filetype=obj -o $@


### PR DESCRIPTION
on Ubuntu 16.04 check no depredations by running:

```
$ sudo apt-get install -y clang llvm
$ cd probe/ebpf
$ make clean all
```

On Ubuntu 14.04 check that it compiles now by running:

```
$ sudo apt-get install -y clang llvm
$ sudo apt-get install -y bcc
$ cd probe/ebpf
$ make clean all
```
