### PR TITLE
K8s: add nodes via k8s probe if do not already exist

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -115,8 +115,6 @@ func init() {
 	cfg.SetDefault("sflow.port_min", 6345)
 	cfg.SetDefault("sflow.port_max", 6355)
 
-	cfg.SetDefault("k8s.polling_rate", "5s")
-	cfg.SetDefault("k8s.max_network_policies", 50)
 	cfg.SetDefault("k8s.config_file", "/etc/skydive/kube-cfg.yml")
 
 	cfg.SetDefault("storage.elasticsearch.host", "127.0.0.1:9200")

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -252,5 +252,6 @@ ui:
   # extra_assets: /usr/share/skydive/assets
 
 k8s:
-  # The KUBECONFIG yml file, if k8sctl is executed inside the cluster, you may use the empty config file - kube-config-empty.yml
+  # The kube config file, if executed inside the cluster, you may use the empty
+  # file, kube-config-empty.yml
   # config_file: /etc/skydive/kube-cfg.yml

--- a/topology/probes/k8s/k8s.go
+++ b/topology/probes/k8s/k8s.go
@@ -46,21 +46,21 @@ type Probe struct {
 }
 
 // Start k8s probe
-func (k8s *Probe) Start() {
-	k8s.networkPolicyCache.Start()
-	k8s.podCache.Start()
-	k8s.nodeCache.Start()
+func (probe *Probe) Start() {
+	probe.networkPolicyCache.Start()
+	probe.podCache.Start()
+	probe.nodeCache.Start()
 }
 
 // Stop k8s probe
-func (k8s *Probe) Stop() {
-	k8s.networkPolicyCache.Stop()
-	k8s.podCache.Stop()
-	k8s.nodeCache.Stop()
+func (probe *Probe) Stop() {
+	probe.networkPolicyCache.Stop()
+	probe.podCache.Stop()
+	probe.nodeCache.Stop()
 }
 
 // NewProbe create the Probe for tracking k8s events
-func NewProbe(g *graph.Graph) (k8s *Probe, err error) {
+func NewProbe(g *graph.Graph) (probe *Probe, err error) {
 	client, err := newKubeClient()
 	if err != nil {
 		return nil, err

--- a/topology/probes/k8s/k8s.go
+++ b/topology/probes/k8s/k8s.go
@@ -27,16 +27,17 @@ import (
 )
 
 const (
-	PodToContainerLink = "pod2container"
-	PolicyToPodLink    = "policy2pod"
+	podToContainerLink = "pod2container"
+	policyToPodLink    = "policy2pod"
 )
 
 var (
-	PodToContainerMetadata = graph.Metadata{"RelationType": PodToContainerLink}
-	PolicyToPodMetadata    = graph.Metadata{"RelationType": PolicyToPodLink}
+	podToContainerMetadata = graph.Metadata{"RelationType": podToContainerLink}
+	policyToPodMetadata    = graph.Metadata{"RelationType": policyToPodLink}
 )
 
-type probe struct {
+// Probe for tracking k8s events
+type Probe struct {
 	graph              *graph.Graph
 	client             *kubeClient
 	podCache           *podCache
@@ -44,19 +45,22 @@ type probe struct {
 	nodeCache          *nodeCache
 }
 
-func (k8s *probe) Start() {
+// Start k8s probe
+func (k8s *Probe) Start() {
 	k8s.networkPolicyCache.Start()
 	k8s.podCache.Start()
 	k8s.nodeCache.Start()
 }
 
-func (k8s *probe) Stop() {
+// Stop k8s probe
+func (k8s *Probe) Stop() {
 	k8s.networkPolicyCache.Stop()
 	k8s.podCache.Stop()
 	k8s.nodeCache.Stop()
 }
 
-func NewProbe(g *graph.Graph) (k8s *probe, err error) {
+// NewProbe create the Probe for tracking k8s events
+func NewProbe(g *graph.Graph) (k8s *Probe, err error) {
 	client, err := newKubeClient()
 	if err != nil {
 		return nil, err
@@ -66,7 +70,7 @@ func NewProbe(g *graph.Graph) (k8s *probe, err error) {
 	networkPolicyCache := newNetworkPolicyCache(client, g, podCache)
 	nodeCache := newNodeCache(client, g)
 
-	return &probe{
+	return &Probe{
 		graph:              g,
 		client:             client,
 		podCache:           podCache,

--- a/topology/probes/k8s/k8s.go
+++ b/topology/probes/k8s/k8s.go
@@ -41,16 +41,19 @@ type probe struct {
 	client             *kubeClient
 	podCache           *podCache
 	networkPolicyCache *networkPolicyCache
+	nodeCache          *nodeCache
 }
 
 func (k8s *probe) Start() {
 	k8s.networkPolicyCache.Start()
 	k8s.podCache.Start()
+	k8s.nodeCache.Start()
 }
 
 func (k8s *probe) Stop() {
 	k8s.networkPolicyCache.Stop()
 	k8s.podCache.Stop()
+	k8s.nodeCache.Stop()
 }
 
 func NewProbe(g *graph.Graph) (k8s *probe, err error) {
@@ -61,11 +64,13 @@ func NewProbe(g *graph.Graph) (k8s *probe, err error) {
 
 	podCache := newPodCache(client, g)
 	networkPolicyCache := newNetworkPolicyCache(client, g, podCache)
+	nodeCache := newNodeCache(client, g)
 
 	return &probe{
 		graph:              g,
 		client:             client,
 		podCache:           podCache,
 		networkPolicyCache: networkPolicyCache,
+		nodeCache:          nodeCache,
 	}, nil
 }

--- a/topology/probes/k8s/networkpolicy.go
+++ b/topology/probes/k8s/networkpolicy.go
@@ -43,12 +43,10 @@ type networkPolicyCache struct {
 
 func (n *networkPolicyCache) getMetadata(np *networking_v1.NetworkPolicy) graph.Metadata {
 	return graph.Metadata{
-		"Type":       "networkpolicy",
-		"Manager":    "k8s",
-		"Name":       np.GetName(),
-		"UID":        np.GetUID(),
-		"ObjectMeta": np.ObjectMeta,
-		"Spec":       np.Spec,
+		"Type":    "networkpolicy",
+		"Manager": "k8s",
+		"Name":    np.GetName(),
+		"K8s":     np,
 	}
 }
 

--- a/topology/probes/k8s/networkpolicy.go
+++ b/topology/probes/k8s/networkpolicy.go
@@ -119,7 +119,7 @@ func (n *networkPolicyCache) handleNetworkPolicy(policyNode *graph.Node, policy 
 	}
 
 	existingChildren := make(map[graph.Identifier]*graph.Node)
-	for _, container := range n.graph.LookupChildren(policyNode, nil, PolicyToPodMetadata) {
+	for _, container := range n.graph.LookupChildren(policyNode, nil, policyToPodMetadata) {
 		existingChildren[container.ID] = container
 	}
 
@@ -127,7 +127,7 @@ func (n *networkPolicyCache) handleNetworkPolicy(policyNode *graph.Node, policy 
 		if _, found := existingChildren[pod.ID]; found {
 			delete(existingChildren, pod.ID)
 		} else {
-			n.graph.Link(policyNode, pod, PolicyToPodMetadata)
+			n.graph.Link(policyNode, pod, policyToPodMetadata)
 		}
 	}
 
@@ -161,7 +161,7 @@ func (n *networkPolicyCache) handlePod(podNode *graph.Node) {
 		}
 
 		if toLink {
-			n.graph.Link(policyNode, podNode, PolicyToPodMetadata)
+			n.graph.Link(policyNode, podNode, policyToPodMetadata)
 		} else {
 			n.graph.Unlink(policyNode, podNode)
 		}

--- a/topology/probes/k8s/node.go
+++ b/topology/probes/k8s/node.go
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package k8s
+
+import (
+	"sync"
+
+	"github.com/skydive-project/skydive/topology/graph"
+
+	"k8s.io/api/core/v1"
+)
+
+type nodeCache struct {
+	sync.RWMutex
+	defaultKubeCacheEventHandler
+	graph.DefaultGraphListener
+	*kubeCache
+	graph *graph.Graph
+}
+
+func (c *nodeCache) getMetadata(node *v1.Node) graph.Metadata{
+	return graph.Metadata{
+		"Type":    "host",
+		"Manager": "k8s",
+		"Name":    node.GetName(),
+		"K8s":     node,
+	}
+}
+
+func (c *nodeCache) OnAdd(obj interface{}) {
+	c.OnUpdate(obj, obj)
+}
+
+func (c *nodeCache) OnUpdate(old, new interface{}) {
+	newNode := new.(*v1.Node)
+
+	c.Lock()
+	defer c.Unlock()
+
+	c.graph.Lock()
+	defer c.graph.Unlock()
+
+	graphMeta := c.getMetadata(newNode)
+	hostIndexer := graph.NewMetadataIndexer(c.graph, graph.Metadata{"Type": "host"}, "Name")
+	hostNodes := hostIndexer.Get(newNode.GetName())
+	if len(hostNodes) == 0 {
+		c.graph.NewNode(graph.Identifier(newNode.GetUID()), graphMeta)
+	} else {
+		if val, ok := graphMeta["Manager"]; ok && val == "k8s" {
+			c.graph.SetMetadata(hostNodes[0], graphMeta)
+		}
+	}
+}
+
+func (c *nodeCache) OnDelete(obj interface{}) {
+	if node, ok := obj.(*v1.Node); ok {
+		c.graph.Lock()
+		if nodeNode := c.graph.GetNode(graph.Identifier(node.GetUID())); nodeNode != nil {
+			c.graph.DelNode(nodeNode)
+		}
+		c.graph.Unlock()
+	}
+}
+
+func (c *nodeCache) Start() {
+	c.kubeCache.Start()
+}
+
+func (c *nodeCache) Stop() {
+	c.kubeCache.Stop()
+}
+
+func newNodeCache(client *kubeClient, g *graph.Graph) *nodeCache {
+	c := &nodeCache{
+		graph: g,
+	}
+	c.kubeCache = client.getCacheFor(client.Core().RESTClient(), &v1.Node{}, "nodes", c)
+	return c
+}

--- a/topology/probes/k8s/node.go
+++ b/topology/probes/k8s/node.go
@@ -38,7 +38,7 @@ type nodeCache struct {
 	graph *graph.Graph
 }
 
-func (c *nodeCache) getMetadata(node *v1.Node) graph.Metadata{
+func (c *nodeCache) getMetadata(node *v1.Node) graph.Metadata {
 	return graph.Metadata{
 		"Type":    "host",
 		"Manager": "k8s",

--- a/topology/probes/k8s/pod.go
+++ b/topology/probes/k8s/pod.go
@@ -46,12 +46,10 @@ type podCache struct {
 
 func (p *podCache) getMetadata(pod *api.Pod) graph.Metadata {
 	return graph.Metadata{
-		"Type":       "pod",
-		"Manager":    "k8s",
-		"Name":       pod.GetName(),
-		"UID":        pod.GetUID(),
-		"ObjectMeta": pod.ObjectMeta,
-		"Spec":       pod.Spec,
+		"Type":    "pod",
+		"Manager": "k8s",
+		"Name":    pod.GetName(),
+		"K8s":     pod,
 	}
 }
 

--- a/topology/probes/k8s/pod.go
+++ b/topology/probes/k8s/pod.go
@@ -74,7 +74,7 @@ func (p *podCache) OnAdd(obj interface{}) {
 
 		containerNodes := p.containerIndexer.Get(pod.Namespace, pod.Name)
 		for _, containerNode := range containerNodes {
-			p.graph.Link(podNode, containerNode, PodToContainerMetadata)
+			p.graph.Link(podNode, containerNode, podToContainerMetadata)
 		}
 
 		p.linkPodToHost(pod, podNode)
@@ -123,7 +123,7 @@ func (p *podCache) OnNodeAdded(n *graph.Node) {
 					logging.GetLogger().Warningf("Failed to find node for pod %s", pod.GetUID())
 					return
 				}
-				p.graph.Link(podNode, n, PodToContainerMetadata)
+				p.graph.Link(podNode, n, podToContainerMetadata)
 			}
 		}
 	case "host":


### PR DESCRIPTION
@lebauce - Added creation of a node item directly from k8s probe, given that this competes with the agent generated node, it will only add/update if an agent created node does not exist. To test you can fireup a k8s and view that even without an agent installed within the host (on which the pods are running) you still get a node element (double-clicking with expose the pods).