### PR TITLE
pi: API to stop the injection

### DIFF
--- a/api/server/handler.go
+++ b/api/server/handler.go
@@ -178,6 +178,18 @@ func (h *BasicAPIHandler) Delete(id string) error {
 	return nil
 }
 
+//Update a resource
+func (h *BasicAPIHandler) Update(id string, resource types.Resource) error {
+	data, err := json.Marshal(&resource)
+	if err != nil {
+		return err
+	}
+
+	etcdPath := fmt.Sprintf("/%s/%s", h.ResourceHandler.Name(), id)
+	_, err = h.EtcdKeyAPI.Update(context.Background(), etcdPath, string(data))
+	return err
+}
+
 // AsyncWatch registers a new resource watcher
 func (h *BasicAPIHandler) AsyncWatch(f WatcherCallback) StoppableWatcher {
 	etcdPath := fmt.Sprintf("/%s/", h.ResourceHandler.Name())

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -122,6 +122,7 @@ type ElectionStatus struct {
 
 // PacketParamsReq packet injector API parameters
 type PacketParamsReq struct {
+	UUID       string
 	Src        string
 	Dst        string
 	SrcIP      string
@@ -133,9 +134,20 @@ type PacketParamsReq struct {
 	Type       string
 	Payload    string
 	TrackingID string
-	ID         int64
+	ICMPID     int64
 	Count      int64
 	Interval   int64
+	StartTime  time.Time
+}
+
+// ID returns the packet injector request identifier
+func (ppr *PacketParamsReq) ID() string {
+	return ppr.UUID
+}
+
+// SetID set a new identifier for this injector
+func (ppr *PacketParamsReq) SetID(id string) {
+	ppr.UUID = id
 }
 
 type PeersStatus struct {

--- a/packet_injector/client.go
+++ b/packet_injector/client.go
@@ -26,9 +26,25 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 	"net/http"
+	"strings"
+	"time"
 
+	apiServer "github.com/skydive-project/skydive/api/server"
+	"github.com/skydive-project/skydive/api/types"
+	"github.com/skydive-project/skydive/common"
+	"github.com/skydive-project/skydive/etcd"
+	ge "github.com/skydive-project/skydive/gremlin/traversal"
 	shttp "github.com/skydive-project/skydive/http"
+	"github.com/skydive-project/skydive/logging"
+	"github.com/skydive-project/skydive/topology/graph"
+	"github.com/skydive-project/skydive/validator"
+)
+
+const (
+	min = 1024
+	max = 65535
 )
 
 type PacketInjectorReply struct {
@@ -37,7 +53,31 @@ type PacketInjectorReply struct {
 }
 
 type PacketInjectorClient struct {
-	pool shttp.WSJSONSpeakerPool
+	*etcd.EtcdMasterElector
+	pool      shttp.WSJSONSpeakerPool
+	watcher   apiServer.StoppableWatcher
+	graph     *graph.Graph
+	piHandler *apiServer.PacketInjectorAPI
+}
+
+func (pc *PacketInjectorClient) StopInjection(host string, uuid string) error {
+	msg := shttp.NewWSJSONMessage(Namespace, "PIStopRequest", uuid)
+
+	resp, err := pc.pool.Request(host, msg, shttp.DefaultRequestTimeout)
+	if err != nil {
+		return fmt.Errorf("Unable to send message to agent %s: %s", host, err.Error())
+	}
+
+	var reply PacketInjectorReply
+	if err := json.Unmarshal([]byte(*resp.Obj), &reply); err != nil {
+		return fmt.Errorf("Failed to parse response from %s: %s", host, err.Error())
+	}
+
+	if resp.Status != http.StatusOK {
+		return errors.New(reply.Error)
+	}
+
+	return nil
 }
 
 func (pc *PacketInjectorClient) InjectPacket(host string, pp *PacketParams) (string, error) {
@@ -60,6 +100,226 @@ func (pc *PacketInjectorClient) InjectPacket(host string, pp *PacketParams) (str
 	return reply.TrackingID, nil
 }
 
-func NewPacketInjectorClient(pool shttp.WSJSONSpeakerPool) *PacketInjectorClient {
-	return &PacketInjectorClient{pool: pool}
+func (pc *PacketInjectorClient) normalizeIP(ip, ipFamily string) string {
+	if strings.Contains(ip, "/") {
+		return ip
+	}
+	if ipFamily == "IPV4" {
+		return ip + "/32"
+	}
+	return ip + "/64"
+}
+
+func (pc *PacketInjectorClient) getNode(gremlinQuery string) *graph.Node {
+	res, err := ge.TopologyGremlinQuery(pc.graph, gremlinQuery)
+	if err != nil {
+		return nil
+	}
+
+	for _, value := range res.Values() {
+		switch value.(type) {
+		case *graph.Node:
+			return value.(*graph.Node)
+		default:
+			return nil
+		}
+	}
+	return nil
+}
+
+func (pc *PacketInjectorClient) requestToParams(ppr *types.PacketParamsReq) (string, *PacketParams, error) {
+	pc.graph.RLock()
+	defer pc.graph.RUnlock()
+
+	srcNode := pc.getNode(ppr.Src)
+	dstNode := pc.getNode(ppr.Dst)
+
+	if srcNode == nil {
+		return "", nil, errors.New("Not able to find a source node")
+	}
+
+	ipField := "IPV4"
+	if ppr.Type == "icmp6" || ppr.Type == "tcp6" || ppr.Type == "udp6" {
+		ipField = "IPV6"
+	}
+
+	if ppr.SrcIP == "" {
+		ips, _ := srcNode.GetFieldStringList(ipField)
+		if len(ips) == 0 {
+			return "", nil, errors.New("No source IP in node and user input")
+		}
+		ppr.SrcIP = ips[0]
+	} else {
+		ppr.SrcIP = pc.normalizeIP(ppr.SrcIP, ipField)
+	}
+
+	if ppr.DstIP == "" {
+		if dstNode != nil {
+			ips, _ := dstNode.GetFieldStringList(ipField)
+			if len(ips) == 0 {
+				return "", nil, errors.New("No dest IP in node and user input")
+			}
+			ppr.DstIP = ips[0]
+		} else {
+			return "", nil, errors.New("Not able to find a dest node and dest IP also empty")
+		}
+	} else {
+		ppr.DstIP = pc.normalizeIP(ppr.DstIP, ipField)
+	}
+
+	if ppr.SrcMAC == "" {
+		if srcNode != nil {
+			mac, _ := srcNode.GetFieldString("MAC")
+			if mac == "" {
+				return "", nil, errors.New("No source MAC in node and user input")
+			}
+			ppr.SrcMAC = mac
+		} else {
+			return "", nil, errors.New("Not able to find a source node and source MAC also empty")
+		}
+	}
+
+	if ppr.DstMAC == "" {
+		if dstNode != nil {
+			mac, _ := dstNode.GetFieldString("MAC")
+			if mac == "" {
+				return "", nil, errors.New("No dest MAC in node and user input")
+			}
+			ppr.DstMAC = mac
+		} else {
+			return "", nil, errors.New("Not able to find a dest node and dest MAC also empty")
+		}
+	}
+
+	if ppr.Type == "tcp4" || ppr.Type == "tcp6" {
+		if ppr.SrcPort == 0 {
+			ppr.SrcPort = rand.Int63n(max-min) + min
+		}
+		if ppr.DstPort == 0 {
+			ppr.DstPort = rand.Int63n(max-min) + min
+		}
+	}
+
+	pp := &PacketParams{
+		UUID:      ppr.UUID,
+		SrcNodeID: srcNode.ID,
+		SrcIP:     ppr.SrcIP,
+		SrcMAC:    ppr.SrcMAC,
+		SrcPort:   ppr.SrcPort,
+		DstIP:     ppr.DstIP,
+		DstMAC:    ppr.DstMAC,
+		DstPort:   ppr.DstPort,
+		Type:      ppr.Type,
+		Payload:   ppr.Payload,
+		Count:     ppr.Count,
+		Interval:  ppr.Interval,
+		ID:        ppr.ICMPID,
+	}
+
+	if errs := validator.Validate(pp); errs != nil {
+		return "", nil, errors.New("All the parms not set properly")
+	}
+
+	return srcNode.Host(), pp, nil
+}
+
+func (pc *PacketInjectorClient) expirePI(id string, expireTime time.Duration) {
+	time.Sleep(expireTime)
+	pc.piHandler.BasicAPIHandler.Delete(id)
+}
+
+// OnStartAsMaster event
+func (pc *PacketInjectorClient) OnStartAsMaster() {
+}
+
+// OnStartAsSlave event
+func (pc *PacketInjectorClient) OnStartAsSlave() {
+}
+
+// OnSwitchToMaster event
+func (pc *PacketInjectorClient) OnSwitchToMaster() {
+	pc.setTimeouts()
+}
+
+// OnSwitchToSlave event
+func (pc *PacketInjectorClient) OnSwitchToSlave() {
+}
+
+func (pc *PacketInjectorClient) onAPIWatcherEvent(action string, id string, resource types.Resource) {
+	logging.GetLogger().Debugf("New watcher event %s for %s", action, id)
+	ppr := resource.(*types.PacketParamsReq)
+	switch action {
+	case "create", "set":
+		host, pp, err := pc.requestToParams(ppr)
+		if err != nil {
+			pc.piHandler.TrackingId <- ""
+			logging.GetLogger().Errorf("Not able to parse request: %s", err.Error())
+			pc.piHandler.BasicAPIHandler.Delete(ppr.UUID)
+			return
+		}
+		trackingID, err := pc.InjectPacket(host, pp)
+		if err != nil {
+			pc.piHandler.TrackingId <- ""
+			logging.GetLogger().Errorf("Not able to inject on host %s :: %s", host, err.Error())
+			pc.piHandler.BasicAPIHandler.Delete(ppr.UUID)
+			return
+		}
+		pc.piHandler.TrackingId <- trackingID
+		ppr.TrackingID = trackingID
+		ppr.StartTime = time.Now()
+		pc.piHandler.BasicAPIHandler.Update(ppr.UUID, ppr)
+
+		go pc.expirePI(ppr.UUID, time.Duration(ppr.Count*ppr.Interval)*time.Millisecond)
+	case "expire", "delete":
+		pc.graph.RLock()
+		srcNode := pc.getNode(ppr.Src)
+		pc.graph.RUnlock()
+		if srcNode == nil {
+			return
+		}
+		pc.StopInjection(srcNode.Host(), ppr.UUID)
+	}
+}
+
+//Start the PI client
+func (pc *PacketInjectorClient) Start() {
+	pc.EtcdMasterElector.StartAndWait()
+	pc.watcher = pc.piHandler.AsyncWatch(pc.onAPIWatcherEvent)
+}
+
+//Stop the PI client
+func (pc *PacketInjectorClient) Stop() {
+	pc.watcher.Stop()
+	pc.EtcdMasterElector.Stop()
+}
+
+func (pc *PacketInjectorClient) setTimeouts() {
+	injections := pc.piHandler.Index()
+	for _, v := range injections {
+		ppr := v.(*types.PacketParamsReq)
+		validity := ppr.StartTime.Add(time.Duration(ppr.Count*ppr.Interval) * time.Millisecond)
+		if validity.After(time.Now()) {
+			elapsedTime := time.Now().Sub(ppr.StartTime)
+			totalTime := time.Duration(ppr.Count*ppr.Interval) * time.Millisecond
+			go pc.expirePI(ppr.UUID, totalTime-elapsedTime)
+		} else {
+			pc.piHandler.BasicAPIHandler.Delete(ppr.UUID)
+		}
+	}
+}
+
+func NewPacketInjectorClient(pool shttp.WSJSONSpeakerPool, etcdClient *etcd.EtcdClient, piHandler *apiServer.PacketInjectorAPI, g *graph.Graph) *PacketInjectorClient {
+	elector := etcd.NewEtcdMasterElectorFromConfig(common.AnalyzerService, "pi-client", etcdClient)
+
+	pic := &PacketInjectorClient{
+		EtcdMasterElector: elector,
+		pool:              pool,
+		piHandler:         piHandler,
+		graph:             g,
+	}
+
+	elector.AddEventListener(pic)
+
+	pic.setTimeouts()
+	return pic
 }

--- a/packet_injector/server.go
+++ b/packet_injector/server.go
@@ -40,7 +40,24 @@ const (
 
 // PacketInjectorServer creates a packet injector server API
 type PacketInjectorServer struct {
-	Graph *graph.Graph
+	Graph    *graph.Graph
+	Channels *Channels
+}
+
+func (pis *PacketInjectorServer) stopPI(msg *shttp.WSJSONMessage) error {
+	var uuid string
+	if err := common.JSONDecode(bytes.NewBuffer([]byte(*msg.Obj)), &uuid); err != nil {
+		return err
+	}
+	pis.Channels.Lock()
+	c, ok := pis.Channels.Pipes[uuid]
+	pis.Channels.Unlock()
+	if ok {
+		c <- true
+		return nil
+	} else {
+		return fmt.Errorf("No PI running on this ID: %s", uuid)
+	}
 }
 
 func (pis *PacketInjectorServer) injectPacket(msg *shttp.WSJSONMessage) (string, error) {
@@ -49,7 +66,7 @@ func (pis *PacketInjectorServer) injectPacket(msg *shttp.WSJSONMessage) (string,
 		return "", fmt.Errorf("Unable to decode packet inject param message %v", msg)
 	}
 
-	trackingID, err := InjectPacket(&params, pis.Graph)
+	trackingID, err := InjectPacket(&params, pis.Graph, pis.Channels)
 	if err != nil {
 		return "", fmt.Errorf("Failed to inject packet: %s", err.Error())
 	}
@@ -74,13 +91,25 @@ func (pis *PacketInjectorServer) OnWSJSONMessage(c shttp.WSSpeaker, msg *shttp.W
 		}
 
 		c.SendMessage(reply)
+	case "PIStopRequest":
+		var reply *shttp.WSJSONMessage
+		err := pis.stopPI(msg)
+		replyObj := &PacketInjectorReply{}
+		if err != nil {
+			replyObj.Error = err.Error()
+			reply = msg.Reply(replyObj, "PIStopResult", http.StatusBadRequest)
+		} else {
+			reply = msg.Reply(replyObj, "PIStopResult", http.StatusOK)
+		}
+		c.SendMessage(reply)
 	}
 }
 
 // NewServer creates a new packet injector server API based on websocket server
 func NewServer(graph *graph.Graph, pool shttp.WSJSONSpeakerPool) *PacketInjectorServer {
 	s := &PacketInjectorServer{
-		Graph: graph,
+		Graph:    graph,
+		Channels: &Channels{Pipes: make(map[string](chan bool))},
 	}
 	pool.AddJSONMessageHandler(s, []string{Namespace})
 	return s

--- a/statics/js/components/inject-form.js
+++ b/statics/js/components/inject-form.js
@@ -252,7 +252,7 @@ Vue.component('inject-form', {
           "DstMAC": this.dstMAC,
           "Type": this.type,
           "Count": this.count,
-          "ID": this.id,
+          "ICMPID": this.id,
           "Interval": this.interval,
           "Payload": this.payload,
         }),

--- a/tests/flow_test.go
+++ b/tests/flow_test.go
@@ -1062,7 +1062,7 @@ func TestICMP(t *testing.T) {
 				DstIP:    "10.0.0.2/24",
 				Count:    1,
 				Interval: 1000,
-				ID:       123,
+				ICMPID:   123,
 			}
 			err := pingRequest(t, c, req)
 			if err != nil {
@@ -1078,7 +1078,7 @@ func TestICMP(t *testing.T) {
 				DstIP:    "fd49:37c8:5229::2/48",
 				Count:    1,
 				Interval: 1000,
-				ID:       456,
+				ICMPID:   456,
 			}
 			err = pingRequest(t, c, req)
 			ipv6TrackingID = req.TrackingID

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -398,7 +398,7 @@ func ping(t *testing.T, context *TestContext, ipVersion int, src string, dst str
 		Dst:      dst,
 		Type:     fmt.Sprintf("icmp%d", ipVersion),
 		Count:    count,
-		ID:       id,
+		ICMPID:   id,
 		Interval: 1000,
 	}
 


### PR DESCRIPTION
added way to stop a long-running packet injector

cli-cmd:
     skydive client inject-packet stop [flags]

Flags:
      --src string    source node gremlin expression (mandatory)
      --uuid string   UUID