### PR TITLE
k8s: fixed livenessProbe (removed agent; analyzer using /api/status)

### DIFF
--- a/contrib/kubernetes/skydive.yaml
+++ b/contrib/kubernetes/skydive.yaml
@@ -52,9 +52,8 @@ spec:
           value: 0.0.0.0:12379
         livenessProbe:
           httpGet:
-            host: localhost
             port: 8082
-            path: /
+            path: /api/status
           initialDelaySeconds: 60
           periodSeconds: 10
           failureThreshold: 3
@@ -62,14 +61,6 @@ spec:
         image: elasticsearch:2
         ports:
         - containerPort: 9200
-        livenessProbe:
-          httpGet:
-            host: localhost
-            port: 9200
-            path: /
-          initialDelaySeconds: 60
-          periodSeconds: 10
-          failureThreshold: 3
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
@@ -103,14 +94,6 @@ spec:
           mountPath: /host/run
         - name: ovsdb
           mountPath: /var/run/openvswitch/db.sock
-        livenessProbe:
-          httpGet:
-            host: localhost
-            port: 8081
-            path: /
-          initialDelaySeconds: 60
-          periodSeconds: 10
-          failureThreshold: 3
       volumes:
       - name: docker
         hostPath:


### PR DESCRIPTION
livenessProbe changes:
- analyzer now using /api/status
- elasticsearch *removed*
- agent *removed*

Can be tested using:

```
kubectl create -f skydive.yaml
kubectl get deployment
```