### PR TITLE
config: default host_id is "<host>-<pid>"

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -44,12 +44,16 @@ var (
 	ErrNoAnalyzerSpecified = errors.New("No analyzer specified in the configuration file")
 )
 
-func init() {
+func hostID() string {
 	host, err := os.Hostname()
 	if err != nil {
 		panic(err)
 	}
+	pid := os.Getpid()
+	return fmt.Sprintf("%s-%d", host, pid)
+}
 
+func init() {
 	cfg = viper.New()
 
 	cfg.SetDefault("agent.flow.probes", []string{"gopacket", "pcapsocket"})
@@ -100,7 +104,7 @@ func init() {
 	cfg.SetDefault("graph.backend", "memory")
 	cfg.SetDefault("graph.gremlin", "ws://127.0.0.1:8182")
 
-	cfg.SetDefault("host_id", host)
+	cfg.SetDefault("host_id", hostID())
 
 	cfg.SetDefault("k8s.probes", []string{"networkpolicy", "pod", "container", "node"})
 


### PR DESCRIPTION
You can tests the effects of this by setting k8s and running  `skydive allinone -c skydive.yml` the result (compared to before the fix) is that you will see all the k8s objects (which now will not be deleted by the agent issued `HostGraphDelMsgType`