### PR TITLE
K8s: add k8s container and node (host) discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,11 +68,11 @@ endif
 all install: skydive
 
 skydive.yml: etc/skydive.yml.default
-	cp $< $@
+	[ -e $@ ] || cp $< $@
 	
 .PHONY: debug
 debug: GOFLAGS+=-gcflags='-N -l'
-debug: skydive.cleanup dlv skydive skydive.yml
+debug: skydive.cleanup skydive skydive.yml
 
 define skydive_debug
 sudo $$(which dlv) exec $$(which skydive) -- $1 -c skydive.yml

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -24,6 +24,7 @@ package common
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"testing"
 )
@@ -80,5 +81,58 @@ func TestIPV4Range16(t *testing.T) {
 	ip := "192.169.3.34/24"
 	if re.MatchString(ip) {
 		t.Errorf("%s matches the rexp %s", ip, expr)
+	}
+}
+
+func TestNormalizeStructToMap(t *testing.T) {
+	type (
+		B struct {
+			C1 string
+			C2 string
+			C3 string
+		}
+		A struct {
+			B B
+		}
+	)
+
+	before := A{
+		B: B{
+			C1: "ccc",
+		},
+	}
+
+	expected := map[string]interface{}{
+		"B": map[string]interface{}{
+			"C1": "ccc",
+			"C2": "",
+			"C3": "",
+		},
+	}
+
+	actual := NormalizeValue(before)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %+v actual %+v", expected, actual)
+	}
+}
+
+func TestNormalizeMapKeys(t *testing.T) {
+	before := map[string]interface{}{
+		"a.b": "A.B",
+		"d":   "D",
+	}
+
+	expected := map[string]interface{}{
+		"a": map[string]interface{}{
+			"b": "A.B",
+		},
+		"d": "D",
+	}
+
+	actual := NormalizeValue(before)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %+v actual %+v", expected, actual)
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -100,6 +100,8 @@ func init() {
 
 	cfg.SetDefault("host_id", host)
 
+	cfg.SetDefault("k8s.subprobes", []string{"networkpolicy", "pod", "container", "node"})
+
 	cfg.SetDefault("logging.backends", []string{"stderr"})
 	cfg.SetDefault("logging.color", true)
 	cfg.SetDefault("logging.encoder", "")
@@ -116,8 +118,6 @@ func init() {
 	cfg.SetDefault("sflow.port_min", 6345)
 	cfg.SetDefault("sflow.port_max", 6355)
 
-	cfg.SetDefault("k8s.polling_rate", "5s")
-	cfg.SetDefault("k8s.max_network_policies", 50)
 	cfg.SetDefault("k8s.config_file", "/etc/skydive/kube-cfg.yml")
 
 	cfg.SetDefault("storage.elasticsearch.host", "127.0.0.1:9200")

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -253,7 +253,9 @@ ui:
   # extra_assets: /usr/share/skydive/assets
 
 k8s:
-  # The KUBECONFIG yml file, if k8sctl is executed inside the cluster, you may use the empty config file - kube-config-empty.yml
+  # EXPERIMENTAL: k8s probe is still under development and should not be used on production systems
+  # The kube config file, if executed inside the cluster, you may use the empty
+  # file, kube-config-empty.yml
   # config_file: /etc/skydive/kube-cfg.yml
   subprobes:
   - networkpolicy

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -255,3 +255,8 @@ ui:
 k8s:
   # The KUBECONFIG yml file, if k8sctl is executed inside the cluster, you may use the empty config file - kube-config-empty.yml
   # config_file: /etc/skydive/kube-cfg.yml
+  subprobes:
+  - networkpolicy
+  - pod
+  - container
+  - node

--- a/statics/js/components/layout.js
+++ b/statics/js/components/layout.js
@@ -26,6 +26,7 @@ var nodeImgMap = setupFixedImages({
   "veth": "veth",
   "bond": "port",
   "container": "docker",
+  "node": "host",
   "pod": "pod",
   "networkpolicy": "networkpolicy",
   "default": "intf",

--- a/topology/graph/graph.go
+++ b/topology/graph/graph.go
@@ -272,8 +272,7 @@ func GenID() Identifier {
 // GenIDNameBased helper generate a node Identifier
 func GenIDNameBased(namespace, name string) Identifier {
 	ns, _ := uuid.ParseHex(namespace)
-	n := []byte(name)
-	u, _ := uuid.NewV5(ns, n)
+	u, _ := uuid.NewV5(ns, []byte(name))
 
 	return Identifier(u.String())
 }

--- a/topology/graph/graph.go
+++ b/topology/graph/graph.go
@@ -701,6 +701,11 @@ func (g *Graph) DelMetadata(i interface{}, k string) bool {
 	return true
 }
 
+// SetField set metadata value based on dot key ("a.b.c.d" = "ok")
+func (m *Metadata) SetField(k string, v interface{}) bool {
+	return common.SetField(*m, k, v)
+}
+
 func (g *Graph) addMetadata(i interface{}, k string, v interface{}, t time.Time) bool {
 	var e *graphElement
 	ge := graphEvent{element: i}
@@ -718,7 +723,7 @@ func (g *Graph) addMetadata(i interface{}, k string, v interface{}, t time.Time)
 		return false
 	}
 
-	if !common.SetField(e.metadata, k, v) {
+	if !e.metadata.SetField(k, v) {
 		return false
 	}
 
@@ -740,7 +745,7 @@ func (g *Graph) AddMetadata(i interface{}, k string, v interface{}) bool {
 
 // AddMetadata in the current transaction
 func (t *MetadataTransaction) AddMetadata(k string, v interface{}) {
-	common.SetField(t.Metadata, k, v)
+	t.Metadata.SetField(k, v)
 }
 
 // Commit the current transaction to the graph

--- a/topology/graph/graph.go
+++ b/topology/graph/graph.go
@@ -269,6 +269,15 @@ func GenID() Identifier {
 	return Identifier(u.String())
 }
 
+// GenIDNameBased helper generate a node Identifier
+func GenIDNameBased(namespace, name string) Identifier {
+	ns, _ := uuid.ParseHex(namespace)
+	n := []byte(name)
+	u, _ := uuid.NewV5(ns, n)
+
+	return Identifier(u.String())
+}
+
 func (m *Metadata) String() string {
 	j, _ := json.Marshal(m)
 	return string(j)

--- a/topology/probes/k8s/container.go
+++ b/topology/probes/k8s/container.go
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package k8s
+
+import (
+	"sync"
+
+	"github.com/skydive-project/skydive/common"
+	"github.com/skydive-project/skydive/filters"
+	"github.com/skydive-project/skydive/logging"
+	"github.com/skydive-project/skydive/topology"
+	"github.com/skydive-project/skydive/topology/graph"
+
+	"k8s.io/api/core/v1"
+)
+
+type containerCache struct {
+	sync.RWMutex
+	defaultKubeCacheEventHandler
+	graph.DefaultGraphListener
+	*kubeCache
+	graph            *graph.Graph
+	hostIndexer      *graph.MetadataIndexer
+	containerIndexer *graph.MetadataIndexer
+}
+
+// commonly accessed docker specific fields
+const (
+	DockerNameField         = "Docker.ContainerName"
+	DockerPodNamespaceField = "Docker.Labels.io.kubernetes.pod.namespace"
+	DockerPodNameField      = "Docker.Labels.io.kubernetes.pod.name"
+)
+
+func addNotNullFilter(m graph.Metadata, field string) {
+	m[field] = filters.NewNotFilter(filters.NewNullFilter(field))
+}
+
+func newContainerIndexer(g *graph.Graph, manager string) *graph.MetadataIndexer {
+	m := graph.Metadata{"Type": "container"}
+	if manager != "" {
+		m["Manager"] = manager
+	}
+	addNotNullFilter(m, DockerPodNamespaceField)
+	addNotNullFilter(m, DockerPodNameField)
+
+	return graph.NewMetadataIndexer(g, m, DockerPodNamespaceField, DockerPodNameField)
+}
+
+func (c *containerCache) getMetadata(pod *v1.Pod, container *v1.Container) graph.Metadata {
+	m := graph.Metadata{
+		"Type":    "container",
+		"Name":    container.Name,
+		"Manager": "k8s",
+	}
+
+	common.SetField(m, DockerNameField, container.Name)
+	common.SetField(m, DockerPodNamespaceField, pod.GetNamespace())
+	common.SetField(m, DockerPodNameField, pod.GetName())
+	return m
+}
+
+func makeContainerUID(podUID, containerName string) string {
+	return podUID + "-" + containerName
+}
+
+func (c *containerCache) OnAdd(obj interface{}) {
+	if pod, ok := obj.(*v1.Pod); ok {
+		c.Lock()
+		defer c.Unlock()
+
+		c.graph.Lock()
+		defer c.graph.Unlock()
+
+		for _, container := range pod.Spec.Containers {
+			uid := makeContainerUID(string(pod.GetUID()), container.Name)
+			hostNodes := c.hostIndexer.Get(pod.Spec.NodeName)
+			if len(hostNodes) == 0 {
+				continue
+			}
+
+			logging.GetLogger().Debugf("Creating node of k8s container %s", uid)
+			containerNode := c.graph.NewNode(graph.Identifier(uid), c.getMetadata(pod, &container))
+			topology.AddOwnershipLink(c.graph, hostNodes[0], containerNode, nil)
+		}
+	}
+}
+
+func (c *containerCache) OnUpdate(oldObj, newObj interface{}) {
+}
+
+func (c *containerCache) OnDelete(obj interface{}) {
+	if pod, ok := obj.(*v1.Pod); ok {
+		c.graph.Lock()
+		defer c.graph.Unlock()
+
+		containerNodes := c.containerIndexer.Get(pod.Namespace, pod.Name)
+		for _, containerNode := range containerNodes {
+			c.graph.DelNode(containerNode)
+		}
+	}
+}
+
+func (c *containerCache) Start() {
+	c.containerIndexer.AddEventListener(c)
+	c.hostIndexer.AddEventListener(c)
+	c.kubeCache.Start()
+}
+
+func (c *containerCache) Stop() {
+	c.containerIndexer.RemoveEventListener(c)
+	c.hostIndexer.RemoveEventListener(c)
+	c.kubeCache.Stop()
+}
+
+func newContainerCache(client *kubeClient, g *graph.Graph) *containerCache {
+	c := &containerCache{
+		graph:            g,
+		hostIndexer:      newHostIndexer(g, "k8s"),
+		containerIndexer: newContainerIndexer(g, "k8s"),
+	}
+	c.kubeCache = client.getCacheFor(client.Core().RESTClient(), &v1.Pod{}, "pods", c)
+	return c
+}

--- a/topology/probes/k8s/container.go
+++ b/topology/probes/k8s/container.go
@@ -25,7 +25,6 @@ package k8s
 import (
 	"sync"
 
-	"github.com/skydive-project/skydive/common"
 	"github.com/skydive-project/skydive/filters"
 	"github.com/skydive-project/skydive/logging"
 	"github.com/skydive-project/skydive/topology"
@@ -65,9 +64,9 @@ func newContainerIndexer(g *graph.Graph) *graph.MetadataIndexer {
 
 func (c *containerCache) newMetadata(pod *v1.Pod, container *v1.Container) graph.Metadata {
 	m := newMetadata("container", container.Name, container)
-	common.SetField(m, DockerNameField, container.Name)
-	common.SetField(m, DockerPodNamespaceField, pod.GetNamespace())
-	common.SetField(m, DockerPodNameField, pod.GetName())
+	m.SetField(DockerNameField, container.Name)
+	m.SetField(DockerPodNamespaceField, pod.GetNamespace())
+	m.SetField(DockerPodNameField, pod.GetName())
 	return m
 }
 

--- a/topology/probes/k8s/graph.go
+++ b/topology/probes/k8s/graph.go
@@ -23,6 +23,7 @@
 package k8s
 
 import (
+	"github.com/skydive-project/skydive/common"
 	"github.com/skydive-project/skydive/topology/graph"
 )
 
@@ -32,7 +33,7 @@ func newMetadata(typ, name string, extra interface{}) graph.Metadata {
 		"Probe":   "k8s",
 		"Manager": "k8s",
 		"Name":    name,
-		"K8s":     extra,
+		"K8s":     common.NormalizeValue(extra),
 	}
 }
 
@@ -40,5 +41,5 @@ func addMetadata(g *graph.Graph, n *graph.Node, extra interface{}) {
 	tr := g.StartMetadataTransaction(n)
 	defer tr.Commit()
 	tr.AddMetadata("Manager", "k8s")
-	tr.AddMetadata("K8s", extra)
+	tr.AddMetadata("K8s", common.NormalizeValue(extra))
 }

--- a/topology/probes/k8s/graph.go
+++ b/topology/probes/k8s/graph.go
@@ -37,6 +37,8 @@ func newMetadata(typ, name string, extra interface{}) graph.Metadata {
 }
 
 func addMetadata(g *graph.Graph, n *graph.Node, extra interface{}) {
-	g.AddMetadata(n, "Manager", "k8s")
-	g.AddMetadata(n, "K8s", extra)
+	tr := g.StartMetadataTransaction(n)
+	defer tr.Commit()
+	tr.AddMetadata("Manager", "k8s")
+	tr.AddMetadata("K8s", extra)
 }

--- a/topology/probes/k8s/graph.go
+++ b/topology/probes/k8s/graph.go
@@ -39,7 +39,7 @@ func newMetadata(typ, name string, extra interface{}) graph.Metadata {
 
 func addMetadata(g *graph.Graph, n *graph.Node, extra interface{}) {
 	tr := g.StartMetadataTransaction(n)
-	defer tr.Commit()
 	tr.AddMetadata("Manager", "k8s")
 	tr.AddMetadata("K8s", common.NormalizeValue(extra))
+	tr.Commit()
 }

--- a/topology/probes/k8s/graph.go
+++ b/topology/probes/k8s/graph.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 IBM Corp.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package k8s
+
+import (
+	"github.com/skydive-project/skydive/topology/graph"
+)
+
+func newMetadata(typ, name string, extra interface{}) graph.Metadata {
+	return graph.Metadata{
+		"Type":    typ,
+		"Probe":   "k8s",
+		"Manager": "k8s",
+		"Name":    name,
+		"K8s":     extra,
+	}
+}
+
+func addMetadata(g *graph.Graph, n *graph.Node, extra interface{}) {
+	g.AddMetadata(n, "Manager", "k8s")
+	g.AddMetadata(n, "K8s", extra)
+}

--- a/topology/probes/k8s/k8s.go
+++ b/topology/probes/k8s/k8s.go
@@ -45,18 +45,31 @@ type Probe struct {
 	nodeCache          *nodeCache
 }
 
+type starter interface{
+	Start()
+	Stop()
+}
+
+func (probe *Probe) getSubProbes() []starter {
+	return []starter{
+		probe.podCache,
+		probe.networkPolicyCache,
+		probe.nodeCache,
+	 }
+}
+
 // Start k8s probe
 func (probe *Probe) Start() {
-	probe.networkPolicyCache.Start()
-	probe.podCache.Start()
-	probe.nodeCache.Start()
+	for _, sub := range probe.getSubProbes() {
+		sub.Start()
+	}
 }
 
 // Stop k8s probe
 func (probe *Probe) Stop() {
-	probe.networkPolicyCache.Stop()
-	probe.podCache.Stop()
-	probe.nodeCache.Stop()
+	for _, sub := range probe.getSubProbes() {
+		sub.Stop()
+	}
 }
 
 // NewProbe create the Probe for tracking k8s events

--- a/topology/probes/k8s/k8s.go
+++ b/topology/probes/k8s/k8s.go
@@ -46,21 +46,21 @@ type Probe struct {
 }
 
 // Start k8s probe
-func (k8s *Probe) Start() {
-	k8s.networkPolicyCache.Start()
-	k8s.podCache.Start()
-	k8s.nodeCache.Start()
+func (probe *Probe) Start() {
+	probe.networkPolicyCache.Start()
+	probe.podCache.Start()
+	probe.nodeCache.Start()
 }
 
 // Stop k8s probe
-func (k8s *Probe) Stop() {
-	k8s.networkPolicyCache.Stop()
-	k8s.podCache.Stop()
-	k8s.nodeCache.Stop()
+func (probe *Probe) Stop() {
+	probe.networkPolicyCache.Stop()
+	probe.podCache.Stop()
+	probe.nodeCache.Stop()
 }
 
 // NewProbe create the Probe for tracking k8s events
-func NewProbe(g *graph.Graph) (k8s *Probe, err error) {
+func NewProbe(g *graph.Graph) (probe *Probe, err error) {
 	client, err := newKubeClient()
 	if err != nil {
 		return nil, err

--- a/topology/probes/k8s/k8s.go
+++ b/topology/probes/k8s/k8s.go
@@ -43,9 +43,10 @@ type Probe struct {
 	podCache           *podCache
 	networkPolicyCache *networkPolicyCache
 	nodeCache          *nodeCache
+	containerCache     *containerCache
 }
 
-type starter interface{
+type starter interface {
 	Start()
 	Stop()
 }
@@ -55,7 +56,8 @@ func (probe *Probe) getSubProbes() []starter {
 		probe.podCache,
 		probe.networkPolicyCache,
 		probe.nodeCache,
-	 }
+		probe.containerCache,
+	}
 }
 
 // Start k8s probe
@@ -82,6 +84,7 @@ func NewProbe(g *graph.Graph) (probe *Probe, err error) {
 	podCache := newPodCache(client, g)
 	networkPolicyCache := newNetworkPolicyCache(client, g, podCache)
 	nodeCache := newNodeCache(client, g)
+	containerCache := newContainerCache(client, g)
 
 	return &Probe{
 		graph:              g,
@@ -89,5 +92,6 @@ func NewProbe(g *graph.Graph) (probe *Probe, err error) {
 		podCache:           podCache,
 		networkPolicyCache: networkPolicyCache,
 		nodeCache:          nodeCache,
+		containerCache:     containerCache,
 	}, nil
 }

--- a/topology/probes/k8s/k8s.go
+++ b/topology/probes/k8s/k8s.go
@@ -27,16 +27,17 @@ import (
 )
 
 const (
-	PodToContainerLink = "pod2container"
-	PolicyToPodLink    = "policy2pod"
+	podToContainerLink = "pod2container"
+	policyToPodLink    = "policy2pod"
 )
 
 var (
-	PodToContainerMetadata = graph.Metadata{"RelationType": PodToContainerLink}
-	PolicyToPodMetadata    = graph.Metadata{"RelationType": PolicyToPodLink}
+	podToContainerMetadata = graph.Metadata{"RelationType": podToContainerLink}
+	policyToPodMetadata    = graph.Metadata{"RelationType": policyToPodLink}
 )
 
-type probe struct {
+// Probe for tracking k8s events
+type Probe struct {
 	graph              *graph.Graph
 	client             *kubeClient
 	podCache           *podCache
@@ -44,19 +45,22 @@ type probe struct {
 	nodeCache          *nodeCache
 }
 
-func (k8s *probe) Start() {
+// Start k8s probe
+func (k8s *Probe) Start() {
 	k8s.networkPolicyCache.Start()
 	k8s.podCache.Start()
 	k8s.nodeCache.Start()
 }
 
-func (k8s *probe) Stop() {
+// Stop k8s probe
+func (k8s *Probe) Stop() {
 	k8s.networkPolicyCache.Stop()
 	k8s.podCache.Stop()
 	k8s.nodeCache.Stop()
 }
 
-func NewProbe(g *graph.Graph) (k8s *probe, err error) {
+// NewProbe create the Probe for tracking k8s events
+func NewProbe(g *graph.Graph) (k8s *Probe, err error) {
 	client, err := newKubeClient()
 	if err != nil {
 		return nil, err
@@ -66,7 +70,7 @@ func NewProbe(g *graph.Graph) (k8s *probe, err error) {
 	networkPolicyCache := newNetworkPolicyCache(client, g, podCache)
 	nodeCache := newNodeCache(client, g)
 
-	return &probe{
+	return &Probe{
 		graph:              g,
 		client:             client,
 		podCache:           podCache,

--- a/topology/probes/k8s/k8s.go
+++ b/topology/probes/k8s/k8s.go
@@ -41,16 +41,19 @@ type probe struct {
 	client             *kubeClient
 	podCache           *podCache
 	networkPolicyCache *networkPolicyCache
+	nodeCache          *nodeCache
 }
 
 func (k8s *probe) Start() {
 	k8s.networkPolicyCache.Start()
 	k8s.podCache.Start()
+	k8s.nodeCache.Start()
 }
 
 func (k8s *probe) Stop() {
 	k8s.networkPolicyCache.Stop()
 	k8s.podCache.Stop()
+	k8s.nodeCache.Stop()
 }
 
 func NewProbe(g *graph.Graph) (k8s *probe, err error) {
@@ -61,11 +64,13 @@ func NewProbe(g *graph.Graph) (k8s *probe, err error) {
 
 	podCache := newPodCache(client, g)
 	networkPolicyCache := newNetworkPolicyCache(client, g, podCache)
+	nodeCache := newNodeCache(client, g)
 
 	return &probe{
 		graph:              g,
 		client:             client,
 		podCache:           podCache,
 		networkPolicyCache: networkPolicyCache,
+		nodeCache:          nodeCache,
 	}, nil
 }

--- a/topology/probes/k8s/networkpolicy.go
+++ b/topology/probes/k8s/networkpolicy.go
@@ -43,12 +43,10 @@ type networkPolicyCache struct {
 
 func (n *networkPolicyCache) getMetadata(np *networking_v1.NetworkPolicy) graph.Metadata {
 	return graph.Metadata{
-		"Type":       "networkpolicy",
-		"Manager":    "k8s",
-		"Name":       np.GetName(),
-		"UID":        np.GetUID(),
-		"ObjectMeta": np.ObjectMeta,
-		"Spec":       np.Spec,
+		"Type":    "networkpolicy",
+		"Manager": "k8s",
+		"Name":    np.GetName(),
+		"K8s":     np,
 	}
 }
 

--- a/topology/probes/k8s/networkpolicy.go
+++ b/topology/probes/k8s/networkpolicy.go
@@ -119,7 +119,7 @@ func (n *networkPolicyCache) handleNetworkPolicy(policyNode *graph.Node, policy 
 	}
 
 	existingChildren := make(map[graph.Identifier]*graph.Node)
-	for _, container := range n.graph.LookupChildren(policyNode, nil, PolicyToPodMetadata) {
+	for _, container := range n.graph.LookupChildren(policyNode, nil, policyToPodMetadata) {
 		existingChildren[container.ID] = container
 	}
 
@@ -127,7 +127,7 @@ func (n *networkPolicyCache) handleNetworkPolicy(policyNode *graph.Node, policy 
 		if _, found := existingChildren[pod.ID]; found {
 			delete(existingChildren, pod.ID)
 		} else {
-			n.graph.Link(policyNode, pod, PolicyToPodMetadata)
+			n.graph.Link(policyNode, pod, policyToPodMetadata)
 		}
 	}
 
@@ -161,7 +161,7 @@ func (n *networkPolicyCache) handlePod(podNode *graph.Node) {
 		}
 
 		if toLink {
-			n.graph.Link(policyNode, podNode, PolicyToPodMetadata)
+			n.graph.Link(policyNode, podNode, policyToPodMetadata)
 		} else {
 			n.graph.Unlink(policyNode, podNode)
 		}

--- a/topology/probes/k8s/networkpolicy.go
+++ b/topology/probes/k8s/networkpolicy.go
@@ -25,10 +25,10 @@ package k8s
 import (
 	"github.com/skydive-project/skydive/logging"
 	"github.com/skydive-project/skydive/topology/graph"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	api "k8s.io/api/core/v1"
 	networking_v1 "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 

--- a/topology/probes/k8s/node.go
+++ b/topology/probes/k8s/node.go
@@ -48,6 +48,10 @@ func (c *nodeCache) newMetadata(node *v1.Node) graph.Metadata {
 	return newMetadata("host", node.GetName(), node)
 }
 
+func hostUID(node *v1.Node) graph.Identifier {
+	return graph.Identifier(node.GetUID())
+}
+
 func (c *nodeCache) onAdd(obj interface{}) {
 	host := obj.(*v1.Node)
 
@@ -61,7 +65,7 @@ func (c *nodeCache) onAdd(obj interface{}) {
 	hostNodes := c.hostIndexer.Get(hostName)
 	var hostNode *graph.Node
 	if len(hostNodes) == 0 {
-		hostNode = c.graph.NewNode(graph.Identifier(host.GetUID()), c.newMetadata(host))
+		hostNode = c.graph.NewNode(hostUID(host), c.newMetadata(host))
 	} else {
 		hostNode = hostNodes[0]
 		addMetadata(c.graph, hostNode, host)
@@ -81,7 +85,7 @@ func (c *nodeCache) OnUpdate(oldObj, newObj interface{}) {
 func (c *nodeCache) OnDelete(obj interface{}) {
 	if node, ok := obj.(*v1.Node); ok {
 		c.graph.Lock()
-		if nodeNode := c.graph.GetNode(graph.Identifier(node.GetUID())); nodeNode != nil {
+		if nodeNode := c.graph.GetNode(hostUID(node)); nodeNode != nil {
 			c.graph.DelNode(nodeNode)
 		}
 		c.graph.Unlock()

--- a/topology/probes/k8s/node.go
+++ b/topology/probes/k8s/node.go
@@ -25,6 +25,7 @@ package k8s
 import (
 	"sync"
 
+	"github.com/skydive-project/skydive/topology"
 	"github.com/skydive-project/skydive/topology/graph"
 
 	"k8s.io/api/core/v1"
@@ -36,8 +37,13 @@ type nodeCache struct {
 	graph.DefaultGraphListener
 	*kubeCache
 	graph       *graph.Graph
+	nodeIndexer *graph.MetadataIndexer
 	hostIndexer *graph.MetadataIndexer
 	podIndexer  *graph.MetadataIndexer
+}
+
+func newNodeIndexer(g *graph.Graph) *graph.MetadataIndexer {
+	return graph.NewMetadataIndexer(g, graph.Metadata{"Type": "node"}, "Name")
 }
 
 func newHostIndexer(g *graph.Graph) *graph.MetadataIndexer {
@@ -45,15 +51,19 @@ func newHostIndexer(g *graph.Graph) *graph.MetadataIndexer {
 }
 
 func (c *nodeCache) newMetadata(node *v1.Node) graph.Metadata {
-	return newMetadata("host", node.GetName(), node)
+	return newMetadata("node", node.GetName(), node)
 }
 
-func hostUID(node *v1.Node) graph.Identifier {
+func linkNodeToHost(g *graph.Graph, host, node *graph.Node) {
+	topology.AddOwnershipLink(g, host, node, nil)
+}
+
+func nodeUID(node *v1.Node) graph.Identifier {
 	return graph.Identifier(node.GetUID())
 }
 
 func (c *nodeCache) onAdd(obj interface{}) {
-	host := obj.(*v1.Node)
+	node := obj.(*v1.Node)
 
 	c.Lock()
 	defer c.Unlock()
@@ -61,17 +71,22 @@ func (c *nodeCache) onAdd(obj interface{}) {
 	c.graph.Lock()
 	defer c.graph.Unlock()
 
-	hostName := host.GetName()
-	hostNodes := c.hostIndexer.Get(hostName)
-	var hostNode *graph.Node
-	if len(hostNodes) == 0 {
-		hostNode = c.graph.NewNode(hostUID(host), c.newMetadata(host))
+	hostName := node.GetName()
+	nodeNodes := c.nodeIndexer.Get(hostName)
+	var nodeNode *graph.Node
+	if len(nodeNodes) == 0 {
+		nodeNode = c.graph.NewNode(nodeUID(node), c.newMetadata(node))
 	} else {
-		hostNode = hostNodes[0]
-		addMetadata(c.graph, hostNode, host)
+		nodeNode = nodeNodes[0]
+		addMetadata(c.graph, nodeNode, node)
 	}
 
-	linkPodsToHost(c.graph, hostNode, c.podIndexer.Get(hostName))
+	linkPodsToNode(c.graph, nodeNode, c.podIndexer.Get(hostName))
+
+	hostNodes := c.hostIndexer.Get(hostName)
+	if len(hostNodes) != 0 {
+		linkNodeToHost(c.graph, hostNodes[0], nodeNode)
+	}
 }
 
 func (c *nodeCache) OnAdd(obj interface{}) {
@@ -85,7 +100,7 @@ func (c *nodeCache) OnUpdate(oldObj, newObj interface{}) {
 func (c *nodeCache) OnDelete(obj interface{}) {
 	if node, ok := obj.(*v1.Node); ok {
 		c.graph.Lock()
-		if nodeNode := c.graph.GetNode(hostUID(node)); nodeNode != nil {
+		if nodeNode := c.graph.GetNode(nodeUID(node)); nodeNode != nil {
 			c.graph.DelNode(nodeNode)
 		}
 		c.graph.Unlock()
@@ -94,18 +109,23 @@ func (c *nodeCache) OnDelete(obj interface{}) {
 
 func (c *nodeCache) Start() {
 	c.kubeCache.Start()
+	c.nodeIndexer.AddEventListener(c)
 	c.hostIndexer.AddEventListener(c)
+	c.podIndexer.AddEventListener(c)
 }
 
 func (c *nodeCache) Stop() {
 	c.kubeCache.Stop()
+	c.nodeIndexer.RemoveEventListener(c)
 	c.hostIndexer.RemoveEventListener(c)
+	c.podIndexer.RemoveEventListener(c)
 }
 
 func newNodeCache(client *kubeClient, g *graph.Graph) *nodeCache {
 	c := &nodeCache{
 		graph:       g,
 		hostIndexer: newHostIndexer(g),
+		nodeIndexer: newNodeIndexer(g),
 		podIndexer:  newPodIndexerByHost(g),
 	}
 	c.kubeCache = client.getCacheFor(client.Core().RESTClient(), &v1.Node{}, "nodes", c)

--- a/topology/probes/k8s/node.go
+++ b/topology/probes/k8s/node.go
@@ -38,6 +38,14 @@ type nodeCache struct {
 	graph *graph.Graph
 }
 
+func newHostIndexer(g *graph.Graph, manager string) *graph.MetadataIndexer {
+	m := graph.Metadata{"Type": "host"}
+	if manager != "" {
+		m["Manager"] = manager
+	}
+	return graph.NewMetadataIndexer(g, m, "Name")
+}
+
 func (c *nodeCache) getMetadata(node *v1.Node) graph.Metadata {
 	return graph.Metadata{
 		"Type":    "host",

--- a/topology/probes/k8s/node.go
+++ b/topology/probes/k8s/node.go
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package k8s
+
+import (
+	"sync"
+
+	"github.com/skydive-project/skydive/topology/graph"
+
+	"k8s.io/api/core/v1"
+)
+
+type nodeCache struct {
+	sync.RWMutex
+	defaultKubeCacheEventHandler
+	graph.DefaultGraphListener
+	*kubeCache
+	graph *graph.Graph
+}
+
+func (c *nodeCache) getMetadata(node *v1.Node) graph.Metadata{
+	return graph.Metadata{
+		"Type":    "host",
+		"Manager": "k8s",
+		"Name":    node.GetName(),
+		"K8s":     node,
+	}
+}
+
+func (c *nodeCache) OnAdd(obj interface{}) {
+	c.OnUpdate(obj, obj)
+}
+
+func (c *nodeCache) OnUpdate(old, new interface{}) {
+	newNode := new.(*v1.Node)
+
+	c.Lock()
+	defer c.Unlock()
+
+	c.graph.Lock()
+	defer c.graph.Unlock()
+
+	graphMeta := c.getMetadata(newNode)
+	hostIndexer := graph.NewMetadataIndexer(c.graph, graph.Metadata{"Type": "host"}, "Name")
+	hostNodes := hostIndexer.Get(newNode.GetName())
+	if len(hostNodes) == 0 {
+		c.graph.NewNode(graph.Identifier(newNode.GetUID()), graphMeta)
+	} else {
+		if val, ok := graphMeta["Manager"]; ok && val == "k8s" {
+			c.graph.SetMetadata(hostNodes[0], graphMeta)
+		}
+	}
+}
+
+func (c *nodeCache) OnDelete(obj interface{}) {
+	if node, ok := obj.(*v1.Node); ok {
+		c.graph.Lock()
+		if nodeNode := c.graph.GetNode(graph.Identifier(node.GetUID())); nodeNode != nil {
+			c.graph.DelNode(nodeNode)
+		}
+		c.graph.Unlock()
+	}
+}
+
+func (c *nodeCache) Start() {
+	c.kubeCache.Start()
+}
+
+func (c *nodeCache) Stop() {
+	c.kubeCache.Stop()
+}
+
+func newNodeCache(client *kubeClient, g *graph.Graph) *nodeCache {
+	c := &nodeCache{
+		graph: g,
+	}
+	c.kubeCache = client.getCacheFor(client.Core().RESTClient(), &v1.Node{}, "nodes", c)
+	return c
+}

--- a/topology/probes/k8s/node.go
+++ b/topology/probes/k8s/node.go
@@ -38,7 +38,7 @@ type nodeCache struct {
 	graph *graph.Graph
 }
 
-func (c *nodeCache) getMetadata(node *v1.Node) graph.Metadata{
+func (c *nodeCache) getMetadata(node *v1.Node) graph.Metadata {
 	return graph.Metadata{
 		"Type":    "host",
 		"Manager": "k8s",

--- a/topology/probes/k8s/pod.go
+++ b/topology/probes/k8s/pod.go
@@ -46,12 +46,10 @@ type podCache struct {
 
 func (p *podCache) getMetadata(pod *api.Pod) graph.Metadata {
 	return graph.Metadata{
-		"Type":       "pod",
-		"Manager":    "k8s",
-		"Name":       pod.GetName(),
-		"UID":        pod.GetUID(),
-		"ObjectMeta": pod.ObjectMeta,
-		"Spec":       pod.Spec,
+		"Type":    "pod",
+		"Manager": "k8s",
+		"Name":    pod.GetName(),
+		"K8s":     pod,
 	}
 }
 

--- a/topology/probes/k8s/pod.go
+++ b/topology/probes/k8s/pod.go
@@ -42,20 +42,20 @@ type podCache struct {
 	nodeIndexer      *graph.MetadataIndexer
 }
 
-func newPodIndex(g *graph.Graph, by string) *graph.MetadataIndexer {
+func newPodIndexer(g *graph.Graph, by string) *graph.MetadataIndexer {
 	return graph.NewMetadataIndexer(g, graph.Metadata{"Type": "pod"}, by)
 }
 
 func newPodIndexerByHost(g *graph.Graph) *graph.MetadataIndexer {
-	return newPodIndex(g, "Pod.NodeName")
+	return newPodIndexer(g, "Pod.NodeName")
 }
 
 func newPodIndexerByNamespace(g *graph.Graph) *graph.MetadataIndexer {
-	return newPodIndex(g, "Pod.Namespace")
+	return newPodIndexer(g, "Pod.Namespace")
 }
 
 func newPodIndexerByName(g *graph.Graph) *graph.MetadataIndexer {
-	return newPodIndex(g, "Name")
+	return newPodIndexer(g, "Name")
 }
 
 func podUID(pod *api.Pod) graph.Identifier {

--- a/topology/probes/k8s/pod.go
+++ b/topology/probes/k8s/pod.go
@@ -40,20 +40,26 @@ type podCache struct {
 	graph            *graph.Graph
 	containerIndexer *graph.MetadataIndexer
 	hostIndexer      *graph.MetadataIndexer
-	podIndexer       *graph.MetadataIndexer
 }
 
-func newPodIndexer(g *graph.Graph) *graph.MetadataIndexer {
-	return graph.NewMetadataIndexer(g, graph.Metadata{"Type": "pod"}, "Pod.NodeName")
+func newPodIndex(g *graph.Graph, by string) *graph.MetadataIndexer {
+	return graph.NewMetadataIndexer(g, graph.Metadata{"Type": "pod"}, by)
 }
 
-func (p *podCache) getMetadata(pod *api.Pod) graph.Metadata {
-	return graph.Metadata{
-		"Type":    "pod",
-		"Manager": "k8s",
-		"Name":    pod.GetName(),
-		"K8s":     pod,
-	}
+func newPodIndexerByHost(g *graph.Graph) *graph.MetadataIndexer {
+	return newPodIndex(g, "Pod.NodeName")
+}
+
+func newPodIndexerByNamespace(g *graph.Graph) *graph.MetadataIndexer {
+	return newPodIndex(g, "Pod.Namespace")
+}
+
+func newPodIndexerByName(g *graph.Graph) *graph.MetadataIndexer {
+	return newPodIndex(g, "Name")
+}
+
+func (p *podCache) newMetadata(pod *api.Pod) graph.Metadata {
+	return newMetadata("pod", pod.GetName(), pod)
 }
 
 func (p *podCache) linkPodToHost(pod *api.Pod, podNode *graph.Node) {
@@ -61,46 +67,70 @@ func (p *podCache) linkPodToHost(pod *api.Pod, podNode *graph.Node) {
 	if len(hostNodes) == 0 {
 		return
 	}
-	topology.AddOwnershipLink(p.graph, hostNodes[0], podNode, nil)
+	linkPodToHost(p.graph, hostNodes[0], podNode)
+}
+
+func (p *podCache) onAdd(obj interface{}) {
+	pod, ok := obj.(*api.Pod)
+	if !ok {
+		return
+	}
+
+	podNode := p.graph.NewNode(graph.Identifier(pod.GetUID()), p.newMetadata(pod))
+
+	containerNodes := p.containerIndexer.Get(pod.Namespace, pod.Name)
+	for _, containerNode := range containerNodes {
+		p.graph.Link(podNode, containerNode, podToContainerMetadata)
+	}
+
+	p.linkPodToHost(pod, podNode)
 }
 
 func (p *podCache) OnAdd(obj interface{}) {
-	if pod, ok := obj.(*api.Pod); ok {
-		p.Lock()
-		defer p.Unlock()
-
-		p.graph.Lock()
-		defer p.graph.Unlock()
-
-		logging.GetLogger().Debugf("Creating node for pod %s", pod.GetUID())
-		podNode := p.graph.NewNode(graph.Identifier(pod.GetUID()), p.getMetadata(pod))
-
-		containerNodes := p.containerIndexer.Get(pod.Namespace, pod.Name)
-		for _, containerNode := range containerNodes {
-			p.graph.Link(podNode, containerNode, podToContainerMetadata)
-		}
-
-		p.linkPodToHost(pod, podNode)
+	pod, ok := obj.(*api.Pod)
+	if !ok {
+		return
 	}
-}
 
-func (p *podCache) OnUpdate(obj, new interface{}) {
-	oldPod := obj.(*api.Pod)
-	newPod := new.(*api.Pod)
-	podNode := p.graph.GetNode(graph.Identifier(newPod.GetUID()))
+	p.Lock()
+	defer p.Unlock()
 
 	p.graph.Lock()
 	defer p.graph.Unlock()
 
+	logging.GetLogger().Infof("Creating node for pod{%s}", pod.GetName())
+
+	p.onAdd(obj)
+}
+
+func (p *podCache) OnUpdate(oldObj, newObj interface{}) {
+	oldPod := oldObj.(*api.Pod)
+	newPod := newObj.(*api.Pod)
+
+	p.Lock()
+	defer p.Unlock()
+
+	p.graph.Lock()
+	defer p.graph.Unlock()
+
+	podNode := p.graph.GetNode(graph.Identifier(newPod.GetUID()))
+	if podNode == nil {
+		logging.GetLogger().Infof("Updating (re-adding) node for pod{%s}", newPod.GetName())
+		p.onAdd(newObj)
+		return
+	}
+
+	logging.GetLogger().Infof("Updating node for pod{%s}", newPod.GetName())
 	if oldPod.Spec.NodeName == "" && newPod.Spec.NodeName != "" {
 		p.linkPodToHost(newPod, podNode)
 	}
 
-	p.graph.SetMetadata(podNode, p.getMetadata(newPod))
+	addMetadata(p.graph, podNode, newPod)
 }
 
 func (p *podCache) OnDelete(obj interface{}) {
 	if pod, ok := obj.(*api.Pod); ok {
+		logging.GetLogger().Infof("Deleting node for pod{%s}", pod.GetName())
 		p.graph.Lock()
 		if podNode := p.graph.GetNode(graph.Identifier(pod.GetUID())); podNode != nil {
 			p.graph.DelNode(podNode)
@@ -109,35 +139,14 @@ func (p *podCache) OnDelete(obj interface{}) {
 	}
 }
 
-func makePodKey(namespace, pod string) string {
-	return namespace + "/" + pod
+func linkPodsToHost(g *graph.Graph, host *graph.Node, pods []*graph.Node) {
+	for _, pod := range pods {
+		linkPodToHost(g, host, pod)
+	}
 }
 
-func (p *podCache) OnNodeAdded(n *graph.Node) {
-	nodeType, _ := n.GetFieldString("Type")
-	switch nodeType {
-	case "container":
-		namespace, _ := n.GetFieldString("Docker.Labels.io.kubernetes.pod.namespace")
-		podName, _ := n.GetFieldString("Docker.Labels.io.kubernetes.pod.name")
-		if namespace != "" && podName != "" {
-			p.Lock()
-			defer p.Unlock()
-
-			if pod := p.GetByKey(makePodKey(namespace, podName)); pod != nil {
-				// We already saw the pod through Kubernetes API
-				podNode := p.graph.GetNode(graph.Identifier(pod.GetUID()))
-				if podNode == nil {
-					logging.GetLogger().Warningf("Failed to find node for pod %s", pod.GetUID())
-					return
-				}
-				p.graph.Link(podNode, n, podToContainerMetadata)
-			}
-		}
-	case "host":
-		for _, pod := range p.podIndexer.Get(n.Host()) {
-			topology.AddOwnershipLink(p.graph, n, pod, nil)
-		}
-	}
+func linkPodToHost(g *graph.Graph, host, pod *graph.Node) {
+	topology.AddOwnershipLink(g, host, pod, nil)
 }
 
 func (p *podCache) List() (pods []*api.Pod) {
@@ -169,9 +178,8 @@ func (p *podCache) Stop() {
 func newPodCache(client *kubeClient, g *graph.Graph) *podCache {
 	p := &podCache{
 		graph:            g,
-		containerIndexer: newContainerIndexer(g, ""),
-		hostIndexer:      newHostIndexer(g, ""),
-		podIndexer:       newPodIndexer(g),
+		containerIndexer: newContainerIndexer(g),
+		hostIndexer:      newHostIndexer(g),
 	}
 	p.kubeCache = client.getCacheFor(client.Core().RESTClient(), &api.Pod{}, "pods", p)
 	return p

--- a/topology/probes/k8s/pod.go
+++ b/topology/probes/k8s/pod.go
@@ -74,7 +74,7 @@ func (p *podCache) OnAdd(obj interface{}) {
 
 		containerNodes := p.containerIndexer.Get(pod.Namespace, pod.Name)
 		for _, containerNode := range containerNodes {
-			p.graph.Link(podNode, containerNode, PodToContainerMetadata)
+			p.graph.Link(podNode, containerNode, podToContainerMetadata)
 		}
 
 		p.linkPodToHost(pod, podNode)
@@ -123,7 +123,7 @@ func (p *podCache) OnNodeAdded(n *graph.Node) {
 					logging.GetLogger().Warningf("Failed to find node for pod %s", pod.GetUID())
 					return
 				}
-				p.graph.Link(podNode, n, PodToContainerMetadata)
+				p.graph.Link(podNode, n, podToContainerMetadata)
 			}
 		}
 	case "host":

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -671,6 +671,12 @@
 			"revisionTime": "2017-07-04T05:34:23Z"
 		},
 		{
+			"checksumSHA1": "Z2LEpah3ZMTYNpRy7Rd+tI+T+W0=",
+			"path": "github.com/fatih/structs",
+			"revision": "f5faa72e73092639913f5833b75e1ac1d6bc7a63",
+			"revisionTime": "2017-10-20T06:48:19Z"
+		},
+		{
 			"checksumSHA1": "LtBBfn+Uw7/gaB2tVsrLRBTprdo=",
 			"path": "github.com/fsnotify/fsnotify",
 			"revision": "30411dbcefb7a1da7e84f75530ad3abe4011b4f8",
@@ -807,7 +813,7 @@
 			"revisionTime": "2016-07-27T17:26:17Z"
 		},
 		{
-			"checksumSHA1": "me40nSy9NBr9MmAwe5vDvTgSVZs=",
+			"checksumSHA1": "GENxfNGiSzB9hzo2fPZkI4F/Zzg=",
 			"path": "github.com/google/btree",
 			"revision": "cc6329d4279e3f025a53a83c397d2339b5705c45"
 		},
@@ -825,14 +831,14 @@
 			"revisionTime": "2017-11-28T22:01:57Z"
 		},
 		{
-			"checksumSHA1": "Uvt0pTvpmwUw0EwDiJm0AiTd754=",
+			"checksumSHA1": "ORc1X58pM+oNj08y5wXask2sV4c=",
 			"comment": "v1.1.11-106-gbdf4ee7",
 			"path": "github.com/google/gopacket/layers",
 			"revision": "67a21c4470a0598531a769727aef40b870ffa128",
 			"revisionTime": "2017-11-28T22:01:57Z"
 		},
 		{
-			"checksumSHA1": "NNhvUjsdyYOMWHlYjcw7KrIaJH8=",
+			"checksumSHA1": "Zq24NvykkROxoBM3vum5unM6TTI=",
 			"comment": "v1.1.11-106-gbdf4ee7",
 			"path": "github.com/google/gopacket/pcap",
 			"revision": "67a21c4470a0598531a769727aef40b870ffa128",
@@ -1212,7 +1218,7 @@
 			"revisionTime": "2013-11-06T22:25:44Z"
 		},
 		{
-			"checksumSHA1": "k1I8piNXcsrel3JptVnKykNJXBY=",
+			"checksumSHA1": "jHOLsfeMPcX84YQB2MXBqXFntBg=",
 			"path": "github.com/kr/pty",
 			"revision": "95d05c1eef33a45bd58676b6ce28d105839b8d0b",
 			"revisionTime": "2017-10-06T17:48:01Z"
@@ -1782,7 +1788,7 @@
 			"revision": "6acef71eb69611914f7a30939ea9f6e194c78172"
 		},
 		{
-			"checksumSHA1": "/oZpHfYc+ZgOwYAhlvcMhmETYpw=",
+			"checksumSHA1": "TVEkpH3gq84iQ39I4R+mlDwjuVI=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "99f16d856c9836c42d24e7ab64ea72916925fa97",
 			"revisionTime": "2017-03-08T15:04:45Z"
@@ -1806,19 +1812,19 @@
 			"revisionTime": "2017-09-13T16:58:53Z"
 		},
 		{
-			"checksumSHA1": "tk+lpF2CDV7e5RwwRY5ZTCGrd9o=",
+			"checksumSHA1": "iB6/RoQIzBaZxVi+t7tzbkwZTlo=",
 			"path": "golang.org/x/text/unicode/bidi",
 			"revision": "1cbadb444a806fd9430d14ad08967ed91da4fa0a",
 			"revisionTime": "2017-09-13T19:45:57Z"
 		},
 		{
-			"checksumSHA1": "TisxVXIAh3Hb6QdUOMso4wdqAQU=",
+			"checksumSHA1": "OwypTTxsp/HEwbfXq9yMR4fACRM=",
 			"path": "golang.org/x/text/unicode/norm",
 			"revision": "02704b6b714738b763ba478766eb55a4b4851cd4",
 			"revisionTime": "2016-04-13T10:07:35Z"
 		},
 		{
-			"checksumSHA1": "U1OTBlgTRUe9ZdMsbISL1E+eMm8=",
+			"checksumSHA1": "mfeW9NCKg58o6w5bbXPvpixpIw0=",
 			"path": "golang.org/x/text/width",
 			"revision": "ab5ac5f9a8deb4855a60fab02bc61a4ec770bd49",
 			"revisionTime": "2017-09-13T16:58:53Z"
@@ -1934,6 +1940,10 @@
 			"checksumSHA1": "2MXUjMNL4Zr28Gom3V3BJxdtiSQ=",
 			"path": "gopkg.in/yaml.v2",
 			"revision": "bef53efd0c76e49e6de55ead051f886bea7e9420"
+		},
+		{
+			"path": "http://github.com/fatih/structs",
+			"revision": ""
 		},
 		{
 			"checksumSHA1": "2AkXviX+M3zAqe5Lo7sZZgY2TRg=",


### PR DESCRIPTION
This is a 2nd phase for the PR adding this capability for node discovery via the k8s probe itself (without relaying on the host agent).

To test just connect to a k8s landscape scape