### PR TITLE
K8s: add minikube tests for k8s graph.Node creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,10 @@ ifeq ($(WITH_CDD), true)
   BUILDTAGS+=cdd
 endif
 
+ifeq ($(WITH_K8S), true)
+  BUILDTAGS+=k8s
+endif
+
 .PHONY: all install
 all install: skydive
 

--- a/gremlin/query.go
+++ b/gremlin/query.go
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2018 IBM, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package gremlin
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/skydive-project/skydive/common"
+)
+
+// QueryString used to construct string representation of query
+type QueryString struct {
+	Query string `json:"omitempty"`
+}
+
+// NewQueryString used to create an empty query string
+func NewQueryString() *QueryString {
+	return &QueryString{}
+}
+
+// String convert query to string
+func (g *QueryString) String() string {
+	return g.Query
+}
+
+// G greate the graph token
+func (g *QueryString) G() *QueryString {
+	return g.Append("G")
+}
+
+// Append appends string value to query
+func (g *QueryString) Append(s string) *QueryString {
+	g.Query += s
+	return g
+}
+
+// Appends appends dot, then string value to query
+func (g *QueryString) DotAppend(s string) *QueryString {
+	if s != "" {
+		g.Append("." + s)
+	}
+	return g
+}
+
+// Append a Context() operation to query
+func (g *QueryString) Context(t time.Time) *QueryString {
+	if !t.IsZero() {
+		g.DotAppend(fmt.Sprintf("Context(%d)", common.UnixMillis(t)))
+	}
+	return g
+}
+
+// V append a V() operation to query
+func (g *QueryString) V() *QueryString {
+	return g.DotAppend("V()")
+}
+
+// Has append a Has() operation to query
+func (g *QueryString) Has(list ...*ValueString) *QueryString {
+	g.DotAppend("Has(")
+	first := true
+	for _, v := range list {
+		if !first {
+			g.Append(", ")
+		}
+		first = false
+		g.Append(v.String())
+	}
+	g.Append(")")
+	return g
+}
+
+// HasNode append a Has() for getting graph.Node elements
+func (g *QueryString) HasNode(mgr, typ, name *ValueString) *QueryString {
+	return g.Has(NewValueString("Manager").Quote(), mgr, NewValueString("Type").Quote(), typ, NewValueString("Name").Quote(), name)
+}
+
+// ValueString a value used within query constructs
+type ValueString struct {
+	Value string `json:"omitempty"`
+}
+
+// NewValueString create a value object
+func NewValueString(s string) *ValueString {
+	return &ValueString{Value: s}
+}
+
+// String converts value to string
+func (v *ValueString) String() string {
+	return v.Value
+}
+
+// Quote used to quote string values as needed by query
+func (v *ValueString) Quote() *ValueString {
+	v.Value = `'` + v.Value + `'`
+	return v
+}
+
+// Regex used for constructing a regexp expression string
+func (v *ValueString) Regex() *ValueString {
+	v.Value = "Regex(" + v.Quote().String() + ")"
+	return v
+}
+
+// StartsWith construct a regexp representing all that start with string
+func (v *ValueString) StartsWith() *ValueString {
+	v.Value += ".*"
+	return v.Regex()
+}
+
+// EndsWith construct a regexp representing all that end with string
+func (v *ValueString) EndsWith() *ValueString {
+	v.Value = ".*" + v.Value
+	return v.Regex()
+}

--- a/scripts/ci/install-go-deps.sh
+++ b/scripts/ci/install-go-deps.sh
@@ -12,6 +12,7 @@ go get -f -u github.com/mattn/goveralls
 go get -f -u golang.org/x/tools/cmd/cover
 go get -f -u github.com/golang/lint/golint
 go get -f -u github.com/tebeka/go2xunit
+go get -f -u github.com/derekparker/delve/cmd/dlv
 
 export PATH=$PATH:$GOPATH/bin
 

--- a/scripts/ci/install-go.sh
+++ b/scripts/ci/install-go.sh
@@ -16,18 +16,5 @@ chmod +x ~/bin/gimme
 # before changing this be sure that it will not break the RHEL packaging
 eval "$(gimme 1.9.1)"
 
-export GOPATH=$WORKSPACE
-
-# Get the Go dependencies
-go get -f -u github.com/axw/gocov/gocov
-go get -f -u github.com/mattn/goveralls
-go get -f -u golang.org/x/tools/cmd/cover
-go get -f -u github.com/golang/lint/golint
-go get -f -u github.com/tebeka/go2xunit
-
-export PATH=$PATH:$GOPATH/bin
-
-# speedup govendor sync command
-mkdir -p $HOME/.govendor $GOPATH/.cache
-rm -rf $GOPATH/.cache/govendor
-ln -s $HOME/.govendor $GOPATH/.cache/govendor
+dir="$(dirname "$0")"
+. "${dir}/install-go-deps.sh"

--- a/scripts/ci/install-k8s.sh
+++ b/scripts/ci/install-k8s.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -v
+
+OS=linux
+ARCH=amd64
+TARGET_DIR="/usr/bin"
+
+MINIKUBE_VERSION="v0.24.1"
+MINIKUBE_URL="https://github.com/kubernetes/minikube/releases/download/$MINIKUBE_VERSION/minikube-$OS-$ARCH"
+
+KUBECTL_VERSION="v1.9.0"
+KUBECTL_URL="https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/$OS/$ARCH/kubectl"
+
+uninstall_binary() {
+	local prog=$1
+	sudo rm -f ${TARGET_DIR}/$prog
+}
+
+install_binary() {
+	local prog=$1
+	local url=$2
+	wget --no-check-certificate -O $prog $url
+	chmod a+x $prog
+	sudo mv -f $prog ${TARGET_DIR}/.
+}
+
+install() {
+	install_binary minikube $MINIKUBE_URL
+	install_binary kubectl $KUBECTL_URL
+}
+
+uninstall() {
+	uninstall_binary minikube
+	uninstall_binary kubectl
+}
+
+stop() {
+	sudo minikube delete || true
+	sudo rm -rf ~/.minikube
+}
+
+start() {
+	sudo CHANGE_MINIKUBE_NONE_USER=true minikube --vm-driver=none start
+	sudo minikube status
+	kubectl config use-context minikube
+}
+
+status() {
+	kubectl version
+	kubectl config get-contexts
+}
+
+case "$1" in
+	start)
+		stop
+		uninstall
+		install
+		start
+		;;
+	stop)
+		stop
+		uninstall
+		;;
+	status)
+		status
+		;;
+	*)
+		echo "$0 [start|stop|status]"
+		exit 1
+		;;
+esac
+
+exit 0

--- a/scripts/ci/run-k8s-tests.sh
+++ b/scripts/ci/run-k8s-tests.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -v
+
+dir="$(dirname "$0")"
+. "${dir}/install-go-deps.sh"
+
+set -e
+
+cd ${GOPATH}/src/github.com/skydive-project/skydive
+make install
+
+export ELASTICSEARCH=localhost:9200
+export SKYDIVE_ANALYZERS=localhost:8082
+export SKYDIVE_LOGGING_LEVEL=DEBUG
+
+ARGS= \
+	"-standalone" \
+	"-graph.backend=elasticsearch" \
+	"-storage.backend=elasticsearch"
+
+make test.functionals WITH_K8S=true VERBOSE=true TIMEOUT=1m ARGS="$ARGS"

--- a/tests/k8s/networkpolicy.yaml
+++ b/tests/k8s/networkpolicy.yaml
@@ -1,0 +1,12 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  namespace: default
+  name: skydive-test
+spec:
+  podSelector:
+    matchLabels:
+      app: skydive-test
+  ingress:
+  - from:
+    - namespaceSelector: {}

--- a/tests/k8s_test.go
+++ b/tests/k8s_test.go
@@ -1,0 +1,113 @@
+// +build k8s
+
+/*
+ * Copyright (C) 2018 IBM, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package tests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/skydive-project/skydive/gremlin"
+	"github.com/skydive-project/skydive/tests/helper"
+)
+
+func k8sConfigFile(name string) string {
+	return "./k8s/" + name + ".yaml"
+}
+
+const (
+	manager    = "k8s"
+	objectName = "skydive-test"
+)
+
+var (
+	networkPolicyConfig = k8sConfigFile("networkpolicy")
+)
+
+var (
+	nodeName, _       = os.Hostname()
+	podName           = objectName
+	containerName     = objectName
+	networkPolicyName = objectName
+)
+
+var (
+	setupPod = []helper.Cmd{
+		{"kubectl run " + podName +
+			"  --image=gcr.io/google_containers/echoserver:1.4" +
+			"  --port=8080", true},
+	}
+	tearDownPod = []helper.Cmd{
+		{"kubectl delete deployment " + podName, false},
+	}
+	setupNetworkPolicy = []helper.Cmd{
+		{"kubectl create -f " + networkPolicyConfig, true},
+	}
+	tearDownNetworkPolicy = []helper.Cmd{
+		{"kubectl delete -f " + networkPolicyConfig, false},
+	}
+)
+
+func testNodeCreation(t *testing.T, setupCmds, tearDownCmds []helper.Cmd, typ, name *gremlin.ValueString) {
+	test := &Test{
+		setupCmds: append(tearDownCmds, setupCmds...),
+
+		tearDownCmds: tearDownCmds,
+
+		checks: []CheckFunction{func(c *CheckContext) error {
+			g := gremlin.NewQueryString()
+			g.G().V().HasNode(gremlin.NewValueString("k8s").Quote(), typ, name)
+			fmt.Printf("Gremlin: %s\n", g.String())
+
+			nodes, err := c.gh.GetNodes(g.String())
+			if err != nil {
+				return err
+			}
+
+			if len(nodes) != 1 {
+				return fmt.Errorf("Ran \"%+v\", expected 1 node, got %+v", g, nodes)
+			}
+
+			return nil
+		}},
+	}
+	RunTest(t, test)
+}
+
+func TestK8sPodNode(t *testing.T) {
+	testNodeCreation(t, setupPod, tearDownPod, gremlin.NewValueString("pod").Quote(), gremlin.NewValueString(podName).StartsWith())
+}
+
+func TestK8sContainerNode(t *testing.T) {
+	testNodeCreation(t, setupPod, tearDownPod, gremlin.NewValueString("container").Quote(), gremlin.NewValueString(containerName).Quote())
+}
+
+func TestK8sNetworkPolicyNode(t *testing.T) {
+	testNodeCreation(t, setupNetworkPolicy, tearDownNetworkPolicy, gremlin.NewValueString("networkpolicy").Quote(), gremlin.NewValueString(networkPolicyName).Quote())
+}
+
+func TestK8sNodeNode(t *testing.T) {
+	testNodeCreation(t, nil, nil, gremlin.NewValueString("node").Quote(), gremlin.NewValueString(nodeName).Quote())
+}

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -65,6 +65,9 @@ analyzer:
     backend: {{.Storage}}
   analyzer_username: admin
   analyzer_password: password
+  topology:
+    probes:
+      - k8s
 
 agent:
   listen: 8081


### PR DESCRIPTION
The basic flow:

```
scripts/ci/install-minikube.sh start
scripts/ci/run-k8s-tests.sh
```

But currently due to a *real* bug in which the agent deletes the nodes created by the k8s probe in the analyzer the tests fail - this issue will be addressed (in a separate PR) and then tests should pass.