### PR TITLE
Use only trollius and not asyncio on both python versions

### DIFF
--- a/contrib/python/api/requirements.txt
+++ b/contrib/python/api/requirements.txt
@@ -1,4 +1,3 @@
 autobahn>=0.17.1
-trollius>=2.1; python_version < '3.0'
-asyncio>=3.4.3; python_version >= '3.0'
+trollius>=2.1
 

--- a/contrib/python/api/setup.py
+++ b/contrib/python/api/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='skydive-client',
-      version='0.3.0',
+      version='0.3.1',
       description='Skydive Python client library',
       url='http://github.com/skydive-project/skydive',
       author='Sylvain Afchain',
@@ -15,7 +15,6 @@ setup(name='skydive-client',
       },
       install_requires=[
           'autobahn>=0.17.1',
-          'trollius>=2.1;python_version<"3.0"',
-          'asyncio>=3.4.3;python_version>="3.0"',
+          'trollius>=2.1',
       ],
       zip_safe=False)

--- a/contrib/python/api/skydive/websocket/client.py
+++ b/contrib/python/api/skydive/websocket/client.py
@@ -19,10 +19,7 @@
 # under the License.
 #
 
-try:
-    import asyncio
-except ImportError:
-    import trollius as asyncio
+import trollius as asyncio
 import base64
 import functools
 import json


### PR DESCRIPTION
Using asyncio for python3 and trollius for python2 requires us to have
both packages in our dependency list (requirements.txt and setup.py).
When using automated installers, they may parse both packages as
required, resulting in unusable python2 environment (asyncio is not
compatible with python2).

As trollius is compatible with both versions, it would be easier to use
it on both platforms instead.