### PR TITLE
ui: setting fixed position for nodes

### DIFF
--- a/statics/js/components/graph-layout.js
+++ b/statics/js/components/graph-layout.js
@@ -1369,6 +1369,27 @@ TopologyGraphLayout.prototype = {
     this.simulation.nodes(nodes);
     this.simulation.force("link").links(links);
     this.simulation.alpha(1).restart();
+    this.reArrangeGraphNodes();
+  },
+
+  setFixedPosition: function(node) {
+    if(node.metadata.X && node.metadata.Y) {
+        var theNode = this.nodes[node.id];
+        if(theNode == null) return;
+        theNode.x = parseInt(node.metadata.X);
+        theNode.fx = node.x;
+        theNode.y = parseInt(node.metadata.Y);
+        theNode.fy = node.y;
+        this.pinNode(node);
+    }
+    return
+  },
+
+  reArrangeGraphNodes: function () {
+    for (var i in this.nodes) {
+        var aNode = this.nodes[i];
+        this.setFixedPosition(aNode);
+    }
   },
 
   highlightLink: function(d) {


### PR DESCRIPTION
For testing add the following rows to the .yml fabric section:

- TOR1[Name=tor1] -> [color=red] TOR1_PORT1[Name=port1, MTU=1500, X=400, Y=428]

Once X and Y are set as metadata of the node, this patch will pin the node
in the selected location