### PR TITLE
Use different install_requires based on python version

### DIFF
--- a/contrib/python/api/requirements.txt
+++ b/contrib/python/api/requirements.txt
@@ -1,4 +1,4 @@
 autobahn>=0.17.1
-trollius>=2.1; python_version < '3.0'
-asyncio>=3.4.3; python_version >= '3.0'
+trollius>=2.1;python_version<'3.0'
+asyncio>=3.4.3;python_version>='3.0'
 

--- a/contrib/python/api/setup.py
+++ b/contrib/python/api/setup.py
@@ -1,7 +1,18 @@
 from setuptools import setup
+import sys
+
+
+def get_install_requires():
+    install_requires = ['autobahn>=0.17.1']
+    if sys.version_info[0] < 3:
+        install_requires.append('trollius>=2.1')
+    else:
+        install_requires.append('asyncio>=3.4.3')
+    return install_requires
+
 
 setup(name='skydive-client',
-      version='0.3.0',
+      version='0.3.1',
       description='Skydive Python client library',
       url='http://github.com/skydive-project/skydive',
       author='Sylvain Afchain',
@@ -13,9 +24,5 @@ setup(name='skydive-client',
             'skydive-ws-client = skydive.wsshell:main',
         ],
       },
-      install_requires=[
-          'autobahn>=0.17.1',
-          'trollius>=2.1;python_version<"3.0"',
-          'asyncio>=3.4.3;python_version>="3.0"',
-      ],
+      install_requires=get_install_requires(),
       zip_safe=False)


### PR DESCRIPTION
Fix the way the install_requires is written to allow correct parsing of
the requirements by python code.
The way it is currently written causes both trollius and asyncio to be
installed on python2, but asyncio is not compatible with that platform.

Install of skydive-client under python2 causes the following behavior:
==> devstack: Collecting skydive-client
==> devstack:   Downloading skydive-client-0.3.0.tar.gz
==> devstack: Collecting autobahn>=0.17.1 (from skydive-client)
==> devstack:   Downloading autobahn-17.10.1-py2.py3-none-any.whl (283kB)
==> devstack: Collecting trollius>=2.1; python_version < "3.0" (from skydive-client)
==> devstack:   Downloading trollius-2.1.tar.gz (276kB)
==> devstack: **Collecting asyncio>=3.4.3; python_version >= "3.0" (from skydive-client)**
==> devstack:   Downloading **asyncio-3.4.3.tar.gz** (204kB)
==> devstack: Collecting txaio>=2.7.0 (from autobahn>=0.17.1->skydive-client)
==> devstack:   Downloading txaio-2.8.2-py2.py3-none-any.whl
==> devstack: Collecting six>=1.10.0 (from autobahn>=0.17.1->skydive-client)
==> devstack:   Downloading six-1.11.0-py2.py3-none-any.whl
==> devstack: Collecting futures (from trollius>=2.1; python_version < "3.0"->skydive-client)
==> devstack:   Downloading futures-3.2.0-py2-none-any.whl
==> devstack: Installing collected packages: six, txaio, autobahn, futures, trollius, asyncio, skydive-client
==> devstack:   Running setup.py install for trollius: started
==> devstack:     Running setup.py install for trollius: finished with status 'done'
==> devstack:   **Running setup.py install for asyncio: started**
==> devstack:     **Running setup.py install for asyncio: finished with status 'done'**
==> devstack:   Running setup.py install for skydive-client: started
==> devstack:     Running setup.py install for skydive-client: finished with status 'done'
==> devstack: Successfully installed **asyncio-3.4.3** autobahn-17.10.1 futures-3.2.0 six-1.11.0 skydive-client-0.3.0 trollius-2.1 txaio-2.8.2
