### PR TITLE
Neutron: tap nodes can not update automatically

### DIFF
--- a/topology/probes/neutron.go
+++ b/topology/probes/neutron.go
@@ -360,6 +360,24 @@ func (mapper *NeutronProbe) OnNodeUpdated(n *graph.Node) {
 
 // OnNodeAdded event
 func (mapper *NeutronProbe) OnNodeAdded(n *graph.Node) {
+	name, _ := n.GetFieldString("Name")
+	attachedMAC, _ := n.GetFieldString("ExtID.attached-mac")
+	if attachedMAC == "" && strings.HasPrefix(name, "tap") {
+		qvo := strings.Replace(name, "tap", "qvo", 1)
+		qvoNode := mapper.graph.LookupFirstNode(graph.Metadata{"Name": qvo, "Type": "veth"})
+		if qvoNode != nil {
+			tr := mapper.graph.StartMetadataTransaction(n)
+			if attachedMAC, _ = qvoNode.GetFieldString("ExtID.attached-mac"); attachedMAC != "" {
+				tr.AddMetadata("ExtID.attached-mac", attachedMAC)
+			}
+
+			if uuid, _ := qvoNode.GetFieldString("ExtID.vm-uuid"); uuid != "" {
+				tr.AddMetadata("ExtID.vm-uuid", uuid)
+			}
+			tr.Commit()
+		}
+	}
+
 	mapper.enhanceNode(n)
 }
 


### PR DESCRIPTION
Execute "nova stop" to shut down a virtual machine, the tap node will disappear
execute "nova start" to power on virtual machine, tap node will rebuild
the new tap node doesn't have neutron topology