### PR TITLE
http: WebSocket enable/disable of write compression

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -51,6 +51,7 @@ func init() {
 	}
 
 	cfg = viper.New()
+
 	cfg.SetDefault("agent.flow.probes", []string{"gopacket", "pcapsocket"})
 	cfg.SetDefault("agent.flow.pcapsocket.bind_address", "127.0.0.1")
 	cfg.SetDefault("agent.flow.pcapsocket.min_port", 8100)
@@ -60,7 +61,6 @@ func init() {
 	cfg.SetDefault("agent.topology.probes", []string{"ovsdb"})
 	cfg.SetDefault("agent.topology.netlink.metrics_update", 30)
 	cfg.SetDefault("agent.X509_servername", "")
-	cfg.SetDefault("agent.http.debug", false)
 
 	cfg.SetDefault("analyzer.bandwidth_absolute_active", 1)
 	cfg.SetDefault("analyzer.bandwidth_absolute_alert", 1000)
@@ -132,6 +132,7 @@ func init() {
 	cfg.SetDefault("storage.orientdb.username", "root")
 	cfg.SetDefault("storage.orientdb.password", "root")
 
+	cfg.SetDefault("http.rest.debug", false)
 	cfg.SetDefault("ws_ping_delay", 2)
 	cfg.SetDefault("ws_pong_timeout", 5)
 	cfg.SetDefault("ws_bulk_maxmsgs", 100)

--- a/config/config.go
+++ b/config/config.go
@@ -138,6 +138,7 @@ func init() {
 	cfg.SetDefault("ws_bulk_maxmsgs", 100)
 	cfg.SetDefault("ws_bulk_maxdelay", 1)
 	cfg.SetDefault("ws_queue_size", 10000)
+	cfg.SetDefault("ws_enable_write_compression", true)
 
 	replacer := strings.NewReplacer(".", "_", "-", "_")
 	cfg.SetEnvPrefix("SKYDIVE")

--- a/config/config.go
+++ b/config/config.go
@@ -133,12 +133,12 @@ func init() {
 	cfg.SetDefault("storage.orientdb.password", "root")
 
 	cfg.SetDefault("http.rest.debug", false)
-	cfg.SetDefault("ws_ping_delay", 2)
-	cfg.SetDefault("ws_pong_timeout", 5)
-	cfg.SetDefault("ws_bulk_maxmsgs", 100)
-	cfg.SetDefault("ws_bulk_maxdelay", 1)
-	cfg.SetDefault("ws_queue_size", 10000)
-	cfg.SetDefault("ws_enable_write_compression", true)
+	cfg.SetDefault("http.ws.ping_delay", 2)
+	cfg.SetDefault("http.ws.pong_timeout", 5)
+	cfg.SetDefault("http.ws.bulk_maxmsgs", 100)
+	cfg.SetDefault("http.ws.bulk_maxdelay", 1)
+	cfg.SetDefault("http.ws.queue_size", 10000)
+	cfg.SetDefault("http.ws.enable_write_compression", true)
 
 	replacer := strings.NewReplacer(".", "_", "-", "_")
 	cfg.SetEnvPrefix("SKYDIVE")

--- a/config/config.go
+++ b/config/config.go
@@ -78,6 +78,7 @@ func init() {
 	cfg.SetDefault("analyzer.storage.bulk_insert_deadline", 5)
 	cfg.SetDefault("analyzer.topology.probes", []string{})
 	cfg.SetDefault("analyzer.ssh_enabled", false)
+	cfg.SetDefault("analyzer.replication.debug", false)
 
 	cfg.SetDefault("auth.type", "noauth")
 	cfg.SetDefault("auth.keystone.tenant", "admin")

--- a/contrib/vagrant/Vagrantfile
+++ b/contrib/vagrant/Vagrantfile
@@ -9,7 +9,7 @@ AGENT_EXTRA_PROVISION_SCRIPT=ENV.fetch("AGENT_EXTRA_PROVISION_SCRIPT", "")
 ANALYZER_EXTRA_PROVISION_SCRIPT=ENV.fetch("ANALYZER_EXTRA_PROVISION_SCRIPT", "")
 
 $skydive_extra_config = {
-  "ws_pong_timeout" => 10,
+  "http.ws.pong_timeout" => 10,
   "agent.topology.probes" => ["ovsdb", "docker"],
   "agent.topology.netlink.metrics_update" => 5
 }

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -3,6 +3,15 @@
 # host_id is used to reference the agent by default set to hostname
 # host_id:
 
+http:
+  # define the Cookie HTTP Request Header
+  # cookie: 
+  #   <name1>: <value1>
+  #   <name2>: <value2>
+  # rest:
+  #   log the HTTP client request and response (to log level DEBUG)
+  #   debug: false
+
 # WebSocket delay between two pings.
 # ws_ping_delay: 2
 # WebSocket Ping/Pong timeout in second.
@@ -106,13 +115,6 @@ agent:
   # Not required, but can be used to allow virtual hosting
   # X509_servername: domain.com
   #
-  http:
-    # log the HTTP client request and response (to log level DEBUG)
-    # debug: false
-    # define the Cookie HTTP Request Header
-    # cookie: 
-    #   <name1>: <value1>
-    #   <name2>: <value2>
   topology:
     # Probes used to capture topology informations like interfaces,
     # bridges, namespaces, etc...

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -87,6 +87,8 @@ analyzer:
   bandwidth_relative_active: 0.1
   bandwidth_relative_warning: 0.4
   bandwidth_relative_alert: 0.8
+  replication:
+    # debug: false
 
 # list of analyzers used by analyzers and agents
 analyzers:

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -22,6 +22,8 @@ http:
 # ws_bulk_maxdelay: 2
 # Maximum size of the message queue
 # ws_queue_size: 10000
+# enable write compression
+# ws_enable_write_compression: true
 
 openstack:
   auth_url: http://xxx.xxx.xxx.xxx:5000/v2.0

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -11,19 +11,19 @@ http:
   # rest:
   #   log the HTTP client request and response (to log level DEBUG)
   #   debug: false
-
-# WebSocket delay between two pings.
-# ws_ping_delay: 2
-# WebSocket Ping/Pong timeout in second.
-# ws_pong_timeout: 5
-# maximum number of topology aggregated messages before sending
-# ws_bulk_maxmsgs: 100
-# duration in seconds before flushing topology aggregated messages
-# ws_bulk_maxdelay: 2
-# Maximum size of the message queue
-# ws_queue_size: 10000
-# enable write compression
-# ws_enable_write_compression: true
+  # ws:
+    # WebSocket delay between two pings.
+    # ping_delay: 2
+    # WebSocket Ping/Pong timeout in second.
+    # pong_timeout: 5
+    # maximum number of topology aggregated messages before sending
+    # bulk_maxmsgs: 100
+    # duration in seconds before flushing topology aggregated messages
+    # bulk_maxdelay: 2
+    # Maximum size of the message queue
+    # queue_size: 10000
+    # enable write compression
+    # enable_write_compression: true
 
 openstack:
   auth_url: http://xxx.xxx.xxx.xxx:5000/v2.0

--- a/http/auth.go
+++ b/http/auth.go
@@ -75,7 +75,7 @@ func cookies(c *AuthenticationClient) []*http.Cookie {
 
 func configCookies() []*http.Cookie {
 	var cookies []*http.Cookie
-	for name, value := range config.GetConfig().GetStringMapString("agent.http.cookie") {
+	for name, value := range config.GetConfig().GetStringMapString("http.cookie") {
 		cookies = append(cookies, &http.Cookie{Name: name, Value: value})
 	}
 	return cookies

--- a/http/client.go
+++ b/http/client.go
@@ -76,6 +76,10 @@ func NewRestClient(url *url.URL, authOptions *AuthenticationOpts) *RestClient {
 	}
 }
 
+func (c *RestClient) debug() bool {
+	return config.GetConfig().GetBool("http.rest.debug")
+}
+
 func (c *RestClient) Request(method, path string, body io.Reader, header http.Header) (*http.Response, error) {
 	if !c.authClient.Authenticated() {
 		if err := c.authClient.Authenticate(); err != nil {
@@ -97,7 +101,7 @@ func (c *RestClient) Request(method, path string, body io.Reader, header http.He
 
 	setCookies(&req.Header, c.authClient)
 
-	if debug := config.GetConfig().GetBool("agent.http.debug"); debug {
+	if c.debug() {
 		if buf, err := httputil.DumpRequest(req, true); err == nil {
 			logging.GetLogger().Debugf("Request:\n%s", buf)
 		}
@@ -118,7 +122,7 @@ func (c *RestClient) Request(method, path string, body io.Reader, header http.He
 		}
 	}
 
-	if debug := config.GetConfig().GetBool("agent.http.debug"); debug {
+	if c.debug() {
 		buf, err := httputil.DumpResponse(resp, true)
 		if err == nil {
 			logging.GetLogger().Debugf("Response:\n%s", buf)

--- a/http/pool.go
+++ b/http/pool.go
@@ -347,8 +347,8 @@ func (s *WSClientPool) ConnectAll() {
 }
 
 func newWSPool(name string) *WSPool {
-	bulkMaxMsgs := config.GetConfig().GetInt("ws_bulk_maxmsgs")
-	bulkMaxDelay := config.GetConfig().GetInt("ws_bulk_maxdelay")
+	bulkMaxMsgs := config.GetConfig().GetInt("http.ws.bulk_maxmsgs")
+	bulkMaxDelay := config.GetConfig().GetInt("http.ws.bulk_maxdelay")
 
 	return &WSPool{
 		name:         name,

--- a/http/wsclient.go
+++ b/http/wsclient.go
@@ -237,7 +237,6 @@ func (c *WSConn) write(msg []byte) error {
 	}
 
 	c.conn.SetWriteDeadline(time.Now().Add(writeWait))
-
 	w, err := c.conn.NextWriter(websocket.TextMessage)
 	if err != nil {
 		return err
@@ -415,6 +414,7 @@ func (c *WSClient) connect() {
 		return
 	}
 	c.conn.SetPingHandler(nil)
+	c.conn.EnableWriteCompression(config.GetConfig().GetBool("http.ws.enable_write_compression"))
 
 	atomic.StoreInt32((*int32)(c.State), common.RunningState)
 	defer atomic.StoreInt32((*int32)(c.State), common.StoppedState)

--- a/scripts/scale.sh
+++ b/scripts/scale.sh
@@ -169,7 +169,9 @@ function create_agent() {
 
 		cat <<EOF >> $TEMP_DIR/$NAME.yml
 host_id: $NAME
-ws_pong_timeout: 15
+http:
+  ws:
+    pong_timeout: 15
 analyzer:
   X509_cert: $ANALYZER_CRT
   X509_key: $ANALYZER_KEY
@@ -293,7 +295,9 @@ function create_analyzer() {
 
 	cat <<EOF >> $TEMP_DIR/$NAME.yml
 host_id: $NAME
-ws_pong_timeout: 15
+http:
+  ws:
+    pong_timeout: 15
 etcd:
   embedded: $ETCD_EMBEDDED
   data_dir: $TEMP_DIR/$NAME-etcd

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -52,7 +52,9 @@ const (
 )
 
 const testConfig = `---
-ws_pong_timeout: 10
+http:
+  ws:
+    pong_timeout: 10
 
 analyzers:
   - 127.0.0.1:8082


### PR DESCRIPTION
We discovered that our local analyzer was not able to connect with the remote analyzer (in the CogNETive demo landscape) if websocket compression was enabled, I have made this configurable (leaving current behavior as-is by setting default to 'true'). To test this you can override the default value by setting:
```
agent.http.websocket.enable_write_compression = false
```

