### PR TITLE
Added login method to python client

### DIFF
--- a/contrib/python/api/requirements.txt
+++ b/contrib/python/api/requirements.txt
@@ -1,4 +1,5 @@
 autobahn>=0.17.1
 trollius>=2.1;python_version<'3.0'
 asyncio>=3.4.3;python_version>='3.0'
+requests>=2.14.2
 

--- a/contrib/python/api/setup.py
+++ b/contrib/python/api/setup.py
@@ -3,7 +3,7 @@ import sys
 
 
 def get_install_requires():
-    install_requires = ['autobahn>=0.17.1']
+    install_requires = ['autobahn>=0.17.1', 'requests>=2.14.2']
     if sys.version_info[0] < 3:
         install_requires.append('trollius>=2.1')
     else:
@@ -12,7 +12,7 @@ def get_install_requires():
 
 
 setup(name='skydive-client',
-      version='0.3.1',
+      version='0.4.0',
       description='Skydive Python client library',
       url='http://github.com/skydive-project/skydive',
       author='Sylvain Afchain',


### PR DESCRIPTION
Added login method to the python client to authenticate with the skydive
analyzer.
The authentication should be performed before the main loop is started.
The method returns a boolean specifying if the login succeeded. In case
it did, a cookie is kept and is sent with all the future requests.

Future work: detect cases in which the authentication is expired, and
raise a notification to the user or re-authenticate automatically.

Co-Authored-By: Omer Anson <oaanson@gmail.com>