### PR TITLE
UI: configuration option to enable ssh to agents

### DIFF
--- a/analyzer/server.go
+++ b/analyzer/server.go
@@ -308,7 +308,9 @@ func NewServerFromConfig() (*Server, error) {
 	api.RegisterConfigAPI(hserver)
 	api.RegisterStatusAPI(hserver, s)
 
-	dede.RegisterTerminalHandler("/dede", hserver.Router)
+	if config.GetConfig().GetBool("analyzer.ssh_enabled") {
+		dede.RegisterTerminalHandler("/dede", hserver.Router)
+	}
 
 	return s, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,7 @@ func init() {
 	cfg.SetDefault("analyzer.storage.bulk_insert", 100)
 	cfg.SetDefault("analyzer.storage.bulk_insert_deadline", 5)
 	cfg.SetDefault("analyzer.topology.probes", []string{})
+	cfg.SetDefault("analyzer.ssh_enabled", false)
 
 	cfg.SetDefault("auth.type", "noauth")
 	cfg.SetDefault("auth.keystone.tenant", "admin")

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -36,7 +36,8 @@ analyzer:
   # topology_filter:
   #   Namespaces: "g.V().Has('Type', 'netns').OutE().BothV()"
   #   Layer2: "g.E().Has('RelationType', 'layer2')"
-
+  # Enable/disable ssh to hosts
+  # ssh_enabled: false
   # Flow storage engine
   # storage:
       # Available: elasticsearch, orientdb

--- a/statics/js/components/topology.js
+++ b/statics/js/components/topology.js
@@ -182,6 +182,13 @@ var TopologyComponent = {
   ',
 
   data: function() {
+    var myTopology = this
+    $.when(this.$getConfigValue('analyzer.ssh_enabled').
+                        then(function(sshEnabled) {
+                        try {
+                            myTopology.isSSHEnabled = sshEnabled;
+                         } catch(err) { console.log(err); }
+                        }));
     return {
       topologyTimeContext: 0,
       topologyTime: null,
@@ -193,6 +200,7 @@ var TopologyComponent = {
       topologyMode: "live",
       topologyHumanTimeContext: "",
       isTopologyOptionsVisible: false,
+      isSSHEnabled: false,
     };
   },
 
@@ -338,8 +346,7 @@ var TopologyComponent = {
 
     dedeSSH: function(m) {
       var self = this;
-
-      if (m.Type !== "host") return;
+      if (m.Type !== "host" || !this.isSSHEnabled) return;
 
       return {
         "Name": {


### PR DESCRIPTION
Since making ssh from analyzer to agents might
be security violation in some cases, we add
configuration flag for administrators to enable/disble it