### PR TITLE
ui: highlight only capture node on flow mouse over

### DIFF
--- a/flow/traversal/traversal.go
+++ b/flow/traversal/traversal.go
@@ -732,7 +732,7 @@ func (e *FlowTraversalExtension) ScanIdent(s string) (traversal.Token, bool) {
 		return e.HopsToken, true
 	case "NODES":
 		return e.NodesToken, true
-	case "CAPTURENODE":
+	case "NODE", "CAPTURENODE":
 		return e.CaptureNodeToken, true
 	case "AGGREGATES":
 		return e.AggregatesToken, true

--- a/statics/js/components/object-detail.js
+++ b/statics/js/components/object-detail.js
@@ -51,7 +51,8 @@ Vue.component('object-detail', {
         <div v-else>\
           <span class="object-key">{{key}}</span> :\
           <span class="object-value" :class="typeof(value)" v-html="transform(path ? path+\'.\'+key : key, value)"></span>\
-          <i v-if="links && links[key]" :class="links[key].class" @click="links[key].fnc"></i>\
+          <i v-if="links && links[key]" :class="links[key].class" @click="links[key].onClick" \
+            @mouseover="links[key].onMouseOver" @mouseout="links[key].onMouseOut"></i>\
         </div>\
       </div>\
     </div>\

--- a/statics/js/components/topology.js
+++ b/statics/js/components/topology.js
@@ -150,7 +150,7 @@ var TopologyComponent = {
                   @click="toggleExpandAll(currentNode)"></i></span>\
               </h1>\
               <div id="metadata-panel" class="sub-left-panel">\
-                <object-detail :object="currentNodeMetadata" :links="dedeSSH(currentNodeMetadata)"></object-detail>\
+                <object-detail :object="currentNodeMetadata" :links="metadataLinks(currentNodeMetadata)"></object-detail>\
               </div>\
               <div v-if="currentNodeMetadata.Type == \'ovsbridge\'">\
                 <h1>Rules</h1>\
@@ -182,13 +182,6 @@ var TopologyComponent = {
   ',
 
   data: function() {
-    var myTopology = this
-    $.when(this.$getConfigValue('analyzer.ssh_enabled').
-                        then(function(sshEnabled) {
-                        try {
-                            myTopology.isSSHEnabled = sshEnabled;
-                         } catch(err) { console.log(err); }
-                        }));
     return {
       topologyTimeContext: 0,
       topologyTime: null,
@@ -262,6 +255,11 @@ var TopologyComponent = {
     });
 
     this.setFilterFromConfig();
+
+    $.when(this.$getConfigValue('analyzer.ssh_enabled').
+      then(function(sshEnabled) {
+        self.isSSHEnabled = sshEnabled;
+    }));
   },
 
   beforeDestroy: function() {
@@ -344,18 +342,23 @@ var TopologyComponent = {
 
   methods: {
 
-    dedeSSH: function(m) {
+    metadataLinks: function(m) {
       var self = this;
-      if (m.Type !== "host" || !this.isSSHEnabled) return;
 
-      return {
-        "Name": {
+      var links = {};
+
+      if (m.Type === "host" && this.isSSHEnabled) {
+        links.Name = {
           "class": "indicator glyphicon glyphicon-new-window raw-packet-link",
-          "fnc": function() {
+          "onClick": function() {
             window.open(location.protocol + '//' + location.host + '/dede/terminal/'+m.Name+ '?title='+m.Name+'&cmd=ssh ' + m.Name, '_blank').focus();
-          }
-        }
-      };
+          },
+          "onMouseOver": function(){},
+          "onMouseOut": function(){}
+        };
+      }
+
+      return links;
     },
 
     unwatch: function() {


### PR DESCRIPTION
It allows to detect whether a packet has reached
A or B. Otherwise they are always highlighted
even if the packet didn't not reach one endpoint.

Instead this add a link on the right side of the
ANddeTID, BNodeTID to highlights endpoints.