### PR TITLE
changes to build to include skydive cleanup and debug of skydive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ statics/bindata.go
 contrib/vagrant/.vagrant/
 .idea
 contrib/snort/snortSkydive
+skydive.yml

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,21 @@
-VERSION_CMD='define="";version=`git rev-parse --verify HEAD`;tagname=`git show-ref --tags | grep $$version`;if [ -n "$$tagname" ]; then define=`echo $$tagname | awk -F "/" "{print \\$$NF}" | tr -d [a-z]`;else define=`printf "%.12s" $$version`;fi;tainted=`git ls-files -m | wc -l`;if [ "$$tainted" -gt 0 ]; then define="$${define}-tainted";fi;echo "$$define"'
-VERSION?=$(shell sh -c $(VERSION_CMD))
+define VERSION_CMD = 
+eval ' \
+	define=""; \
+	version=`git rev-parse --verify HEAD`; \
+	tagname=`git show-ref --tags | grep $$version`; \
+	if [ -n "$$tagname" ]; then \
+		define=`echo $$tagname | awk -F "/" "{print \\$$NF}" | tr -d [a-z]`; \
+	else \
+		define=`printf "%.12s" $$version`; \
+	fi; \
+	tainted=`git ls-files -m | wc -l` ; \
+	if [ "$$tainted" -gt 0 ]; then \
+		define="$${define}-tainted"; \
+	fi; \
+	echo "$$define" \
+'
+endef
+VERSION?=$(shell $(VERSION_CMD))
 $(info ${VERSION})
 
 # really Basic Makefile for Skydive

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,14 @@ fmt: govendor genlocalfiles
 
 vet: govendor
 	@echo "+ $@"
-	test -z "$$($(GOVENDOR) tool vet $$($(GOVENDOR) list -no-status +local | perl -pe 's|$(SKYDIVE_GITHUB)/?||g' | grep -v '^tests') 2>&1 | tee /dev/stderr | grep -v '^flow/probes/afpacket/' | grep -v 'exit status 1')"
+	test -z "$$($(GOVENDOR) tool vet $$( \
+			$(GOVENDOR) list -no-status +local \
+			| perl -pe 's|$(SKYDIVE_GITHUB)/?||g' \
+			| grep -v '^tests') 2>&1 \
+		| tee /dev/stderr \
+		| grep -v '^flow/probes/afpacket/' \
+		| grep -v 'exit status 1' \
+		)"
 
 check: govendor
 	@test -z "$$($(GOVENDOR) list +u)" || \

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,25 @@ endif
 .PHONY: all install
 all install: skydive
 
+skydive.yml: etc/skydive.yml.default
+	cp $< $@
+	
+.PHONY: debug
+debug: GOFLAGS+=-gcflags='-N -l'
+debug: skydive.cleanup dlv skydive skydive.yml
+
+define skydive_debug
+sudo $$(which dlv) exec $$(which skydive) -- $1 -c skydive.yml
+endef
+
+.PHONY: debug.agent
+debug.agent:
+	$(call skydive_debug,agent)
+
+.PHONY: debug.analyzer
+debug.analyzer:
+	$(call skydive_debug,analyzer)
+
 .proto: builddep ${FLOW_PROTO_FILES} ${FILTERS_PROTO_FILES}
 	protoc --go_out . ${FLOW_PROTO_FILES}
 	protoc --go_out . ${FILTERS_PROTO_FILES}

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,15 @@ all: install
 	# add flowState to flow generated struct
 	sed -e 's/type Flow struct {/type Flow struct {\n\tXXX_state flowState `json:"-"`/' -i flow/flow.pb.go
 
+BINDATA_DIRS := \
+	statics/* \
+	statics/css/images/* \
+	statics/js/vendor/* \
+	statics/js/components/* \
+	${EXTRABINDATA}
+
 .bindata: builddep ebpf.build
-	go-bindata ${GO_BINDATA_FLAGS} -nometadata -o statics/bindata.go -pkg=statics -ignore=bindata.go statics/* statics/css/images/* statics/js/vendor/* statics/js/components/* ${EXTRABINDATA}
+	go-bindata ${GO_BINDATA_FLAGS} -nometadata -o statics/bindata.go -pkg=statics -ignore=bindata.go $(BINDATA_DIRS)
 	gofmt -w -s statics/bindata.go
 
 define govendor_do


### PR DESCRIPTION
The scope of these changes:
- cleanup - added `make skydive.cleanup` (and some other targets) to enable deleting artifacts created when building `make skydive`
- refactoring - mainly broke very long single lines within Makefile to multiline
- debug - added helper targets to build `make debug`, and run `make debug.agent` / `make debug.analyzer`
- go installation - added `make golang` to automate installation of Go