### PR TITLE
logging: sync syslog severity with log level

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -253,15 +253,15 @@ func initLogger() (err error) {
 			}
 			backends = append(backends, zapcore.NewCore(encoder, zapcore.Lock(file), msgPriority))
 		case "syslog":
-			w, err := newSyslog(cfg.GetString("logging.syslog.tag"))
-			if err != nil {
-				return err
-			}
 			encoder := defaultEncoder
 			if cfg.GetString("logging.syslog.encoder") == "json" {
 				encoder = zapcore.NewJSONEncoder(newEncoderConfig())
 			}
-			backends = append(backends, zapcore.NewCore(encoder, zapcore.AddSync(w), msgPriority))
+			syslogTag := cfg.GetString("logging.syslog.tag")
+			backends, err = addSyslogBackend(backends, msgPriority, encoder, syslogTag)
+			if err != nil {
+				return err
+			}
 		case "stderr":
 			encoder := defaultEncoder
 			if cfg.GetString("logging.stderr.encoder") == "json" {

--- a/logging/no_syslog.go
+++ b/logging/no_syslog.go
@@ -25,11 +25,11 @@
 package logging
 
 import (
-	"io"
-
 	"github.com/skydive-project/skydive/common"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
-func newSyslog(tag string) (io.Writer, error) {
+func addSyslogBackend(backends []zapcore.Core, msgPriority zap.LevelEnablerFunc, encoder zapcore.Encoder, tag string) ([]zapcore.Core, error) {
 	return nil, common.ErrNotImplemented
 }

--- a/logging/syslog.go
+++ b/logging/syslog.go
@@ -25,10 +25,17 @@
 package logging
 
 import (
-	"io"
 	"log/syslog"
+
+	"github.com/tchap/zapext/zapsyslog"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
-func newSyslog(tag string) (io.Writer, error) {
-	return syslog.New(syslog.LOG_CRIT, tag)
+func addSyslogBackend(backends []zapcore.Core, msgPriority zap.LevelEnablerFunc, encoder zapcore.Encoder, tag string) ([]zapcore.Core, error) {
+	w, err := syslog.New(syslog.LOG_CRIT, tag)
+	if err != nil {
+		return nil, err
+	}
+	return append(backends, zapsyslog.NewCore(msgPriority, encoder, w)), nil
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -831,7 +831,7 @@
 			"revisionTime": "2016-07-27T17:26:17Z"
 		},
 		{
-			"checksumSHA1": "GENxfNGiSzB9hzo2fPZkI4F/Zzg=",
+			"checksumSHA1": "me40nSy9NBr9MmAwe5vDvTgSVZs=",
 			"path": "github.com/google/btree",
 			"revision": "cc6329d4279e3f025a53a83c397d2339b5705c45"
 		},
@@ -849,14 +849,14 @@
 			"revisionTime": "2017-11-28T22:01:57Z"
 		},
 		{
-			"checksumSHA1": "ORc1X58pM+oNj08y5wXask2sV4c=",
+			"checksumSHA1": "Uvt0pTvpmwUw0EwDiJm0AiTd754=",
 			"comment": "v1.1.11-106-gbdf4ee7",
 			"path": "github.com/google/gopacket/layers",
 			"revision": "67a21c4470a0598531a769727aef40b870ffa128",
 			"revisionTime": "2017-11-28T22:01:57Z"
 		},
 		{
-			"checksumSHA1": "Zq24NvykkROxoBM3vum5unM6TTI=",
+			"checksumSHA1": "NNhvUjsdyYOMWHlYjcw7KrIaJH8=",
 			"comment": "v1.1.11-106-gbdf4ee7",
 			"path": "github.com/google/gopacket/pcap",
 			"revision": "67a21c4470a0598531a769727aef40b870ffa128",
@@ -1236,7 +1236,7 @@
 			"revisionTime": "2013-11-06T22:25:44Z"
 		},
 		{
-			"checksumSHA1": "jHOLsfeMPcX84YQB2MXBqXFntBg=",
+			"checksumSHA1": "k1I8piNXcsrel3JptVnKykNJXBY=",
 			"path": "github.com/kr/pty",
 			"revision": "95d05c1eef33a45bd58676b6ce28d105839b8d0b",
 			"revisionTime": "2017-10-06T17:48:01Z"
@@ -1471,7 +1471,7 @@
 			"revisionTime": "2018-01-11T02:47:13Z"
 		},
 		{
-			"checksumSHA1": "a74I4/fP/YJh6OoX/CGgGVyREmM=",
+			"checksumSHA1": "Np5vq0isl4dJFj58WyulKakNsbo=",
 			"path": "github.com/shirou/gopsutil/host",
 			"revision": "6a368fb7cd1221fa6ea90facc9447c9a2234c255",
 			"revisionTime": "2018-01-11T02:47:13Z"
@@ -1483,7 +1483,7 @@
 			"revisionTime": "2018-01-11T02:47:13Z"
 		},
 		{
-			"checksumSHA1": "Cgm7wMq9rJpnUeZFV3OD8qkTKOM=",
+			"checksumSHA1": "gMwdI0KesvErYwAAx4BL8bk2Dp4=",
 			"path": "github.com/shirou/gopsutil/mem",
 			"revision": "6a368fb7cd1221fa6ea90facc9447c9a2234c255",
 			"revisionTime": "2018-01-11T02:47:13Z"
@@ -1495,7 +1495,7 @@
 			"revisionTime": "2018-01-11T02:47:13Z"
 		},
 		{
-			"checksumSHA1": "a5m6WLMC9Y0N96wxwM1n4JoIIyg=",
+			"checksumSHA1": "obL9SPuDQ2pQ6p3umBG+moH9uHQ=",
 			"path": "github.com/shirou/gopsutil/process",
 			"revision": "6a368fb7cd1221fa6ea90facc9447c9a2234c255",
 			"revisionTime": "2018-01-11T02:47:13Z"
@@ -1574,6 +1574,12 @@
 			"revision": "382f87b929b84ce13e9c8a375a4b217f224e6c65"
 		},
 		{
+			"checksumSHA1": "ANGOe9JH8sHzYNOQgEFCXuAhiuM=",
+			"path": "github.com/tchap/zapext/zapsyslog",
+			"revision": "e61c0c8823393722ae09ce0faee42fa177088a4b",
+			"revisionTime": "2018-01-17T14:17:35Z"
+		},
+		{
 			"checksumSHA1": "3GkzZHlhDZz0wSkOVjzbWlW5RJQ=",
 			"path": "github.com/tebeka/selenium",
 			"revision": "657e45ec600f26e76da253936c1f2adb6978ff72",
@@ -1620,7 +1626,7 @@
 			"revision": "604eaf189ee867d8c147fafc28def2394e878d25"
 		},
 		{
-			"checksumSHA1": "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
+			"checksumSHA1": "rFSw9cpg4vxtZD7dlOtKx25h4kI=",
 			"path": "github.com/weaveworks/tcptracer-bpf",
 			"revision": "e080bd747dc6b62d4ed3ed2b7f0be4801bef8faf",
 			"revisionTime": "2017-08-17T15:53:01Z",
@@ -1851,7 +1857,7 @@
 			"revision": "6acef71eb69611914f7a30939ea9f6e194c78172"
 		},
 		{
-			"checksumSHA1": "gRu2kYXXhEN+A+NpuAuMrjuiud0=",
+			"checksumSHA1": "++MsxaBN30inOcAz7KvFGddE7ic=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "810d7000345868fc619eb81f46307107118f4ae1",
 			"revisionTime": "2018-01-09T14:25:55Z"
@@ -1875,19 +1881,19 @@
 			"revisionTime": "2017-09-13T16:58:53Z"
 		},
 		{
-			"checksumSHA1": "iB6/RoQIzBaZxVi+t7tzbkwZTlo=",
+			"checksumSHA1": "tk+lpF2CDV7e5RwwRY5ZTCGrd9o=",
 			"path": "golang.org/x/text/unicode/bidi",
 			"revision": "1cbadb444a806fd9430d14ad08967ed91da4fa0a",
 			"revisionTime": "2017-09-13T19:45:57Z"
 		},
 		{
-			"checksumSHA1": "OwypTTxsp/HEwbfXq9yMR4fACRM=",
+			"checksumSHA1": "TisxVXIAh3Hb6QdUOMso4wdqAQU=",
 			"path": "golang.org/x/text/unicode/norm",
 			"revision": "02704b6b714738b763ba478766eb55a4b4851cd4",
 			"revisionTime": "2016-04-13T10:07:35Z"
 		},
 		{
-			"checksumSHA1": "mfeW9NCKg58o6w5bbXPvpixpIw0=",
+			"checksumSHA1": "U1OTBlgTRUe9ZdMsbISL1E+eMm8=",
 			"path": "golang.org/x/text/width",
 			"revision": "ab5ac5f9a8deb4855a60fab02bc61a4ec770bd49",
 			"revisionTime": "2017-09-13T16:58:53Z"


### PR DESCRIPTION
Currently all logs sent to syslog have the critical severity.

With this patch depending on the level of the log the correct syslog
severity will be used.