### PR TITLE
build: allow client to build on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ debug.analyzer:
 	sed -e 's/json:"LastRawPackets,omitempty"/json:"-"/g' -i.bak flow/flow.pb.go
 	# add flowState to flow generated struct
 	sed -e 's/type Flow struct {/type Flow struct { XXX_state flowState `json:"-"`/' -i.bak flow/flow.pb.go
+	gofmt -s -w flow/flow.pb.go
 
 BINDATA_DIRS := \
 	statics/* \

--- a/Makefile
+++ b/Makefile
@@ -87,11 +87,11 @@ debug.analyzer:
 	protoc --go_out . ${FILTERS_PROTO_FILES}
 	# always export flow.ParentUUID as we need to store this information to know
 	# if it's a Outer or Inner packet.
-	sed -e 's/ParentUUID\(.*\),omitempty\(.*\)/ParentUUID\1\2/' -e 's/int64\(.*\),omitempty\(.*\)/int64\1\2/' -i flow/flow.pb.go
+	sed -e 's/ParentUUID\(.*\),omitempty\(.*\)/ParentUUID\1\2/' -e 's/int64\(.*\),omitempty\(.*\)/int64\1\2/' -i '' flow/flow.pb.go
 	# do not export LastRawPackets used internally
-	sed -e 's/json:"LastRawPackets,omitempty"/json:"-"/g' -i flow/flow.pb.go
+	sed -e 's/json:"LastRawPackets,omitempty"/json:"-"/g' -i '' flow/flow.pb.go
 	# add flowState to flow generated struct
-	sed -e 's/type Flow struct {/type Flow struct {\n\tXXX_state flowState `json:"-"`/' -i flow/flow.pb.go
+	sed -e 's/type Flow struct {/type Flow struct { XXX_state flowState `json:"-"`/' -i '' flow/flow.pb.go
 
 BINDATA_DIRS := \
 	statics/* \

--- a/Makefile
+++ b/Makefile
@@ -87,11 +87,11 @@ debug.analyzer:
 	protoc --go_out . ${FILTERS_PROTO_FILES}
 	# always export flow.ParentUUID as we need to store this information to know
 	# if it's a Outer or Inner packet.
-	sed -e 's/ParentUUID\(.*\),omitempty\(.*\)/ParentUUID\1\2/' -e 's/int64\(.*\),omitempty\(.*\)/int64\1\2/' -i '' flow/flow.pb.go
+	sed -e 's/ParentUUID\(.*\),omitempty\(.*\)/ParentUUID\1\2/' -e 's/int64\(.*\),omitempty\(.*\)/int64\1\2/' -i.bak flow/flow.pb.go
 	# do not export LastRawPackets used internally
-	sed -e 's/json:"LastRawPackets,omitempty"/json:"-"/g' -i '' flow/flow.pb.go
+	sed -e 's/json:"LastRawPackets,omitempty"/json:"-"/g' -i.bak flow/flow.pb.go
 	# add flowState to flow generated struct
-	sed -e 's/type Flow struct {/type Flow struct { XXX_state flowState `json:"-"`/' -i '' flow/flow.pb.go
+	sed -e 's/type Flow struct {/type Flow struct { XXX_state flowState `json:"-"`/' -i.bak flow/flow.pb.go
 
 BINDATA_DIRS := \
 	statics/* \

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -1,3 +1,5 @@
+// +build linux
+
 /*
  * Copyright (C) 2015 Red Hat, Inc.
  *
@@ -65,6 +67,8 @@ var Agent = &cobra.Command{
 }
 
 func init() {
+	RootCmd.AddCommand(Agent)
+
 	host, err := os.Hostname()
 	if err != nil {
 		panic(err)

--- a/cmd/allinone.go
+++ b/cmd/allinone.go
@@ -1,3 +1,5 @@
+// +build linux
+
 /*
  * Copyright (C) 2016 Red Hat, Inc.
  *
@@ -150,6 +152,8 @@ var AllInOne = &cobra.Command{
 }
 
 func init() {
+	RootCmd.AddCommand(AllInOne)
+
 	var uid uint32
 
 	skydivePath, _ := osext.Executable()

--- a/cmd/analyzer.go
+++ b/cmd/analyzer.go
@@ -1,3 +1,5 @@
+// +build linux
+
 /*
  * Copyright (C) 2015 Red Hat, Inc.
  *
@@ -69,6 +71,8 @@ var Analyzer = &cobra.Command{
 }
 
 func init() {
+	RootCmd.AddCommand(Analyzer)
+
 	Analyzer.Flags().String("listen", "127.0.0.1:8082", "address and port for the analyzer API")
 	config.GetConfig().BindPFlag("analyzer.listen", Analyzer.Flags().Lookup("listen"))
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -66,9 +66,6 @@ func init() {
 	RootCmd.PersistentFlags().StringArrayVarP(&CfgFiles, "conf", "c", []string{}, "location of Skydive agent config files")
 	RootCmd.PersistentFlags().StringVarP(&cfgBackend, "config-backend", "b", "file", "configuration backend (defaults to file)")
 	RootCmd.AddCommand(VersionCmd)
-	RootCmd.AddCommand(Agent)
-	RootCmd.AddCommand(Analyzer)
 	RootCmd.AddCommand(Client)
-	RootCmd.AddCommand(AllInOne)
 	RootCmd.AddCommand(BashCompletion)
 }

--- a/common/socket.go
+++ b/common/socket.go
@@ -81,6 +81,18 @@ int open_raw_socket_in_netns(int curns, int newns, const char *name)
 
   return fd;
 }
+#elif __APPLE__
+#include <stdlib.h>
+
+int open_raw_socket(const char *name)
+{
+   return 0; // UNIMPLEMENTED
+}
+
+int open_raw_socket_in_netns(int curns, int newns, const char *name)
+{
+   return 0; // UNIMPLEMENTED
+}
 #endif
 */
 import "C"

--- a/flow/probes/afpacket/afpacket_unspecified.go
+++ b/flow/probes/afpacket/afpacket_unspecified.go
@@ -1,0 +1,57 @@
+// Copyright 2012 Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+// +build !linux
+
+// Package afpacket provides Go bindings for MMap'd AF_PACKET socket reading.
+package afpacket
+
+import (
+	"errors"
+
+	"golang.org/x/net/bpf"
+
+	"github.com/google/gopacket"
+)
+
+var (
+	ErrNotImplemented = errors.New("not implemented")
+	ErrTimeout        = errors.New("packet poll timeout expired")
+)
+
+type TPacket struct {
+}
+
+type SocketStats struct{}
+type SocketStatsV3 struct{}
+
+func (h *TPacket) ReadPacketData() (data []byte, ci gopacket.CaptureInfo, err error) {
+	return []byte{}, gopacket.CaptureInfo{}, ErrNotImplemented
+}
+
+func (h *TPacket) Close() {
+}
+
+func NewTPacket(opts ...interface{}) (h *TPacket, err error) {
+	return nil, ErrNotImplemented
+}
+
+func (h *TPacket) SetBPF(filter []bpf.RawInstruction) error {
+	return ErrNotImplemented
+}
+
+// SocketStats saves stats from the socket to the TPacket instance.
+func (h *TPacket) SocketStats() (SocketStats, SocketStatsV3, error) {
+	return SocketStats{}, SocketStatsV3{}, ErrNotImplemented
+}
+
+func (s SocketStatsV3) Packets() uint64 {
+	return 0
+}
+
+func (s SocketStatsV3) Drops() uint64 {
+	return 0
+}

--- a/flow/probes/afpacket/options_unspecified.go
+++ b/flow/probes/afpacket/options_unspecified.go
@@ -1,0 +1,29 @@
+// Copyright 2012 Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+// +build !linux
+
+package afpacket
+
+import (
+	"time"
+)
+
+type OptInterface string
+type OptFrameSize int
+type OptBlockSize int
+type OptNumBlocks int
+type OptBlockTimeout time.Duration
+type OptPollTimeout time.Duration
+
+// Default constants used by options.
+const (
+	DefaultFrameSize    = 4096                   // Default value for OptFrameSize.
+	DefaultBlockSize    = DefaultFrameSize * 128 // Default value for OptBlockSize.
+	DefaultNumBlocks    = 128                    // Default value for OptNumBlocks.
+	DefaultBlockTimeout = 64 * time.Millisecond  // Default value for OptBlockTimeout.
+	DefaultPollTimeout  = -1 * time.Millisecond  // Default value for OptPollTimeout. This blocks forever.
+)

--- a/topology/probes/netlink.go
+++ b/topology/probes/netlink.go
@@ -1,3 +1,5 @@
+// +build linux
+
 /*
  * Copyright (C) 2015 Red Hat, Inc.
  *

--- a/topology/probes/netlink_unspecified.go
+++ b/topology/probes/netlink_unspecified.go
@@ -1,0 +1,62 @@
+// +build !linux
+
+package probes
+
+import (
+	"errors"
+	"net"
+	"sync"
+
+	"github.com/skydive-project/skydive/topology/graph"
+)
+
+var (
+	ErrNotImplemented = errors.New("not implemented")
+)
+
+// NetNsNetLinkProbe describes a topology probe based on netlink in a network namespace
+type NetNsNetLinkProbe struct {
+	sync.RWMutex
+	Graph  *graph.Graph
+	Root   *graph.Node
+	NsPath string
+}
+
+// NetLinkProbe describes a list NetLink NameSpace probe to enhance the graph
+type NetLinkProbe struct {
+	sync.RWMutex
+	Graph *graph.Graph
+}
+
+// RouteTable describes a list of Routes
+type RoutingTable struct {
+	Id     int
+	Src    net.IP `json:"Src,omitempty"`
+	Routes []Route
+}
+
+// Route describes a route
+type Route struct {
+	Prefix   string    `json:"Prefix,omitempty"`
+	Nexthops []NextHop `json:"Nexthops,omitempty"`
+}
+
+// NextHop describes a next hop
+type NextHop struct {
+	Priority int    `json:"Priority,omitempty"`
+	Ip       net.IP `json:"Ip,omitempty"`
+}
+
+func NewNetLinkProbe(g *graph.Graph) (*NetLinkProbe, error) {
+	return nil, ErrNotImplemented
+}
+
+func (u *NetLinkProbe) Start() {
+}
+
+func (u *NetLinkProbe) Stop() {
+}
+
+func (u *NetLinkProbe) Register(nsPath string, root *graph.Node) (*NetNsNetLinkProbe, error) {
+	return nil, ErrNotImplemented
+}

--- a/topology/probes/netns.go
+++ b/topology/probes/netns.go
@@ -1,3 +1,5 @@
+// +build linux
+
 /*
  * Copyright (C) 2015 Red Hat, Inc.
  *

--- a/topology/probes/netns_unspecified.go
+++ b/topology/probes/netns_unspecified.go
@@ -1,0 +1,45 @@
+// +build !linux
+
+package probes
+
+import (
+	"sync"
+
+	"github.com/skydive-project/skydive/logging"
+	"github.com/skydive-project/skydive/topology/graph"
+)
+
+// NetNSProbe describes a netlink probe in a network namespace
+type NetNSProbe struct {
+	sync.RWMutex
+	Graph        *graph.Graph
+	Root         *graph.Node
+	NetLinkProbe *NetLinkProbe
+}
+
+// NetNs describes a network namespace path associated with a device / inode
+type NetNs struct {
+}
+
+// Register a new network namespace path
+func (u *NetNSProbe) Register(path string, name string) *graph.Node {
+	logging.GetLogger().Errorf("Register Network Namespace unimplemented: %s", path)
+	return nil
+}
+
+// Unregister a network namespace path
+func (u *NetNSProbe) Unregister(path string) {
+}
+
+func NewNetNSProbe(g *graph.Graph, n *graph.Node, nlProbe *NetLinkProbe) (*NetNSProbe, error) {
+	return nil, ErrNotImplemented
+}
+
+func (u *NetNSProbe) Watch(path string) {
+}
+
+func (u *NetNSProbe) Start() {
+}
+
+func (u *NetNSProbe) Stop() {
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1557,9 +1557,9 @@
 			"revisionTime": "2017-08-21T15:13:55Z"
 		},
 		{
-			"checksumSHA1": "JCH45h0NMsN7LFN18mwjzNgDaYI=",
+			"checksumSHA1": "qf37dJzNS2iXycH62ukEw+cleZY=",
 			"path": "github.com/vishvananda/netns",
-			"revision": "604eaf189ee867d8c147fafc28def2394e878d25"
+			"revision": "be1fbeda19366dea804f00efff2dd73a1642fdcc"
 		},
 		{
 			"checksumSHA1": "B9K+5clCq0PU8n8/utbKT0QjQyU=",


### PR DESCRIPTION
I use OSX.  Skydive's `make install` didn't succeed on OSX.

After these changes I am able to run `skydive client query` queries and `skydive client status` etc.

Three changes:
1. OSX uses BSD-style _sed_ so I added argument to sed invocations in Makefile and removed newline and tab escapes that are not necessary.
2. Switched to newer version of github.com/vishvananda/netns to get a fix for non-Linux
3. Added files with unimplemented or failing versions of methods that had Linux dependencies.