### PR TITLE
http: added to debug info to WebSocket pools

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -69,7 +69,7 @@ type Agent struct {
 // NewAnalyzerWSJSONClientPool creates a new http WebSocket client Pool
 // with authentification
 func NewAnalyzerWSJSONClientPool(authOptions *shttp.AuthenticationOpts) (*shttp.WSJSONClientPool, error) {
-	pool := shttp.NewWSJSONClientPool()
+	pool := shttp.NewWSJSONClientPool("AnalyzerClientPool")
 
 	addresses, err := config.GetAnalyzerServiceAddresses()
 	if err != nil {

--- a/analyzer/topology_replication_endpoint.go
+++ b/analyzer/topology_replication_endpoint.go
@@ -370,7 +370,7 @@ func NewTopologyReplicationEndpoint(pool shttp.WSJSONSpeakerPool, auth *shttp.Au
 		Graph:  g,
 		cached: cached,
 		in:     pool,
-		out:    shttp.NewWSJSONClientPool(),
+		out:    shttp.NewWSJSONClientPool("TopologyReplicationEndpoint"),
 		conns:  make(map[string]shttp.WSSpeaker),
 	}
 	t.replicateMsg.Store(true)

--- a/http/wsjson.go
+++ b/http/wsjson.go
@@ -344,8 +344,8 @@ func (s *WSJSONClientPool) Request(host string, request *WSJSONMessage, timeout 
 }
 
 // NewWSJSONClientPool returns a new WSJSONClientPool.
-func NewWSJSONClientPool() *WSJSONClientPool {
-	pool := NewWSClientPool()
+func NewWSJSONClientPool(name string) *WSJSONClientPool {
+	pool := NewWSClientPool(name)
 	return &WSJSONClientPool{
 		WSClientPool:                     pool,
 		wsJSONSpeakerPoolEventDispatcher: newWSJSONSpeakerPoolEventDispatcher(pool),

--- a/http/wsmessage_test.go
+++ b/http/wsmessage_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/skydive-project/skydive/common"
 	"github.com/skydive-project/skydive/config"
+	"github.com/skydive-project/skydive/logging"
 )
 
 type fakeWSMessageServerSubscriptionHandler struct {
@@ -86,6 +87,7 @@ func (f *fakeWSMessageClientSubscriptionHandler) OnWSJSONMessage(c WSSpeaker, m 
 }
 
 func TestWSMessageSubscription(t *testing.T) {
+	logging.InitLogging()
 	httpserver := NewServer("myhost", common.AnalyzerService, "localhost", 59999, NewNoAuthenticationBackend(), "")
 
 	go httpserver.ListenAndServe()
@@ -102,7 +104,7 @@ func TestWSMessageSubscription(t *testing.T) {
 
 	wsclient := NewWSClient("myhost", common.AgentService, config.GetURL("ws", "localhost", 59999, "/wstest"), nil, http.Header{}, 1000)
 
-	wspool := NewWSJSONClientPool()
+	wspool := NewWSJSONClientPool("TestWSMessageSubscription")
 	wspool.AddClient(wsclient)
 
 	clientHandler := &fakeWSMessageClientSubscriptionHandler{t: t, received: make(map[string]bool)}

--- a/http/wsserver.go
+++ b/http/wsserver.go
@@ -66,6 +66,7 @@ func (s *WSServer) serveMessages(w http.ResponseWriter, r *auth.AuthenticatedReq
 	if host == "" {
 		host = r.RemoteAddr
 	}
+	logging.GetLogger().Debugf("Serving messages for client %s for pool %s", host, s.GetName())
 
 	s.wsIncomerPool.RLock()
 	c := s.GetSpeakerByHost(host)
@@ -95,7 +96,7 @@ func (s *WSServer) serveMessages(w http.ResponseWriter, r *auth.AuthenticatedReq
 // NewWSServer returns a new WSServer.
 func NewWSServer(server *Server, endpoint string) *WSServer {
 	s := &WSServer{
-		wsIncomerPool: newWSIncomerPool(), // server inherites from a WSSpeaker pool
+		wsIncomerPool: newWSIncomerPool(endpoint), // server inherites from a WSSpeaker pool
 		incomerHandler: func(c *websocket.Conn, a *auth.AuthenticatedRequest) WSSpeaker {
 			return defaultIncomerHandler(c, a)
 		},

--- a/http/wsserver_test.go
+++ b/http/wsserver_test.go
@@ -91,7 +91,7 @@ func TestSubscription(t *testing.T) {
 	defer wsserver.Stop()
 
 	wsclient := NewWSClient("myhost", common.AgentService, config.GetURL("ws", "localhost", 59999, "/wstest"), nil, http.Header{}, 1000)
-	wspool := NewWSClientPool()
+	wspool := NewWSClientPool("TestSubscription")
 
 	wspool.AddClient(wsclient)
 

--- a/tests/topology_test.go
+++ b/tests/topology_test.go
@@ -754,7 +754,7 @@ func TestQueryMetadata(t *testing.T) {
 			}
 
 			hostname, _ := os.Hostname()
-			wspool := shttp.NewWSJSONClientPool()
+			wspool := shttp.NewWSJSONClientPool("TestQueryMetadata")
 			for _, sa := range addresses {
 				authClient := shttp.NewAuthenticationClient(config.GetURL("http", sa.Addr, sa.Port, ""), authOptions)
 				client := shttp.NewWSClient(hostname+"-cli", common.UnknownService, config.GetURL("ws", sa.Addr, sa.Port, "/ws/publisher"), authClient, http.Header{}, 1000)


### PR DESCRIPTION
Co-Authored-By: eranra@il.ibm.com

This is intended for debugging the correct creation/destruction of WS Pools, each pool is now assigned a new `name` field which is printed via logs.