### PR TITLE
flow: keep a flow table clock to keep flow aligned

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -51,7 +51,7 @@ const (
 	MaxCaptureLength uint32 = 4096
 	// MaxRawPacketLimit : maximum raw packet captured, limitation could be removed once flow over tcp
 	MaxRawPacketLimit uint32 = 10
-	// DefaultFlowProtobufSize : the default protobuf size without any raw packet for a flow
+	// DefaultProtobufFlowSize : the default protobuf size without any raw packet for a flow
 	DefaultProtobufFlowSize = 500
 )
 
@@ -62,6 +62,7 @@ type flowState struct {
 	link1stPacket    int64
 	network1stPacket int64
 	skipSocketInfo   bool
+	lastUpdate       int64
 }
 
 // Packet describes one packet

--- a/flow/table_test.go
+++ b/flow/table_test.go
@@ -208,12 +208,11 @@ func TestUpdate(t *testing.T) {
 
 	flow1, _ := table.getOrCreateFlow("flow1")
 
-	now := common.UnixMillis(time.Now())
 	flow1.Metric.ABBytes = 1
-	flow1.Last = now
+	flow1.XXX_state.lastUpdate = table.tableClock
 
 	// check that LastUpdateMetric is filled after a expire before an update
-	table.expire(now + 1)
+	table.expire(table.tableClock + 1)
 
 	if flow1.LastUpdateMetric.ABBytes != 1 {
 		t.Errorf("Flow should have been updated by expire : %+v", flow1)
@@ -222,10 +221,10 @@ func TestUpdate(t *testing.T) {
 	flow2, _ := table.getOrCreateFlow("flow2")
 
 	// clock is used to simulate real clock
-	clock := common.UnixMillis(time.Now())
+	clock := table.tableClock
 
 	flow2.Metric.ABBytes = 2
-	flow2.Last = clock + 1
+	flow2.XXX_state.lastUpdate = clock + 1
 
 	updatedAt := clock + 5
 
@@ -253,7 +252,7 @@ func TestUpdate(t *testing.T) {
 	}
 
 	flow2.Metric.ABBytes = 10
-	flow2.Last = updatedAt + 1
+	flow2.XXX_state.lastUpdate = updatedAt
 
 	// should update everything between previous updateAt and the new one
 	updatedAt += 5
@@ -268,7 +267,7 @@ func TestUpdate(t *testing.T) {
 	}
 
 	flow2.Metric.ABBytes = 15
-	flow2.Last = updatedAt + 1
+	flow2.XXX_state.lastUpdate = updatedAt + 1
 
 	// should update everything between previous updateAt and the new one
 	updatedAt += 5


### PR DESCRIPTION
We need to keep the flow last field aligned with a table
clock as the original timestamp can be seen by the table
after a long period. In this situation we have a flow
that is present in the flow table but that is
not sent to the analayzer since not seen as updated.