### PR TITLE
HTTP: user defined "Cookie" and extended logging for client(s)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,7 @@ func init() {
 	cfg.SetDefault("agent.topology.probes", []string{"ovsdb"})
 	cfg.SetDefault("agent.topology.netlink.metrics_update", 30)
 	cfg.SetDefault("agent.X509_servername", "")
+	cfg.SetDefault("agent.http.debug", false)
 
 	cfg.SetDefault("analyzer.bandwidth_absolute_active", 1)
 	cfg.SetDefault("analyzer.bandwidth_absolute_alert", 1000)

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -107,6 +107,10 @@ agent:
   http:
     # log the HTTP client request and response (to log level DEBUG)
     # debug: false
+    # define the Cookie HTTP Request Header
+    # cookie: 
+    #   <name1>: <value1>
+    #   <name2>: <value2>
   topology:
     # Probes used to capture topology informations like interfaces,
     # bridges, namespaces, etc...

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -104,6 +104,9 @@ agent:
   # Not required, but can be used to allow virtual hosting
   # X509_servername: domain.com
   #
+  http:
+    # log the HTTP client request and response (to log level DEBUG)
+    # debug: false
   topology:
     # Probes used to capture topology informations like interfaces,
     # bridges, namespaces, etc...

--- a/http/client.go
+++ b/http/client.go
@@ -58,14 +58,8 @@ func readBody(resp *http.Response) string {
 
 func getHttpClient() *http.Client {
 	client := &http.Client{}
-	if config.IsTLSenabled() == true {
-		certPEM := config.GetConfig().GetString("agent.X509_cert")
-		keyPEM := config.GetConfig().GetString("agent.X509_key")
-		analyzerCertPEM := config.GetConfig().GetString("analyzer.X509_cert")
-		tlsConfig := common.SetupTLSClientConfig(certPEM, keyPEM)
-		tlsConfig.RootCAs = common.SetupTLSLoadCertificate(analyzerCertPEM)
-		checkTLSConfig(tlsConfig)
-
+	if config.IsTLSenabled() {
+		tlsConfig := getTLSConfig(true)
 		tr := &http.Transport{TLSClientConfig: tlsConfig}
 		client = &http.Client{Transport: tr}
 	}

--- a/http/client.go
+++ b/http/client.go
@@ -110,6 +110,8 @@ func (c *RestClient) Request(method, path string, body io.Reader, header http.He
 	switch resp.Header.Get("Content-Encoding") {
 	case "gzip":
 		resp.Body, err = gzip.NewReader(resp.Body)
+		resp.Uncompressed = true
+		resp.ContentLength = -1
 		if err != nil {
 			return nil, err
 		}

--- a/http/client.go
+++ b/http/client.go
@@ -101,8 +101,7 @@ func (c *RestClient) Request(method, path string, body io.Reader, header http.He
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Add("Accept-Encoding", "gzip")
 
-	cookie := http.Cookie{Name: "authtok", Value: c.authClient.AuthToken}
-	req.Header.Set("Cookie", cookie.String())
+	setCookies(&req.Header, c.authClient)
 
 	if debug := config.GetConfig().GetBool("agent.http.debug"); debug {
 		if buf, err := httputil.DumpRequest(req, true); err == nil {

--- a/http/wsclient.go
+++ b/http/wsclient.go
@@ -405,12 +405,7 @@ func (c *WSClient) connect() {
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
 	}
-	certPEM := config.GetConfig().GetString("agent.X509_cert")
-	keyPEM := config.GetConfig().GetString("agent.X509_key")
-	if certPEM != "" && keyPEM != "" {
-		d.TLSClientConfig = common.SetupTLSClientConfig(certPEM, keyPEM)
-		checkTLSConfig(d.TLSClientConfig)
-	}
+	d.TLSClientConfig = getTLSConfig(false)
 	c.conn, _, err = d.Dial(endpoint, headers)
 
 	if err != nil {

--- a/http/wsclient.go
+++ b/http/wsclient.go
@@ -396,8 +396,9 @@ func (c *WSClient) connect() {
 			logging.GetLogger().Errorf("Unable to authenticate %s : %s", endpoint, err.Error())
 			return
 		}
-		c.AuthClient.SetHeaders(headers)
 	}
+
+	setCookies(&headers, c.AuthClient)
 
 	d := websocket.Dialer{
 		Proxy:           http.ProxyFromEnvironment,


### PR DESCRIPTION
Several fixes affecting HTTP client (both REST and WS), which can be tested by using:

In skydive.yml

```
agent:
  http:
    debug: true
    cookie: <value>
```
And then one can run the following commands:

```
skydive client status -c skydive.yml
skydive agent -c skydive.yml
```