### PR TITLE
ui: fix default node/manager image

### DIFF
--- a/statics/js/components/graph-layout.js
+++ b/statics/js/components/graph-layout.js
@@ -1504,12 +1504,12 @@ TopologyGraphLayout.prototype = {
 
   nodeImg: function(d) {
     var t = d.metadata.Type || "default";
-    return nodeImgMap[t];
+    return (t in nodeImgMap) ? nodeImgMap[t] : nodeImgMap["default"];
   },
 
   managerImg: function(d) {
     var t = d.metadata.Orchestrator || d.metadata.Manager || "default";
-    return managerImgMap[t];
+    return (t in managerImgMap) ? managerImgMap[t] : managerImgMap["default"];
   },
 
   collapseImg: function(d) {


### PR DESCRIPTION
This fixes a bug introduce by
the commit cec365762dce258123dddb0220a250a7ba8adfd0