### PR TITLE
opencontrail: get the err from Retry function

### DIFF
--- a/topology/probes/opencontrail.go
+++ b/topology/probes/opencontrail.go
@@ -115,7 +115,7 @@ func getInterfaceFromIntrospect(host string, port int, name string) (col collect
 		}
 		return
 	}
-	common.Retry(getFromIntrospect, 3, 500*time.Millisecond)
+	err = common.Retry(getFromIntrospect, 3, 500*time.Millisecond)
 	return
 }
 


### PR DESCRIPTION
Otherwise, this can lead to empty data structure without any error.