### PR TITLE
ui: Add launch in context /topology?filter=<G>;hightlight=<G>

### DIFF
--- a/http/server.go
+++ b/http/server.go
@@ -306,6 +306,7 @@ func NewServer(host string, serviceType common.ServiceType, addr string, port in
 	router.PathPrefix("/statics").HandlerFunc(server.serveStatics)
 	router.PathPrefix(ExtraAssetPrefix).HandlerFunc(server.serveStatics)
 	router.HandleFunc("/login", server.serveLogin)
+	router.PathPrefix("/topology").HandlerFunc(server.serveIndex)
 	router.HandleFunc("/", server.serveIndex)
 
 	return server

--- a/statics/js/app.js
+++ b/statics/js/app.js
@@ -134,7 +134,7 @@ var routes = [
       }
     }
   },
-  { path: '/topology', component: TopologyComponent },
+  { path: '/topology', component: TopologyComponent, props: (route) => ({ query: route.query }) },
   { path: '/conversation', component: ConversationComponent },
   { path: '/discovery', component: DiscoveryComponent },
   { path: '/preference', component: PreferenceComponent },
@@ -142,6 +142,7 @@ var routes = [
 ];
 
 var router = new VueRouter({
+  mode: 'history',
   linkActiveClass: 'active',
   routes: routes
 });

--- a/statics/js/components/topology.js
+++ b/statics/js/components/topology.js
@@ -285,6 +285,21 @@ var TopologyComponent = {
 
     this.setGremlinFavoritesFromConfig();
 
+    if (typeof(this.$route.query.highlight) !== "undefined") {
+      this.topologyEmphasize = this.$route.query.highlight;
+      setTimeout(function(){self.emphasizeGremlinExpr();}, 2000)
+    }
+
+    if (typeof(this.$route.query.filter) !== "undefined") {
+      this.topologyFilter = this.$route.query.filter;
+    }
+
+    websocket.addConnectHandler(function() {
+      if (self.topologyFilter !== '') {
+        self.topologyFilterQuery();
+      }
+    });
+
     $.when(this.$getConfigValue('analyzer.ssh_enabled').
       then(function(sshEnabled) {
         self.isSSHEnabled = sshEnabled;


### PR DESCRIPTION
- Open Skydive UI with custom view based on URL query string.
- Support for Multiple query keys,values

- Current support is for filter and highlight (gremlin expression)

Some examples:

http://localhost:8082/topology?filter=G.V().Has("Name", "AGGR1")

http://localhost:8082/topology?filter=G.V().Has("Name", "AGGR1")&highlight=G.V().Has("Name", Regex("AGGR1"))

http://localhost:8082/topology?filter=G.V().Has("Probe", Regex("fabric"))&highlight=G.V().Has("Name", Regex("AGGR1"))

Co-authored-by:    eranra <eranra@ERAN-TP>