### PR TITLE
Neutron：qvb and qbr don't have neutron topology

### DIFF
--- a/topology/probes/neutron.go
+++ b/topology/probes/neutron.go
@@ -287,7 +287,14 @@ func (mapper *NeutronProbe) updateNode(node *graph.Node, attrs *attributes) {
 				mapper.graph.RUnlock()
 
 				if len(path) == 0 {
-					return errors.New("Path not found")
+					qbr := strings.Replace(name, "qvo", "qbr", 1)
+					mapper.graph.RLock()
+					path = mapper.graph.LookupShortestPath(node, graph.Metadata{"Name": qbr}, topology.Layer2Metadata)
+					mapper.graph.RUnlock()
+
+					if len(path) == 0 {
+						return errors.New("Path not found")
+					}
 				}
 
 				mapper.graph.Lock()


### PR DESCRIPTION
When the Status of VM is "SHUTOFF", the tap node will disappear
we start skydive in this time, the qvb and qbr will not have neutron topology