### PR TITLE
k8s: fallback in case k8s.config_file is missing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -118,7 +118,7 @@ func init() {
 	cfg.SetDefault("sflow.port_min", 6345)
 	cfg.SetDefault("sflow.port_max", 6355)
 
-	cfg.SetDefault("k8s.config_file", "/etc/skydive/kube-cfg.yml")
+	cfg.SetDefault("k8s.config_file", "/etc/skydive/kubeconfig")
 
 	cfg.SetDefault("storage.elasticsearch.host", "127.0.0.1:9200")
 	cfg.SetDefault("storage.elasticsearch.maxconns", 10)

--- a/etc/kube-config-empty.yml
+++ b/etc/kube-config-empty.yml
@@ -1,7 +1,0 @@
-apiVersion: v1
-clusters: []
-contexts: []
-current-context: ""
-kind: Config
-preferences: {}
-users: []

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -253,10 +253,17 @@ ui:
   # extra_assets: /usr/share/skydive/assets
 
 k8s:
-  # EXPERIMENTAL: k8s probe is still under development and should not be used on production systems
-  # The kube config file, if executed inside the cluster, you may use the empty
-  # file, kube-config-empty.yml
-  # config_file: /etc/skydive/kube-cfg.yml
+  # EXPERIMENTAL: k8s probe is still under development and should not be used
+  # on production systems
+  #
+  # kubeconfig resolution order:
+  # if kubeconfig param is defined then use it
+  # else if $KUBECONFIG environment is define then use it
+  # else if $HOME/.kube/config file exists then use it
+  # else use empty configuration (for accessing from within the k8s cluster)
+  #
+  # Specify the path of k8s configuration YAML file
+  # config_file: /etc/skydive/kubeconfig
   subprobes:
   - networkpolicy
   - pod

--- a/topology/probes/k8s/client.go
+++ b/topology/probes/k8s/client.go
@@ -46,7 +46,15 @@ func newKubeClient() (*kubeClient, error) {
 	kubeconfig := config.GetConfig().GetString("k8s.config_file")
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to load Kubernetes config %s: %s", kubeconfig, err.Error())
+		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+
+		configOverrides := &clientcmd.ConfigOverrides{}
+
+		kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+		config, err = kubeConfig.ClientConfig()
+		if err != nil {
+			return nil, fmt.Errorf("Failed to load Kubernetes config: %s", err.Error())
+		}
 	}
 
 	clientset, err := kubernetes.NewForConfig(config)


### PR DESCRIPTION
If k8s.config_file (either defined or default value /etc/skydive/kubeconfig) does not exist then resolve k8s configuration as the `kubectl` does: first check `$KUBECONFIG`, next check `$HOME/.kube/config` finally resolve to empty definition (which works when running from within a k8s cluster). 