### PR TITLE
flow: treat flows buffer overflow state

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -82,6 +82,7 @@ func init() {
 	cfg.SetDefault("analyzer.ssh_enabled", false)
 	cfg.SetDefault("analyzer.storage.bulk_insert", 100)
 	cfg.SetDefault("analyzer.storage.bulk_insert_deadline", 5)
+	cfg.SetDefault("analyzer.storage.max_flow_buffer_size", 100000)
 	cfg.SetDefault("analyzer.topology.probes", []string{})
 
 	cfg.SetDefault("auth.type", "noauth")

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -63,6 +63,9 @@ analyzer:
     # deadline of each bulk insert in second
     # bulk_insert_deadline: 5
 
+    # Max number of flows in write buffer (after which all flows accumulated are dropped)
+    # max_flow_buffer_size: 100000
+
   topology:
     # Define static interfaces and links updating Skydive topology
     # Can be useful to define external resources like : TOR, Router, etc.


### PR DESCRIPTION
If we reach flow limit, all the flows from the channel are cleared
without saving the data and we send notification about it to the log.