### PR TITLE
test : Fedora resolve localhost as an IPv4 address

### DIFF
--- a/common/service_test.go
+++ b/common/service_test.go
@@ -37,7 +37,7 @@ func TestServiceAddress(t *testing.T) {
 	if err != nil {
 		t.Errorf("should not return an error: %s", err)
 	}
-	if sa.Addr != "[::1]" || sa.Port != 8080 {
+	if (sa.Addr != "[::1]" && sa.Addr != "127.0.0.1") || sa.Port != 8080 {
 		t.Errorf("expected not found, got: %s", sa)
 	}
 


### PR DESCRIPTION
Fedora resolve localhost as an IPv4 address and localhost6 as IPv6 address 