### PR TITLE
tests: gremlin query builder 

### DIFF
--- a/api/client/gremlin.go
+++ b/api/client/gremlin.go
@@ -34,6 +34,7 @@ import (
 	"github.com/skydive-project/skydive/api/types"
 	"github.com/skydive-project/skydive/common"
 	"github.com/skydive-project/skydive/flow"
+	"github.com/skydive-project/skydive/gremlin"
 	shttp "github.com/skydive-project/skydive/http"
 	"github.com/skydive-project/skydive/topology"
 	"github.com/skydive-project/skydive/topology/graph"
@@ -45,13 +46,13 @@ type GremlinQueryHelper struct {
 }
 
 // Request send a Gremlin request to the topology API
-func (g *GremlinQueryHelper) Request(query string, header http.Header) (*http.Response, error) {
+func (g *GremlinQueryHelper) Request(query interface{}, header http.Header) (*http.Response, error) {
 	client, err := NewRestClientFromConfig(g.authOptions)
 	if err != nil {
 		return nil, err
 	}
 
-	gq := types.TopologyParam{GremlinQuery: query}
+	gq := types.TopologyParam{GremlinQuery: gremlin.NewQueryStringFromArgument(query).String()}
 	s, err := json.Marshal(gq)
 	if err != nil {
 		return nil, err
@@ -63,7 +64,7 @@ func (g *GremlinQueryHelper) Request(query string, header http.Header) (*http.Re
 }
 
 // Query the topology API
-func (g *GremlinQueryHelper) QueryRaw(query string) ([]byte, error) {
+func (g *GremlinQueryHelper) QueryRaw(query interface{}) ([]byte, error) {
 	resp, err := g.Request(query, nil)
 	if err != nil {
 		return nil, err
@@ -83,7 +84,7 @@ func (g *GremlinQueryHelper) QueryRaw(query string) ([]byte, error) {
 }
 
 // QueryObject the topology API and deserialize into value
-func (g *GremlinQueryHelper) QueryObject(query string, value interface{}) error {
+func (g *GremlinQueryHelper) QueryObject(query interface{}, value interface{}) error {
 	resp, err := g.Request(query, nil)
 	if err != nil {
 		return err
@@ -103,7 +104,7 @@ func (g *GremlinQueryHelper) QueryObject(query string, value interface{}) error 
 }
 
 // GetNodes from the Gremlin query
-func (g *GremlinQueryHelper) GetNodes(query string) ([]*graph.Node, error) {
+func (g *GremlinQueryHelper) GetNodes(query interface{}) ([]*graph.Node, error) {
 	var values []interface{}
 	if err := g.QueryObject(query, &values); err != nil {
 		return nil, err
@@ -133,7 +134,7 @@ func (g *GremlinQueryHelper) GetNodes(query string) ([]*graph.Node, error) {
 }
 
 // GetNode from the Gremlin query
-func (g *GremlinQueryHelper) GetNode(query string) (node *graph.Node, _ error) {
+func (g *GremlinQueryHelper) GetNode(query interface{}) (node *graph.Node, _ error) {
 	nodes, err := g.GetNodes(query)
 	if err != nil {
 		return nil, err
@@ -147,13 +148,13 @@ func (g *GremlinQueryHelper) GetNode(query string) (node *graph.Node, _ error) {
 }
 
 // GetFlows form the Gremlin query
-func (g *GremlinQueryHelper) GetFlows(query string) (flows []*flow.Flow, err error) {
+func (g *GremlinQueryHelper) GetFlows(query interface{}) (flows []*flow.Flow, err error) {
 	err = g.QueryObject(query, &flows)
 	return
 }
 
 // GetFlowMetric from Gremlin query
-func (g *GremlinQueryHelper) GetFlowMetric(query string) (m *flow.FlowMetric, _ error) {
+func (g *GremlinQueryHelper) GetFlowMetric(query interface{}) (m *flow.FlowMetric, _ error) {
 	flows, err := g.GetFlows(query)
 	if err != nil {
 		return nil, err
@@ -186,7 +187,7 @@ func flatMetricToTypedMetric(flat map[string]interface{}) (common.Metric, error)
 }
 
 // GetMetrics from Gremlin query
-func (g *GremlinQueryHelper) GetMetrics(query string) (map[string][]common.Metric, error) {
+func (g *GremlinQueryHelper) GetMetrics(query interface{}) (map[string][]common.Metric, error) {
 	flat := []map[string][]map[string]interface{}{}
 
 	if err := g.QueryObject(query, &flat); err != nil {
@@ -214,7 +215,7 @@ func (g *GremlinQueryHelper) GetMetrics(query string) (map[string][]common.Metri
 }
 
 // GetMetric from Gremlin query
-func (g *GremlinQueryHelper) GetMetric(query string) (common.Metric, error) {
+func (g *GremlinQueryHelper) GetMetric(query interface{}) (common.Metric, error) {
 	flat := map[string]interface{}{}
 
 	if err := g.QueryObject(query, &flat); err != nil {

--- a/gremlin/query.go
+++ b/gremlin/query.go
@@ -32,6 +32,18 @@ import (
 // QueryString used to construct string representation of query
 type QueryString string
 
+// NewValueStringFromArgument via inferance creates a correct ValueString
+func NewQueryStringFromArgument(v interface{}) QueryString {
+	switch v := v.(type) {
+	case QueryString:
+		return v
+	case string:
+		return QueryString(v)
+	default:
+		panic(fmt.Sprintf("argument %v: type %T not supported", v, v))
+	}
+}
+
 // String converts value to string
 func (v QueryString) String() string {
 	return string(v)
@@ -41,81 +53,140 @@ func (v QueryString) String() string {
 const G = QueryString("G")
 
 // Append appends string value to query
-func (q QueryString) Append(s string) QueryString {
+func (q QueryString) appends(s string) QueryString {
 	return QueryString(q.String() + s)
 }
 
-// Append a Context() operation to query
-func (q QueryString) Context(t time.Time) QueryString {
-	if !t.IsZero() {
-		return q.Append(fmt.Sprintf(".Context(%d)", common.UnixMillis(t)))
-	}
-	return q
-}
-
-// V append a V() operation to query
-func (q QueryString) V() QueryString {
-	return q.Append(".V()")
-}
-
-// Has append a Has() operation to query
-func (q QueryString) Has(list ...ValueString) QueryString {
-	q = q.Append(".Has(")
+func (q QueryString) newQueryString(name string, list ...interface{}) QueryString {
+	q = q.appends(fmt.Sprintf(".%s(", name))
 	first := true
 	for _, v := range list {
 		if !first {
-			q = q.Append(", ")
+			q = q.appends(", ")
 		}
 		first = false
-		q = q.Append(v.String())
+		q = q.appends(NewValueStringFromArgument(v).String())
 	}
-	return q.Append(")")
+	return q.appends(")")
 }
 
-// ValueString a value used within query constructs
-type ValueString string
-
-// String converts value to string
-func (v ValueString) String() string {
-	return string(v)
+// Aggregates append a Aggregates() operation to query
+func (q QueryString) Aggregates() QueryString {
+	return q.newQueryString("Aggregates")
 }
 
-// Quote used to quote string values as needed by query
-func (v ValueString) Quote() ValueString {
-	return ValueString(fmt.Sprintf("'%s'", v.String()))
+// At append a At() operation to query
+func (q QueryString) At(list ...interface{}) QueryString {
+	return q.newQueryString("At", list...)
 }
 
-// Regex used for constructing a regexp expression string
-func (v ValueString) Regex() ValueString {
-	return ValueString(fmt.Sprintf("Regex(%s)", v.Quote()))
+// Both append a Both() operation to query
+func (q QueryString) Both() QueryString {
+	return q.newQueryString("Both")
 }
 
-// StartsWith construct a regexp representing all that start with string
-func (v ValueString) StartsWith() ValueString {
-	return ValueString(fmt.Sprintf("%s.*", v.String())).Regex()
+// BPF append a PBF() operation to query
+func (q QueryString) BPF(list ...interface{}) QueryString {
+	return q.newQueryString("BPF", list...)
 }
 
-// EndsWith construct a regexp representing all that end with string
-func (v ValueString) EndsWith() ValueString {
-	return ValueString(fmt.Sprintf(".*%s", v.String())).Regex()
+// CaptureNode append a CaptureNode() operation to query
+func (q QueryString) CaptureNode() QueryString {
+	return q.newQueryString("CaptureNode")
 }
 
-// Quote used to quote string values as needed by query
-func Quote(s string) ValueString {
-	return ValueString(s).Quote()
+// Context append a Context() operation to query
+func (q QueryString) Context(list ...interface{}) QueryString {
+	newQ := q.appends(".Context(")
+	first := true
+	for _, v := range list {
+		if !first {
+			newQ = newQ.appends(", ")
+		}
+		switch v := v.(type) {
+		case time.Time:
+			if v.IsZero() {
+				return q
+			}
+			newQ = newQ.appends(fmt.Sprintf("%d", common.UnixMillis(v)))
+		case int:
+			newQ = newQ.appends(fmt.Sprintf("%d", v))
+		}
+	}
+	return newQ.appends(")")
 }
 
-// Regex used for constructing a regexp expression string
-func Regex(s string) ValueString {
-	return ValueString(s).Regex()
+// Count append a Count() operation to query
+func (q QueryString) Count() QueryString {
+	return q.newQueryString("Count")
 }
 
-// StartsWith construct a regexp representing all that start with string
-func StartsWith(s string) ValueString {
-	return ValueString(s).StartsWith()
+// Dedup append a Dedup() operation to query
+func (q QueryString) Dedup() QueryString {
+	return q.newQueryString("Dedup")
 }
 
-// EndsWith construct a regexp representing all that end with string
-func EndsWith(s string) ValueString {
-	return ValueString(s).EndsWith()
+// Flows append a Flows() operation to query
+func (q QueryString) Flows(list ...interface{}) QueryString {
+	return q.newQueryString("Flows", list...)
+}
+
+// Has append a Has() operation to query
+func (q QueryString) Has(list ...interface{}) QueryString {
+	return q.newQueryString("Has", list...)
+}
+
+// HasKey append a HasKey() operation to query
+func (q QueryString) HasKey(v interface{}) QueryString {
+	return q.newQueryString("HasKey", v)
+}
+
+// Hops append a Hops() operation to query
+func (q QueryString) Hops() QueryString {
+	return q.newQueryString("Hops")
+}
+
+// In append a In() operation to query
+func (q QueryString) In() QueryString {
+	return q.newQueryString("In")
+}
+
+// Metrics append a Metrics() operation to query
+func (q QueryString) Metrics() QueryString {
+	return q.newQueryString("Metrics")
+}
+
+// Sum append a Sum() operation to query
+func (q QueryString) Sum(list ...interface{}) QueryString {
+	return q.newQueryString("Sum", list...)
+}
+
+// Nodes append a Nodes() operation to query
+func (q QueryString) Nodes() QueryString {
+	return q.newQueryString("Nodes")
+}
+
+// Out append a Out() operation to query
+func (q QueryString) Out() QueryString {
+	return q.newQueryString("Out")
+}
+
+// RawPackets append a RawPackets() operation to query
+func (q QueryString) RawPackets() QueryString {
+	return q.newQueryString("RawPackets")
+}
+
+// ShortestPathTo append a ShortestPathTo() operation to query
+func (q QueryString) ShortestPathTo(list ...interface{}) QueryString {
+	return q.newQueryString("ShortestPathTo", list...)
+}
+
+// Sort append a Sort() operation to query
+func (q QueryString) Sort(list ...interface{}) QueryString {
+	return q.newQueryString("Sort", list...)
+}
+
+// V append a V() operation to query
+func (q QueryString) V(list ...interface{}) QueryString {
+	return q.newQueryString("V", list...)
 }

--- a/gremlin/query_test.go
+++ b/gremlin/query_test.go
@@ -29,9 +29,9 @@ import (
 
 func TestQueryBuilder(t *testing.T) {
 	const key, val = "Type", "host"
-	expected := fmt.Sprintf("G.V().Has('%s', Regex('%s'), '%s', Regex('%s.*'), '%s', Regex('.*%s'))",
+	expected := fmt.Sprintf(`G.V().Has("%s", Regex("%s"), "%s", Regex("%s.*"), "%s", Regex(".*%s")).Flows().Sort()`,
 		key, val, key, val, key, val)
-	actual := G.V().Has(Quote(key), Regex(val), Quote(key), StartsWith(val), Quote(key), EndsWith(val))
+	actual := G.V().Has(Quote(key), Regex(val), Quote(key), StartsWith(val), Quote(key), EndsWith(val)).Flows().Sort()
 	if actual.String() != expected {
 		t.Errorf("Wrong query,\nexpected: \"%s\",\nactual: \"%s\"", expected, actual)
 	}

--- a/gremlin/value.go
+++ b/gremlin/value.go
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2018 IBM, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package gremlin
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// ValueString a value used within query constructs
+type ValueString string
+
+// newValueStringFromArgument via inferance creates a correct ValueString
+func NewValueStringFromArgument(v interface{}) ValueString {
+	switch v := v.(type) {
+	case ValueString:
+		return v
+	case string:
+		return Quote(v)
+	case int:
+		return ValueString(strconv.Itoa(v))
+	default:
+		panic(fmt.Sprintf("argument %v: type %T not supported", v, v))
+	}
+}
+
+// String converts value to string
+func (v ValueString) String() string {
+	return string(v)
+}
+
+// DESC const definition
+const DESC = ValueString("DESC")
+
+// Quote used to quote string values as needed by query
+func (v ValueString) Quote() ValueString {
+	return ValueString(fmt.Sprintf(`"%s"`, v))
+}
+
+// Regex used for constructing a regexp expression string
+func (v ValueString) Regex() ValueString {
+	return ValueString(fmt.Sprintf("Regex(%s)", v.Quote()))
+}
+
+// StartsWith construct a regexp representing all that start with string
+func (v ValueString) StartsWith() ValueString {
+	return ValueString(fmt.Sprintf("%s.*", v)).Regex()
+}
+
+// EndsWith construct a regexp representing all that end with string
+func (v ValueString) EndsWith() ValueString {
+	return ValueString(fmt.Sprintf(".*%s", v)).Regex()
+}
+
+// Quote used to quote string values as needed by query
+func Quote(s string) ValueString {
+	return ValueString(s).Quote()
+}
+
+// Regex used for constructing a regexp expression string
+func Regex(s string) ValueString {
+	return ValueString(s).Regex()
+}
+
+// StartsWith construct a regexp representing all that start with string
+func StartsWith(s string) ValueString {
+	return ValueString(s).StartsWith()
+}
+
+// EndsWith construct a regexp representing all that end with string
+func EndsWith(s string) ValueString {
+	return ValueString(s).EndsWith()
+}
+
+func newValueString(name string, list ...interface{}) ValueString {
+	s := fmt.Sprintf("%s(", name)
+	first := true
+	for _, v := range list {
+		if !first {
+			s = s + ", "
+		}
+		first = false
+		s = s + NewValueStringFromArgument(v).String()
+	}
+	return ValueString(s + ")")
+}
+
+// Between append a Between() operation to query
+func Between(list ...interface{}) ValueString {
+	return newValueString("Between", list...)
+}
+
+// Contains append a Contains() operation to query
+func Contains(v interface{}) ValueString {
+	return newValueString("Contains", v)
+}
+
+// Gt append a Gt() operation to query
+func Gt(v interface{}) ValueString {
+	return newValueString("Gt", v)
+}
+
+// Gte append a Gte() operation to query
+func Gte(v interface{}) ValueString {
+	return newValueString("Gte", v)
+}
+
+// Ipv4Range append a Ipv4Range() operation to query
+func Ipv4Range(list ...interface{}) ValueString {
+	return newValueString("Ipv4Range", list...)
+}
+
+// Inside append a Inside() operation to query
+func Inside(list ...interface{}) ValueString {
+	return newValueString("Inside", list...)
+}
+
+// Lt append a Lt() operation to query
+func Lt(v interface{}) ValueString {
+	return newValueString("Lt", v)
+}
+
+// Lte append a Lte() operation to query
+func Lte(v interface{}) ValueString {
+	return newValueString("Lte", v)
+}
+
+// Metadata append a Metadata() operation to query
+func Metadata(list ...interface{}) ValueString {
+	return newValueString("Metadata", list...)
+}
+
+// Within append a Within() operation to query
+func Within(list ...interface{}) ValueString {
+	return newValueString("Within", list...)
+}

--- a/tests/flow_test.go
+++ b/tests/flow_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/skydive-project/skydive/api/types"
 	"github.com/skydive-project/skydive/common"
 	"github.com/skydive-project/skydive/flow"
+	g "github.com/skydive-project/skydive/gremlin"
 	"github.com/skydive-project/skydive/tests/helper"
 )
 
@@ -61,22 +62,18 @@ func TestSFlowProbeNode(t *testing.T) {
 		},
 
 		captures: []TestCapture{
-			{gremlin: `g.V().Has("Name", "br-spn", "Type", "ovsbridge")`},
+			{gremlin: g.G.V().Has("Name", "br-spn", "Type", "ovsbridge")},
 		},
 
 		checks: []CheckFunction{func(c *CheckContext) error {
-			prefix := "g"
-			if !c.time.IsZero() {
-				prefix += fmt.Sprintf(".Context(%d)", common.UnixMillis(c.time))
-			}
-
+			prefix := g.G.Context(c.time)
 			gh := c.gh
-			node, err := gh.GetNode(prefix + `.V().Has("Name", "br-spn", "Type", "ovsbridge").HasKey("TID")`)
+			node, err := gh.GetNode(prefix.V().Has("Name", "br-spn", "Type", "ovsbridge").HasKey("TID"))
 			if err != nil {
 				return err
 			}
 
-			flows, err := gh.GetFlows(prefix + fmt.Sprintf(`.Flows("NodeTID", "%s", "LayersPath", "Ethernet/ARP")`, node.Metadata()["TID"].(string)))
+			flows, err := gh.GetFlows(prefix.Flows("NodeTID", node.Metadata()["TID"], "LayersPath", "Ethernet/ARP"))
 			if err != nil {
 				return err
 			}
@@ -114,22 +111,18 @@ func TestSFlowNodeTIDOvsInternalNetNS(t *testing.T) {
 		},
 
 		captures: []TestCapture{
-			{gremlin: `g.V().Has("Name", "br-sntoin", "Type", "ovsbridge")`},
+			{gremlin: g.G.V().Has("Name", "br-sntoin", "Type", "ovsbridge")},
 		},
 
 		checks: []CheckFunction{func(c *CheckContext) error {
-			prefix := "g"
-			if !c.time.IsZero() {
-				prefix += fmt.Sprintf(".Context(%d)", common.UnixMillis(c.time))
-			}
-
+			prefix := g.G.Context(c.time)
 			gh := c.gh
-			node, err := gh.GetNode(prefix + `.V().Has("Name", "br-sntoin", "Type", "ovsbridge").HasKey("TID")`)
+			node, err := gh.GetNode(prefix.V().Has("Name", "br-sntoin", "Type", "ovsbridge").HasKey("TID"))
 			if err != nil {
 				return err
 			}
 
-			flows, err := gh.GetFlows(prefix + fmt.Sprintf(`.Flows("NodeTID", "%s", "LayersPath", "Ethernet/ARP")`, node.Metadata()["TID"].(string)))
+			flows, err := gh.GetFlows(prefix.Flows("NodeTID", node.Metadata()["TID"], "LayersPath", "Ethernet/ARP"))
 			if err != nil {
 				return err
 			}
@@ -195,13 +188,9 @@ func TestSFlowTwoNodeTID(t *testing.T) {
 		},
 
 		checks: []CheckFunction{func(c *CheckContext) error {
-			prefix := "g"
-			if !c.time.IsZero() {
-				prefix += fmt.Sprintf(".Context(%d)", common.UnixMillis(c.time))
-			}
-
+			prefix := g.G.Context(c.time)
 			gh := c.gh
-			flows, err := gh.GetFlows(prefix + ".V().Has('Type', 'ovsbridge').Flows().Has('LayersPath', 'Ethernet/IPv4/ICMPv4')")
+			flows, err := gh.GetFlows(prefix.V().Has("Type", "ovsbridge").Flows().Has("LayersPath", "Ethernet/IPv4/ICMPv4"))
 			if err != nil {
 				return err
 			}
@@ -210,12 +199,12 @@ func TestSFlowTwoNodeTID(t *testing.T) {
 				return fmt.Errorf("Should have 2 flow entries one per NodeTID got: %d", len(flows))
 			}
 
-			node1, err := gh.GetNode(prefix + `.V().Has("Name", "br-stnt1", "Type", "ovsbridge").HasKey("TID")`)
+			node1, err := gh.GetNode(prefix.V().Has("Name", "br-stnt1", "Type", "ovsbridge").HasKey("TID"))
 			if err != nil {
 				return err
 			}
 
-			node2, err := gh.GetNode(prefix + `.V().Has("Name", "br-stnt2", "Type", "ovsbridge").HasKey("TID")`)
+			node2, err := gh.GetNode(prefix.V().Has("Name", "br-stnt2", "Type", "ovsbridge").HasKey("TID"))
 			if err != nil {
 				return err
 			}
@@ -281,16 +270,11 @@ func TestBPF(t *testing.T) {
 		},
 
 		captures: []TestCapture{
-			{gremlin: `G.V().Has('Name', 'bpf-vm1-eth0')`, bpf: "icmp and host 169.254.66.67"},
+			{gremlin: g.G.V().Has("Name", "bpf-vm1-eth0"), bpf: "icmp and host 169.254.66.67"},
 		},
 
 		checks: []CheckFunction{func(c *CheckContext) error {
-			prefix := "g"
-			if !c.time.IsZero() {
-				prefix += fmt.Sprintf(".Context(%d)", common.UnixMillis(c.time))
-			}
-
-			flows, err := c.gh.GetFlows(prefix + `.V().Has('Name', 'bpf-vm1-eth0').Flows()`)
+			flows, err := c.gh.GetFlows(g.G.Context(c.time).V().Has("Name", "bpf-vm1-eth0").Flows())
 			if err != nil {
 				return err
 			}
@@ -341,22 +325,18 @@ func TestPCAPProbe(t *testing.T) {
 		},
 
 		captures: []TestCapture{
-			{gremlin: `G.V().Has('Name', 'br-pp', 'Type', 'bridge')`, kind: "pcap"},
+			{gremlin: g.G.V().Has("Name", "br-pp", "Type", "bridge"), kind: "pcap"},
 		},
 
 		checks: []CheckFunction{func(c *CheckContext) error {
-			prefix := "g"
-			if !c.time.IsZero() {
-				prefix += fmt.Sprintf(".Context(%d)", common.UnixMillis(c.time))
-			}
-
+			prefix := g.G.Context(c.time)
 			gh := c.gh
-			node, err := gh.GetNode(prefix + `.V().Has("Name", "br-pp", "Type", "bridge").HasKey("TID")`)
+			node, err := gh.GetNode(prefix.V().Has("Name", "br-pp", "Type", "bridge").HasKey("TID"))
 			if err != nil {
 				return err
 			}
 
-			flows, err := gh.GetFlows(fmt.Sprintf(prefix+`.Flows().Has("NodeTID", "%s")`, node.Metadata()["TID"]))
+			flows, err := gh.GetFlows(prefix.Flows().Has("NodeTID", node.Metadata()["TID"]))
 			if err != nil {
 				return err
 			}
@@ -406,30 +386,26 @@ func TestSFlowSrcDstPath(t *testing.T) {
 		},
 
 		checks: []CheckFunction{func(c *CheckContext) error {
-			prefix := "g"
-			if !c.time.IsZero() {
-				prefix += fmt.Sprintf(".Context(%d)", common.UnixMillis(c.time))
-			}
-
+			prefix := g.G.Context(c.time)
 			gh := c.gh
-			node1, err := gh.GetNode(prefix + `.V().Has("Name", "ssdp-intf1", "Type", "internal").HasKey("TID")`)
+			node1, err := gh.GetNode(prefix.V().Has("Name", "ssdp-intf1", "Type", "internal").HasKey("TID"))
 			if err != nil {
 				var res interface{}
 				gh.QueryObject("g", &res)
 				return fmt.Errorf("ssdp-intf1 not found, %v", res)
 			}
 
-			node2, err := gh.GetNode(prefix + `.V().Has("Name", "ssdp-intf2", "Type", "internal").HasKey("TID")`)
+			node2, err := gh.GetNode(prefix.V().Has("Name", "ssdp-intf2", "Type", "internal").HasKey("TID"))
 			if err != nil {
 				var res interface{}
-				gh.QueryObject("G", &res)
+				gh.QueryObject(g.G, &res)
 				return fmt.Errorf("ssdp-intf2 not found, %v", res)
 			}
 
-			within := fmt.Sprintf(`Within("%s", "%s")`, node1.Metadata()["TID"], node2.Metadata()["TID"])
-			flows, err := gh.GetFlows(fmt.Sprintf(prefix+`.Flows().Has("ANodeTID", %s, "BNodeTID", %s)`, within, within))
+			within := g.Within(node1.Metadata()["TID"], node2.Metadata()["TID"])
+			flows, err := gh.GetFlows(prefix.Flows().Has("ANodeTID", within, "BNodeTID", within))
 			if err != nil {
-				flows, _ = gh.GetFlows("g.Flows()")
+				flows, _ = gh.GetFlows(g.G.Flows())
 				return fmt.Errorf("flow with ANodeTID and BNodeTID not found: %v", flows)
 			}
 
@@ -459,23 +435,19 @@ func TestFlowGremlin(t *testing.T) {
 		},
 
 		captures: []TestCapture{
-			{gremlin: `G.V().Has('Name', 'br-fg', 'Type', 'ovsbridge')`},
+			{gremlin: g.G.V().Has("Name", "br-fg", "Type", "ovsbridge")},
 		},
 
 		checks: []CheckFunction{func(c *CheckContext) error {
-			prefix := "g"
-			if !c.time.IsZero() {
-				prefix += fmt.Sprintf(".Context(%d)", common.UnixMillis(c.time))
-			}
-
+			prefix := g.G.Context(c.time)
 			gh := c.gh
-			node, err := gh.GetNode(prefix + `.V().Has("Name", "br-fg", "Type", "ovsbridge")`)
+			node, err := gh.GetNode(prefix.V().Has("Name", "br-fg", "Type", "ovsbridge"))
 			if err != nil {
 				return err
 			}
 
 			var count int64
-			gh.QueryObject(prefix+`.V().Has("Name", "br-fg", "Type", "ovsbridge").Count()`, &count)
+			gh.QueryObject(prefix.V().Has("Name", "br-fg", "Type", "ovsbridge").Count(), &count)
 			if count != 1 {
 				return fmt.Errorf("Should return 1, got: %d", count)
 			}
@@ -485,32 +457,32 @@ func TestFlowGremlin(t *testing.T) {
 				return errors.New("Node TID not Found")
 			}
 
-			flows, _ := gh.GetFlows(prefix + `.V().Has("Name", "br-fg", "Type", "ovsbridge").Flows().Has("NodeTID", "` + tid + `")`)
+			flows, _ := gh.GetFlows(prefix.V().Has("Name", "br-fg", "Type", "ovsbridge").Flows().Has("NodeTID", tid))
 			if len(flows) == 0 {
 				return fmt.Errorf("Should return at least 1 flow, got: %v", flows)
 			}
 
-			flowsOpt, _ := gh.GetFlows(prefix + `.V().Has("Name", "br-fg", "Type", "ovsbridge").Flows().Has("NodeTID", "` + tid + `")`)
+			flowsOpt, _ := gh.GetFlows(prefix.V().Has("Name", "br-fg", "Type", "ovsbridge").Flows().Has("NodeTID", tid))
 			if len(flowsOpt) != len(flows) {
 				return fmt.Errorf("Should return the same number of flows that without optimisation, got: %v", flowsOpt)
 			}
 
-			nodes, _ := gh.GetNodes(prefix + `.V().Has("Name", "br-fg", "Type", "ovsbridge").Flows().Has("NodeTID", "` + tid + `").Out()`)
+			nodes, _ := gh.GetNodes(prefix.V().Has("Name", "br-fg", "Type", "ovsbridge").Flows().Has("NodeTID", tid).Out())
 			if len(nodes) != 0 {
 				return fmt.Errorf("Should return no destination node, got %d", len(nodes))
 			}
 
-			nodes, _ = gh.GetNodes(prefix + `.V().Has("Name", "br-fg", "Type", "ovsbridge").Flows().Has("NodeTID", "` + tid + `").Both().Dedup()`)
+			nodes, _ = gh.GetNodes(prefix.V().Has("Name", "br-fg", "Type", "ovsbridge").Flows().Has("NodeTID", tid).Both().Dedup())
 			if len(nodes) != 1 {
 				return fmt.Errorf("Should return one node, got %d", len(nodes))
 			}
 
-			nodes, _ = gh.GetNodes(prefix + `.V().Has("Name", "br-fg", "Type", "ovsbridge").Flows().Has("NodeTID", "` + tid + `").In().Dedup()`)
+			nodes, _ = gh.GetNodes(prefix.V().Has("Name", "br-fg", "Type", "ovsbridge").Flows().Has("NodeTID", tid).In().Dedup())
 			if len(nodes) != 1 {
 				return fmt.Errorf("Should return one source node, got %d", len(nodes))
 			}
 
-			gh.QueryObject(prefix+`.V().Has("Name", "br-fg", "Type", "ovsbridge").Flows().Has("NodeTID", "`+tid+`").Count()`, &count)
+			gh.QueryObject(prefix.V().Has("Name", "br-fg", "Type", "ovsbridge").Flows().Has("NodeTID", tid).Count(), &count)
 			if int(count) != len(flows) {
 				return fmt.Errorf("Gremlin count doesn't correspond to the number of flows, got: %v, expected: %v", len(flows), count)
 			}
@@ -523,17 +495,12 @@ func TestFlowGremlin(t *testing.T) {
 }
 
 func queryFlowMetrics(gh *gclient.GremlinQueryHelper, bridge string, timeContext int64, pings int64) error {
-	graphGremlin := "g"
-	if timeContext != -1 {
-		graphGremlin += fmt.Sprintf(".Context(%d)", timeContext)
-	}
-
-	ovsGremlin := graphGremlin + fmt.Sprintf(`.V().Has("Name", "%s", "Type", "ovsbridge")`, bridge)
+	ovsGremlin := g.G.Context(timeContext).V().Has("Name", bridge, "Type", "ovsbridge")
 	if _, err := gh.GetNode(ovsGremlin); err != nil {
 		return err
 	}
 
-	gremlin := ovsGremlin + `.Flows().Has("LayersPath", Regex(".*ICMPv4.*"))`
+	gremlin := ovsGremlin.Flows().Has("LayersPath", g.Contains("ICMPv4"))
 
 	icmp, err := gh.GetFlows(gremlin)
 	if err != nil {
@@ -560,7 +527,7 @@ func queryFlowMetrics(gh *gclient.GremlinQueryHelper, bridge string, timeContext
 		return fmt.Errorf("Number of bytes is wrong, got: %v", ethernet.BABytes)
 	}
 
-	flows, err := gh.GetFlows(fmt.Sprintf(`%s.Flows().Has("LayersPath", "Ethernet/IPv4/ICMPv4", "Metric.ABPackets", %d)`, ovsGremlin, pings))
+	flows, err := gh.GetFlows(ovsGremlin.Flows().Has("LayersPath", "Ethernet/IPv4/ICMPv4", "Metric.ABPackets", pings))
 	if len(flows) != 1 || flows[0].Metric.BAPackets != pings {
 		return fmt.Errorf("Number of packets is wrong, got %d, flows: %v (error: %+v)", len(flows), flows, err)
 	}
@@ -571,62 +538,62 @@ func queryFlowMetrics(gh *gclient.GremlinQueryHelper, bridge string, timeContext
 	}
 
 	pingLen := icmp[0].Metric.ABBytes
-	metric, err := gh.GetFlowMetric(gremlin + fmt.Sprintf(`.Has("Metric.ABBytes", Gt(%d))`, pingLen-1))
+	metric, err := gh.GetFlowMetric(gremlin.Has("Metric.ABBytes", g.Gt(pingLen-1)))
 	if err != nil || metric.ABBytes < pingLen {
 		return fmt.Errorf("Number of bytes is wrong, got: %v (error: %+v)", metric, err)
 	}
 
-	metric, err = gh.GetFlowMetric(gremlin + fmt.Sprintf(`.Has("Metric.ABBytes", Gt(%d))`, pingLen))
+	metric, err = gh.GetFlowMetric(gremlin.Has("Metric.ABBytes", g.Gt(pingLen)))
 	if err != common.ErrNotFound {
 		return fmt.Errorf("Wrong number of flow, should have none, got : %v", metric)
 	}
 
-	metric, err = gh.GetFlowMetric(gremlin + fmt.Sprintf(`.Has("Metric.ABBytes", Gte(%d))`, pingLen))
+	metric, err = gh.GetFlowMetric(gremlin.Has("Metric.ABBytes", g.Gte(pingLen)))
 	if err != nil || metric == nil || metric.ABBytes < pingLen {
 		return fmt.Errorf("Number of bytes is wrong, got: %v", metric)
 	}
 
-	metric, err = gh.GetFlowMetric(gremlin + fmt.Sprintf(`.Has("Metric.ABBytes", Gte(%d))`, pingLen+1))
+	metric, err = gh.GetFlowMetric(gremlin.Has("Metric.ABBytes", g.Gte(pingLen+1)))
 	if err != common.ErrNotFound {
 		return fmt.Errorf("Wrong number of flow, should have none, got : %v", metric)
 	}
 
-	metric, err = gh.GetFlowMetric(gremlin + fmt.Sprintf(`.Has("Metric.ABBytes", Lt(%d))`, pingLen+1))
+	metric, err = gh.GetFlowMetric(gremlin.Has("Metric.ABBytes", g.Lt(pingLen+1)))
 	if err != nil || metric.ABBytes > pingLen {
 		return fmt.Errorf("Number of bytes is wrong, got: %v", metric)
 	}
 
-	metric, err = gh.GetFlowMetric(gremlin + fmt.Sprintf(`.Has("Metric.ABBytes", Lt(%d))`, pingLen))
+	metric, err = gh.GetFlowMetric(gremlin.Has("Metric.ABBytes", g.Lt(pingLen)))
 	if err != common.ErrNotFound {
 		return fmt.Errorf("Wrong number of flow, should have none, got : %v", metric)
 	}
 
-	metric, err = gh.GetFlowMetric(gremlin + fmt.Sprintf(`.Has("Metric.ABBytes", Lte(%d))`, pingLen))
+	metric, err = gh.GetFlowMetric(gremlin.Has("Metric.ABBytes", g.Lte(pingLen)))
 	if err != nil || metric == nil || metric.ABBytes > pingLen {
 		return fmt.Errorf("Number of bytes is wrong, got: %v", metric)
 	}
 
-	metric, err = gh.GetFlowMetric(gremlin + fmt.Sprintf(`.Has("Metric.ABBytes", Lte(%d))`, pingLen-1))
+	metric, err = gh.GetFlowMetric(gremlin.Has("Metric.ABBytes", g.Lte(pingLen-1)))
 	if err != common.ErrNotFound {
 		return fmt.Errorf("Wrong number of flow, should have none, got : %v", metric)
 	}
 
-	metric, err = gh.GetFlowMetric(gremlin + fmt.Sprintf(`.Has("Metric.ABBytes", Inside(%d, %d))`, pingLen-1, pingLen+1))
+	metric, err = gh.GetFlowMetric(gremlin.Has("Metric.ABBytes", g.Inside(pingLen-1, pingLen+1)))
 	if err != nil || metric == nil || metric.ABBytes <= pingLen-1 || metric.ABBytes >= pingLen+1 {
 		return fmt.Errorf("Number of bytes is wrong, got: %v", metric)
 	}
 
-	metric, err = gh.GetFlowMetric(gremlin + fmt.Sprintf(`.Has("Metric.ABBytes", Inside(%d, %d))`, pingLen, pingLen+1))
+	metric, err = gh.GetFlowMetric(gremlin.Has("Metric.ABBytes", g.Inside(pingLen, pingLen+1)))
 	if err != common.ErrNotFound {
 		return fmt.Errorf("Wrong number of flow, should have none, got : %v", metric)
 	}
 
-	metric, err = gh.GetFlowMetric(gremlin + fmt.Sprintf(`.Has("Metric.ABBytes", Between(%d, %d))`, pingLen, pingLen+1))
+	metric, err = gh.GetFlowMetric(gremlin.Has("Metric.ABBytes", g.Between(pingLen, pingLen+1)))
 	if metric == nil || metric.ABBytes <= pingLen-1 || metric.ABBytes >= pingLen+1 {
 		return fmt.Errorf("Number of bytes is wrong, got: %v", metric)
 	}
 
-	metric, err = gh.GetFlowMetric(gremlin + fmt.Sprintf(`.Has("Metric.ABBytes", Between(%d, %d))`, pingLen, pingLen))
+	metric, err = gh.GetFlowMetric(gremlin.Has("Metric.ABBytes", g.Between(pingLen, pingLen)))
 	if err != common.ErrNotFound {
 		return fmt.Errorf("Wrong number of flow, should have none, got : %v", metric)
 	}
@@ -667,7 +634,7 @@ func TestFlowMetrics(t *testing.T) {
 		},
 
 		captures: []TestCapture{
-			{gremlin: `G.V().Has('Name', 'br-fm', 'Type', 'ovsbridge')`},
+			{gremlin: g.G.V().Has("Name", "br-fm", "Type", "ovsbridge")},
 		},
 
 		checks: []CheckFunction{func(c *CheckContext) error {
@@ -717,15 +684,14 @@ func TestFlowMetricsStep(t *testing.T) {
 		},
 
 		captures: []TestCapture{
-			{gremlin: `G.V().Has('Name', 'br-fms', 'Type', 'ovsbridge')`},
+			{gremlin: g.G.V().Has("Name", "br-fms", "Type", "ovsbridge")},
 		},
 
 		checks: []CheckFunction{func(c *CheckContext) error {
 			gh := c.gh
-			gremlin := fmt.Sprintf("g.Context(%d, %d)", common.UnixMillis(c.startTime), c.startTime.Unix()-c.setupTime.Unix()+5)
-			gremlin += `.V().Has("Name", "br-fms", "Type", "ovsbridge").Flows()`
+			gremlin := g.G.Context(c.startTime, c.startTime.Unix()-c.setupTime.Unix()+5).V().Has("Name", "br-fms", "Type", "ovsbridge").Flows()
 
-			m, err := gh.GetMetric(gremlin + `.Has("LayersPath", "Ethernet/IPv4/ICMPv4").Dedup().Metrics().Sum()`)
+			m, err := gh.GetMetric(gremlin.Has("LayersPath", "Ethernet/IPv4/ICMPv4").Dedup().Metrics().Sum())
 			if err != nil {
 				flows, _ := gh.GetFlows(gremlin)
 				return fmt.Errorf("Could not find metrics (%+v) for flows %s", m, helper.FlowsToString(flows))
@@ -734,7 +700,7 @@ func TestFlowMetricsStep(t *testing.T) {
 
 			if metric.ABPackets != 15 || metric.BAPackets != 15 || metric.ABBytes < 15360 || metric.BABytes < 15360 {
 				flows, _ := gh.GetFlows(gremlin)
-				return fmt.Errorf("Wrong metric returned, got : %+v for flows %+v, request: %s", metric, helper.FlowsToString(flows), gremlin+`.Has("LayersPath", "Ethernet/IPv4/ICMPv4").Dedup().Metrics().Sum()`)
+				return fmt.Errorf("Wrong metric returned, got : %+v for flows %+v, request: %s", metric, helper.FlowsToString(flows), gremlin.Has("LayersPath", "Ethernet/IPv4/ICMPv4").Dedup().Metrics().Sum())
 			}
 
 			checkMetrics := func(metrics map[string][]common.Metric) error {
@@ -760,7 +726,7 @@ func TestFlowMetricsStep(t *testing.T) {
 				return nil
 			}
 
-			metrics, err := gh.GetMetrics(gremlin + `.Has("LayersPath", "Ethernet/IPv4/ICMPv4").Dedup().Metrics()`)
+			metrics, err := gh.GetMetrics(gremlin.Has("LayersPath", "Ethernet/IPv4/ICMPv4").Dedup().Metrics())
 			if err != nil || len(metrics) == 0 {
 				return fmt.Errorf("Could not find metrics (%+v)", metrics)
 			}
@@ -769,7 +735,7 @@ func TestFlowMetricsStep(t *testing.T) {
 				return err
 			}
 
-			metrics, err = gh.GetMetrics(gremlin + `.Has("LayersPath", "Ethernet/IPv4/ICMPv4").Dedup().Metrics().Aggregates()`)
+			metrics, err = gh.GetMetrics(gremlin.Has("LayersPath", "Ethernet/IPv4/ICMPv4").Dedup().Metrics().Aggregates())
 			if err != nil || len(metrics) == 0 {
 				return fmt.Errorf("Could not find metrics (%+v)", metrics)
 			}
@@ -805,13 +771,13 @@ func TestFlowHops(t *testing.T) {
 
 		settleFunction: func(c *TestContext) error {
 			// check that src and dst interfaces are in the right place before doing the ping
-			gremlin := `G.V().Has("Name", "fh-vm1").Out().Has("Name", "fh-intf1")`
+			gremlin := g.G.V().Has("Name", "fh-vm1").Out().Has("Name", "fh-intf1")
 			nodes, err := c.gh.GetNodes(gremlin)
 			if err != nil || len(nodes) == 0 {
 				return errors.New("fh-intf1 not found in the expected namespace")
 			}
 
-			gremlin = `G.V().Has("Name", "fh-vm2").Out().Has("Name", "fh-intf2")`
+			gremlin = g.G.V().Has("Name", "fh-vm2").Out().Has("Name", "fh-intf2")
 			nodes, err = c.gh.GetNodes(gremlin)
 			if err != nil || len(nodes) == 0 {
 				return errors.New("fh-intf2 not found in the expected namespace")
@@ -832,20 +798,16 @@ func TestFlowHops(t *testing.T) {
 		},
 
 		captures: []TestCapture{
-			{gremlin: `G.V().Has('Name', 'br-fh', 'Type', 'ovsbridge')`},
+			{gremlin: g.G.V().Has("Name", "br-fh", "Type", "ovsbridge")},
 		},
 
 		// since the agent update ticker is about 10 sec according to the configuration
 		// we should wait 11 sec to have the first update and the MetricRange filled
 		checks: []CheckFunction{func(c *CheckContext) error {
-			prefix := "g"
-			if !c.time.IsZero() {
-				prefix += fmt.Sprintf(".Context(%d)", common.UnixMillis(c.time))
-			}
-			prefix += `.V().Has("Name", "br-fh", "Type", "ovsbridge")`
+			prefix := g.G.Context(c.time).V().Has("Name", "br-fh", "Type", "ovsbridge")
 
 			gh := c.gh
-			gremlin := prefix + `.Flows().Has("LayersPath", "Ethernet/IPv4/ICMPv4")`
+			gremlin := prefix.Flows().Has("LayersPath", "Ethernet/IPv4/ICMPv4")
 			flows, err := gh.GetFlows(gremlin)
 			if err != nil {
 				return err
@@ -855,7 +817,7 @@ func TestFlowHops(t *testing.T) {
 				return errors.New("We should receive only one ICMPv4 flow")
 			}
 
-			gremlin = fmt.Sprintf(prefix+`.Flows().Has("TrackingID", "%s").Nodes()`, flows[0].TrackingID)
+			gremlin = prefix.Flows().Has("TrackingID", flows[0].TrackingID).Nodes()
 			tnodes, err := gh.GetNodes(gremlin)
 			if err != nil {
 				return err
@@ -865,7 +827,7 @@ func TestFlowHops(t *testing.T) {
 				return fmt.Errorf("We should have 3 nodes NodeTID,A,B got : %v for flows : %v", tnodes, flows)
 			}
 
-			gremlin = prefix + `.Flows().Has("LayersPath", "Ethernet/IPv4/ICMPv4").Hops()`
+			gremlin = prefix.Flows().Has("LayersPath", "Ethernet/IPv4/ICMPv4").Hops()
 			nodes, err := gh.GetNodes(gremlin)
 			if err != nil {
 				return err
@@ -918,13 +880,13 @@ func TestIPv6FlowHopsIPv6(t *testing.T) {
 
 		settleFunction: func(c *TestContext) error {
 			// check that src and dst interfaces are in the right place before doing the ping
-			gremlin := `G.V().Has("Name", "ipv6fh-vm1").Out().Has("Name", "ipv6fh-intf1")`
+			gremlin := g.G.V().Has("Name", "ipv6fh-vm1").Out().Has("Name", "ipv6fh-intf1")
 			nodes, err := c.gh.GetNodes(gremlin)
 			if err != nil || len(nodes) == 0 {
 				return errors.New("ipv6fh-intf1 not found in the expected namespace")
 			}
 
-			gremlin = `G.V().Has("Name", "ipv6fh-vm2").Out().Has("Name", "ipv6fh-intf2")`
+			gremlin = g.G.V().Has("Name", "ipv6fh-vm2").Out().Has("Name", "ipv6fh-intf2")
 			nodes, err = c.gh.GetNodes(gremlin)
 			if err != nil || len(nodes) == 0 {
 				return errors.New("ipv6fh-intf2 not found in the expected namespace")
@@ -946,20 +908,16 @@ func TestIPv6FlowHopsIPv6(t *testing.T) {
 		},
 
 		captures: []TestCapture{
-			{gremlin: `G.V().Has('Name', 'br-ipv6fh', 'Type', 'ovsbridge')`},
+			{gremlin: g.G.V().Has("Name", "br-ipv6fh", "Type", "ovsbridge")},
 		},
 
 		// since the agent update ticker is about 10 sec according to the configuration
 		// we should wait 11 sec to have the first update and the MetricRange filled
 		checks: []CheckFunction{func(c *CheckContext) error {
-			prefix := "g"
-			if !c.time.IsZero() {
-				prefix += fmt.Sprintf(".Context(%d)", common.UnixMillis(c.time))
-			}
-			prefix += `.V().Has("Name", "br-ipv6fh", "Type", "ovsbridge")`
+			prefix := g.G.Context(c.time).V().Has("Name", "br-ipv6fh", "Type", "ovsbridge")
 
 			gh := c.gh
-			gremlin := prefix + `.Flows().Has("LayersPath", "Ethernet/IPv6/ICMPv6", "ICMP.Type", "ECHO")`
+			gremlin := prefix.Flows().Has("LayersPath", "Ethernet/IPv6/ICMPv6", "ICMP.Type", "ECHO")
 			// filterIPv6AddrAnd() as we received multicast/broadcast from fresh registered interfaces announcement
 			allFlows, err := gh.GetFlows(gremlin)
 			if err != nil {
@@ -971,7 +929,7 @@ func TestIPv6FlowHopsIPv6(t *testing.T) {
 				return errors.New("We should receive only one ICMPv6 flow")
 			}
 
-			gremlin = fmt.Sprintf(prefix+`.Flows().Has("TrackingID", "%s").Nodes()`, flows[0].TrackingID)
+			gremlin = prefix.Flows().Has("TrackingID", flows[0].TrackingID).Nodes()
 			tnodes, err := gh.GetNodes(gremlin)
 			if err != nil {
 				return err
@@ -982,7 +940,7 @@ func TestIPv6FlowHopsIPv6(t *testing.T) {
 			}
 
 			/* Dedup() here for same reason than above ^^^ */
-			gremlin = prefix + `.Flows().Has("LayersPath", "Ethernet/IPv6/ICMPv6").Hops().Dedup()`
+			gremlin = prefix.Flows().Has("LayersPath", "Ethernet/IPv6/ICMPv6").Hops().Dedup()
 			nodes, err := gh.GetNodes(gremlin)
 			if err != nil {
 				return err
@@ -1038,13 +996,13 @@ func TestICMP(t *testing.T) {
 
 		settleFunction: func(c *TestContext) error {
 			// check that src and dst interfaces are in the right place before doing the ping
-			gremlin := `G.V().Has("Name", "icmp-vm1").Out().Has("Name", "icmp-intf1")`
+			gremlin := g.G.V().Has("Name", "icmp-vm1").Out().Has("Name", "icmp-intf1")
 			_, err := c.gh.GetNode(gremlin)
 			if err != nil {
 				return errors.New("icmp-intf1 not found in the expected namespace")
 			}
 
-			gremlin = `G.V().Has("Name", "icmp-vm2").Out().Has("Name", "icmp-intf2")`
+			gremlin = g.G.V().Has("Name", "icmp-vm2").Out().Has("Name", "icmp-intf2")
 			_, err = c.gh.GetNode(gremlin)
 			if err != nil {
 				return errors.New("icmp-intf2 not found in the expected namespace")
@@ -1056,8 +1014,8 @@ func TestICMP(t *testing.T) {
 		setupFunction: func(c *TestContext) error {
 			req := &types.PacketParamsReq{
 				Type:     "icmp4",
-				Src:      "G.V().Has('Name', 'icmp-intf1', 'Type', 'internal')",
-				Dst:      "G.V().Has('Name', 'icmp-intf2', 'Type', 'internal')",
+				Src:      g.G.V().Has("Name", "icmp-intf1", "Type", "internal").String(),
+				Dst:      g.G.V().Has("Name", "icmp-intf2", "Type", "internal").String(),
 				SrcIP:    "10.0.0.1/24",
 				DstIP:    "10.0.0.2/24",
 				Count:    1,
@@ -1072,8 +1030,8 @@ func TestICMP(t *testing.T) {
 
 			req = &types.PacketParamsReq{
 				Type:     "icmp6",
-				Src:      "G.V().Has('Name', 'icmp-intf1', 'Type', 'internal')",
-				Dst:      "G.V().Has('Name', 'icmp-intf2', 'Type', 'internal')",
+				Src:      g.G.V().Has("Name", "icmp-intf1", "Type", "internal").String(),
+				Dst:      g.G.V().Has("Name", "icmp-intf2", "Type", "internal").String(),
 				SrcIP:    "fd49:37c8:5229::1/48",
 				DstIP:    "fd49:37c8:5229::2/48",
 				Count:    1,
@@ -1092,20 +1050,16 @@ func TestICMP(t *testing.T) {
 		},
 
 		captures: []TestCapture{
-			{gremlin: `G.V().Has('Name', 'br-icmp', 'Type', 'ovsbridge')`},
+			{gremlin: g.G.V().Has("Name", "br-icmp", "Type", "ovsbridge")},
 		},
 
 		// since the agent update ticker is about 10 sec according to the configuration
 		// we should wait 11 sec to have the first update and the MetricRange filled
 		checks: []CheckFunction{func(c *CheckContext) error {
-			prefix := "g"
-			if !c.time.IsZero() {
-				prefix += fmt.Sprintf(".Context(%d)", common.UnixMillis(c.time))
-			}
-			prefix += `.V().Has("Name", "br-icmp", "Type", "ovsbridge")`
+			prefix := g.G.Context(c.time).V().Has("Name", "br-icmp", "Type", "ovsbridge")
 
 			gh := c.gh
-			gremlin := prefix + `.Flows().Has('LayersPath', 'Ethernet/IPv4/ICMPv4', 'ICMP.ID', 123)`
+			gremlin := prefix.Flows().Has("LayersPath", "Ethernet/IPv4/ICMPv4", "ICMP.ID", 123)
 			icmpFlows, err := gh.GetFlows(gremlin)
 			if err != nil {
 				return err
@@ -1115,7 +1069,7 @@ func TestICMP(t *testing.T) {
 				return fmt.Errorf("We should receive one ICMPv4 flow with ID 123, got %s", helper.FlowsToString(icmpFlows))
 			}
 
-			gremlin = prefix + fmt.Sprintf(`.Flows().Has('TrackingID', '%s')`, ipv4TrackingID)
+			gremlin = prefix.Flows().Has("TrackingID", ipv4TrackingID)
 			icmpFlows, err = gh.GetFlows(gremlin)
 			if err != nil {
 				return err
@@ -1125,7 +1079,7 @@ func TestICMP(t *testing.T) {
 				return fmt.Errorf("We should receive one ICMPv4 flow with TrackingID %s, got %s", ipv4TrackingID, helper.FlowsToString(icmpFlows))
 			}
 
-			gremlin = prefix + `.Flows().Has('LayersPath', 'Ethernet/IPv6/ICMPv6', 'ICMP.ID', 456)`
+			gremlin = prefix.Flows().Has("LayersPath", "Ethernet/IPv6/ICMPv6", "ICMP.ID", 456)
 			icmpFlows, err = gh.GetFlows(gremlin)
 			if err != nil {
 				return err
@@ -1135,7 +1089,7 @@ func TestICMP(t *testing.T) {
 				return fmt.Errorf("We should receive one ICMPv6 flow with ID 456, got %s", helper.FlowsToString(icmpFlows))
 			}
 
-			gremlin = prefix + fmt.Sprintf(`.Flows().Has('TrackingID', '%s')`, ipv6TrackingID)
+			gremlin = prefix.Flows().Has("TrackingID", ipv6TrackingID)
 			icmpFlows, err = gh.GetFlows(gremlin)
 			if err != nil {
 				return err
@@ -1247,8 +1201,8 @@ func testFlowTunnel(t *testing.T, bridge string, tunnelType string, ipv6 bool, I
 		},
 
 		captures: []TestCapture{
-			{gremlin: `G.V().Has('Name', 'tunnel-vm1').Out().Has('Name', 'tunnel')`},
-			{gremlin: `G.V().Has('Name', 'tunnel-vm2-eth0')`},
+			{gremlin: g.G.V().Has("Name", "tunnel-vm1").Out().Has("Name", "tunnel")},
+			{gremlin: g.G.V().Has("Name", "tunnel-vm2-eth0")},
 		},
 
 		setupFunction: func(c *TestContext) error {
@@ -1257,13 +1211,9 @@ func testFlowTunnel(t *testing.T, bridge string, tunnelType string, ipv6 bool, I
 		},
 
 		checks: []CheckFunction{func(c *CheckContext) error {
-			prefix := "g"
-			if !c.time.IsZero() {
-				prefix += fmt.Sprintf(".Context(%d)", common.UnixMillis(c.time))
-			}
-
+			prefix := g.G.Context(c.time)
 			gh := c.gh
-			nodes, err := gh.GetNodes(prefix + `.V().Has('Name', 'tunnel-vm1').Out().Has('Name', 'tunnel')`)
+			nodes, err := gh.GetNodes(prefix.V().Has("Name", "tunnel-vm1").Out().Has("Name", "tunnel"))
 			if err != nil {
 				return err
 			}
@@ -1278,7 +1228,7 @@ func testFlowTunnel(t *testing.T, bridge string, tunnelType string, ipv6 bool, I
 				return fmt.Errorf("Node %s has no TID", node.ID)
 			}
 
-			flowsInnerTunnel, err := gh.GetFlows(prefix + fmt.Sprintf(`.Flows().Has("NodeTID", "%s", "Application", "%s")`, tid, icmpVersion))
+			flowsInnerTunnel, err := gh.GetFlows(prefix.Flows().Has("NodeTID", tid, "Application", icmpVersion))
 			if err != nil {
 				return err
 			}
@@ -1288,7 +1238,7 @@ func testFlowTunnel(t *testing.T, bridge string, tunnelType string, ipv6 bool, I
 			}
 
 			trackingID := flowsInnerTunnel[0].TrackingID
-			flowsBridge, err := gh.GetFlows(prefix + fmt.Sprintf(`.V().Has('Name', 'tunnel-vm2-eth0').Flows().Has('TrackingID', '%s', 'Application', '%s').Dedup()`, trackingID, icmpVersion))
+			flowsBridge, err := gh.GetFlows(prefix.V().Has("Name", "tunnel-vm2-eth0").Flows().Has("TrackingID", trackingID, "Application", icmpVersion).Dedup())
 			if err != nil {
 				return err
 			}
@@ -1332,23 +1282,20 @@ func TestReplayCapture(t *testing.T) {
 		},
 
 		captures: []TestCapture{
-			{gremlin: `G.V().Has('Name', 'br-rc', 'Type', 'ovsbridge')`, kind: "pcapsocket"},
+			{gremlin: g.G.V().Has("Name", "br-rc", "Type", "ovsbridge"), kind: "pcapsocket"},
 		},
 
 		checks: []CheckFunction{func(c *CheckContext) error {
-			prefix := "g"
-			if !c.time.IsZero() {
-				prefix += fmt.Sprintf(".Context(%d)", common.UnixMillis(c.time))
-			}
+			prefix := g.G.Context(c.time)
 
 			gh := c.gh
-			gremlin := prefix + ".V().Has('Name', 'br-rc', 'Type', 'ovsbridge').HasKey('TID')"
+			gremlin := prefix.V().Has("Name", "br-rc", "Type", "ovsbridge").HasKey("TID")
 			node, err := gh.GetNode(gremlin)
 			if err != nil {
 				return err
 			}
 
-			gremlin = fmt.Sprintf(prefix+".Flows().Has('NodeTID', '%s')", node.Metadata()["TID"].(string))
+			gremlin = prefix.Flows().Has("NodeTID", node.Metadata()["TID"])
 			flows, err := gh.GetFlows(gremlin)
 			if err != nil {
 				return err
@@ -1358,7 +1305,7 @@ func TestReplayCapture(t *testing.T) {
 				return fmt.Errorf("Wrong number of flows. Expected 5, got %d", len(flows))
 			}
 
-			flows, err = gh.GetFlows(gremlin + ".Has('Application', 'DNS')")
+			flows, err = gh.GetFlows(gremlin.Has("Application", "DNS"))
 			if err != nil {
 				return err
 			}
@@ -1398,7 +1345,7 @@ func TestPcapInject(t *testing.T) {
 		},
 
 		checks: []CheckFunction{func(c *CheckContext) error {
-			flows, _ := c.gh.GetFlows(`G.Context(1454659514).Flows().Has('Application', 'DNS')`)
+			flows, _ := c.gh.GetFlows(g.G.Context(1454659514).Flows().Has("Application", "DNS"))
 			if len(flows) != 2 {
 				return fmt.Errorf("Wrong number of DNS flows. Expected 2, got %d", len(flows))
 			}
@@ -1449,18 +1396,15 @@ func TestFlowVLANSegmentation(t *testing.T) {
 		},
 
 		captures: []TestCapture{
-			{gremlin: `G.V().Has('Name', 'vlan-vm1').Out().Has('Name', 'vlan')`},
-			{gremlin: `G.V().Has('Name', 'vlan-vm2-eth0')`},
+			{gremlin: g.G.V().Has("Name", "vlan-vm1").Out().Has("Name", "vlan")},
+			{gremlin: g.G.V().Has("Name", "vlan-vm2-eth0")},
 		},
 
 		checks: []CheckFunction{func(c *CheckContext) error {
-			prefix := "g"
-			if !c.time.IsZero() {
-				prefix += fmt.Sprintf(".Context(%d)", common.UnixMillis(c.time))
-			}
+			prefix := g.G.Context(c.time)
 
 			gh := c.gh
-			outFlows, err := gh.GetFlows(prefix + `.V().Has('Name', 'vlan-vm2-eth0').Flows().Has('LayersPath', 'Ethernet/Dot1Q/IPv4/ICMPv4')`)
+			outFlows, err := gh.GetFlows(prefix.V().Has("Name", "vlan-vm2-eth0").Flows().Has("LayersPath", "Ethernet/Dot1Q/IPv4/ICMPv4"))
 			if err != nil {
 				return err
 			}
@@ -1473,7 +1417,7 @@ func TestFlowVLANSegmentation(t *testing.T) {
 				return fmt.Errorf("Should have a Vlan ID equal to 8 got: %v", helper.FlowsToString(outFlows))
 			}
 
-			inFlows, err := gh.GetFlows(prefix + `.V().Has('Name', 'vlan').Flows().Has('LayersPath', 'Ethernet/IPv4/ICMPv4')`)
+			inFlows, err := gh.GetFlows(prefix.V().Has("Name", "vlan").Flows().Has("LayersPath", "Ethernet/IPv4/ICMPv4"))
 			if err != nil {
 				return err
 			}
@@ -1522,24 +1466,24 @@ func TestSort(t *testing.T) {
 		},
 
 		settleFunction: func(c *TestContext) (err error) {
-			if _, err = c.gh.GetNode("G.V().Has('Name', 'src1-eth0', 'State', 'UP')"); err != nil {
+			if _, err = c.gh.GetNode(g.G.V().Has("Name", "src1-eth0", "State", "UP")); err != nil {
 				return
 			}
 
-			if _, err = c.gh.GetNode("G.V().Has('Name', 'src2-eth0', 'State', 'UP')"); err != nil {
+			if _, err = c.gh.GetNode(g.G.V().Has("Name", "src2-eth0", "State", "UP")); err != nil {
 				return
 			}
 
-			_, err = c.gh.GetNode("G.V().Has('Name', 'dst-eth0', 'State', 'UP')")
+			_, err = c.gh.GetNode(g.G.V().Has("Name", "dst-eth0", "State", "UP"))
 			return
 		},
 
 		setupFunction: func(c *TestContext) (err error) {
-			if err = ping(t, c, 4, "G.V().Has('Name', 'src1-eth0')", "G.V().Has('Name', 'dst-eth0')", 10, 0); err != nil {
+			if err = ping(t, c, 4, g.G.V().Has("Name", "src1-eth0"), g.G.V().Has("Name", "dst-eth0"), 10, 0); err != nil {
 				return
 			}
 
-			if err = ping(t, c, 4, "G.V().Has('Name', 'src2-eth0')", "G.V().Has('Name', 'dst-eth0')", 20, 0); err != nil {
+			if err = ping(t, c, 4, g.G.V().Has("Name", "src2-eth0"), g.G.V().Has("Name", "dst-eth0"), 20, 0); err != nil {
 				return
 			}
 
@@ -1557,22 +1501,19 @@ func TestSort(t *testing.T) {
 		},
 
 		captures: []TestCapture{
-			{gremlin: `G.V().Has('Name', 'dst-eth0', 'Type', 'veth')`},
+			{gremlin: g.G.V().Has("Name", "dst-eth0", "Type", "veth")},
 		},
 
 		checks: []CheckFunction{func(c *CheckContext) error {
-			g := "g"
-			if !c.time.IsZero() {
-				g += fmt.Sprintf(".Context(%d, %d)", common.UnixMillis(c.time), 60)
-			}
-			gremlin := g + ".Flows().Has('Network', '169.254.34.33').Sort()"
+			prefix := g.G.Context(c.time, 60)
+			gremlin := prefix.Flows().Has("Network", "169.254.34.33").Sort()
 
 			flows, err := c.gh.GetFlows(gremlin)
 			if err != nil {
 				return err
 			}
 			if len(flows) != 2 {
-				flows, _ = c.gh.GetFlows(g + ".Flows()")
+				flows, _ = c.gh.GetFlows(prefix.Flows())
 				return fmt.Errorf("Expected two flow, got %+v", flows)
 			}
 			//check is it in ascending order by Last field
@@ -1580,14 +1521,14 @@ func TestSort(t *testing.T) {
 				return fmt.Errorf("Flows not in expected order, expected ASC got DESC")
 			}
 
-			gremlin = g + ".Flows().Has('Network', '169.254.34.33').Sort(DESC, 'Start')"
+			gremlin = prefix.Flows().Has("Network", "169.254.34.33").Sort(g.DESC, "Start")
 
 			flows, err = c.gh.GetFlows(gremlin)
 			if err != nil {
 				return err
 			}
 			if len(flows) != 2 {
-				flows, _ = c.gh.GetFlows(g + ".Flows()")
+				flows, _ = c.gh.GetFlows(prefix.Flows())
 				return fmt.Errorf("Expected two flow, got %+v", flows)
 			}
 			//check is it in descending order by Start field
@@ -1630,19 +1571,19 @@ func TestFlowSumStep(t *testing.T) {
 		},
 
 		settleFunction: func(c *TestContext) (err error) {
-			if _, err := c.gh.GetNode("G.V().Has('Name', 'intf1', 'State', 'UP')"); err != nil {
+			if _, err := c.gh.GetNode(g.G.V().Has("Name", "intf1", "State", "UP")); err != nil {
 				return err
 			}
 
-			if _, err := c.gh.GetNode("G.V().Has('Name', 'intf2', 'State', 'UP')"); err != nil {
+			if _, err := c.gh.GetNode(g.G.V().Has("Name", "intf2", "State", "UP")); err != nil {
 				return err
 			}
 
-			if _, err := c.gh.GetNode("G.V().Has('Name', 'intf3', 'State', 'UP')"); err != nil {
+			if _, err := c.gh.GetNode(g.G.V().Has("Name", "intf3", "State", "UP")); err != nil {
 				return err
 			}
 
-			nodes, err := c.gh.GetNodes("G.V().Has('Name', 'br-sum').Out().Has('Type', 'ovsport').Dedup()")
+			nodes, err := c.gh.GetNodes(g.G.V().Has("Name", "br-sum").Out().Has("Type", "ovsport").Dedup())
 			if err != nil {
 				return err
 			}
@@ -1655,13 +1596,13 @@ func TestFlowSumStep(t *testing.T) {
 		},
 
 		setupFunction: func(c *TestContext) (err error) {
-			if err = ping(t, c, 4, "G.V().Has('Name', 'intf1')", "G.V().Has('Name', 'intf2')", 3, 0); err != nil {
+			if err = ping(t, c, 4, g.G.V().Has("Name", "intf1"), g.G.V().Has("Name", "intf2"), 3, 0); err != nil {
 				return
 			}
-			if err = ping(t, c, 4, "G.V().Has('Name', 'intf2')", "G.V().Has('Name', 'intf3')", 4, 0); err != nil {
+			if err = ping(t, c, 4, g.G.V().Has("Name", "intf2"), g.G.V().Has("Name", "intf3"), 4, 0); err != nil {
 				return
 			}
-			if err = ping(t, c, 4, "G.V().Has('Name', 'intf1')", "G.V().Has('Name', 'intf3')", 3, 0); err != nil {
+			if err = ping(t, c, 4, g.G.V().Has("Name", "intf1"), g.G.V().Has("Name", "intf3"), 3, 0); err != nil {
 				return
 			}
 			return
@@ -1678,18 +1619,13 @@ func TestFlowSumStep(t *testing.T) {
 		},
 
 		captures: []TestCapture{
-			{gremlin: `G.V().Has('Name', 'br-sum', 'Type', 'ovsbridge')`},
+			{gremlin: g.G.V().Has("Name", "br-sum", "Type", "ovsbridge")},
 		},
 
 		checks: []CheckFunction{func(c *CheckContext) error {
 			gh := c.gh
-			gremlin := "g"
 
-			if !c.time.IsZero() {
-				gremlin += fmt.Sprintf(".Context(%d)", common.UnixMillis(c.time))
-			}
-
-			gremlin += `.V().Has("Name", "br-sum", "Type", "ovsbridge").Flows().Has("LayersPath", "Ethernet/IPv4/ICMPv4").Dedup().Sum("Metric.ABPackets")`
+			gremlin := g.G.Context(c.time).V().Has("Name", "br-sum", "Type", "ovsbridge").Flows().Has("LayersPath", "Ethernet/IPv4/ICMPv4").Dedup().Sum("Metric.ABPackets")
 
 			var s interface{}
 			if err := gh.QueryObject(gremlin, &s); err != nil {
@@ -1728,11 +1664,11 @@ func TestFlowCaptureNodeStep(t *testing.T) {
 		},
 
 		settleFunction: func(c *TestContext) (err error) {
-			if _, err := c.gh.GetNode("G.V().Has('Name', 'intf1', 'State', 'UP')"); err != nil {
+			if _, err := c.gh.GetNode(g.G.V().Has("Name", "intf1", "State", "UP")); err != nil {
 				return err
 			}
 
-			if _, err := c.gh.GetNode("G.V().Has('Name', 'intf2', 'State', 'UP')"); err != nil {
+			if _, err := c.gh.GetNode(g.G.V().Has("Name", "intf2", "State", "UP")); err != nil {
 				return err
 			}
 
@@ -1740,7 +1676,7 @@ func TestFlowCaptureNodeStep(t *testing.T) {
 		},
 
 		setupFunction: func(c *TestContext) (err error) {
-			return ping(t, c, 4, "G.V().Has('Name', 'intf1')", "G.V().Has('Name', 'intf2')", 3, 0)
+			return ping(t, c, 4, g.G.V().Has("Name", "intf1"), g.G.V().Has("Name", "intf2"), 3, 0)
 		},
 
 		tearDownCmds: []helper.Cmd{
@@ -1752,16 +1688,12 @@ func TestFlowCaptureNodeStep(t *testing.T) {
 		},
 
 		captures: []TestCapture{
-			{gremlin: `G.V().Has('Name', 'br-fcn', 'Type', 'ovsbridge')`},
+			{gremlin: g.G.V().Has("Name", "br-fcn", "Type", "ovsbridge")},
 		},
 
 		checks: []CheckFunction{func(c *CheckContext) error {
 			gh := c.gh
-			gremlin := "g"
-			if !c.time.IsZero() {
-				gremlin += fmt.Sprintf(".Context(%d)", common.UnixMillis(c.time))
-			}
-			gremlin += `.Flows().Has("Network", "169.254.38.33").Dedup().CaptureNode()`
+			gremlin := g.G.Context(c.time).Flows().Has("Network", "169.254.38.33").Dedup().CaptureNode()
 
 			nodes, err := gh.GetNodes(gremlin)
 			if err != nil {
@@ -1805,7 +1737,7 @@ func TestFlowsWithShortestPath(t *testing.T) {
 		},
 
 		setupFunction: func(c *TestContext) (err error) {
-			return ping(t, c, 4, "G.V().Has('Name', 'spt-src-eth0')", "G.V().Has('Name', 'spt-dst-eth0')", 10, 0)
+			return ping(t, c, 4, g.G.V().Has("Name", "spt-src-eth0"), g.G.V().Has("Name", "spt-dst-eth0"), 10, 0)
 		},
 
 		tearDownCmds: []helper.Cmd{
@@ -1817,15 +1749,11 @@ func TestFlowsWithShortestPath(t *testing.T) {
 		},
 
 		captures: []TestCapture{
-			{gremlin: `G.V().Has('Name', 'spt-src-eth0').ShortestPathTo(Metadata('Name', 'spt-dst-eth0'), Metadata('RelationType', 'layer2'))`},
+			{gremlin: g.G.V().Has("Name", "spt-src-eth0").ShortestPathTo(g.Metadata("Name", "spt-dst-eth0"), g.Metadata("RelationType", "layer2"))},
 		},
 
 		checks: []CheckFunction{func(c *CheckContext) error {
-			g := "g"
-			if !c.time.IsZero() {
-				g += fmt.Sprintf(".Context(%d)", common.UnixMillis(c.time))
-			}
-			gremlin := g + ".V().Has('Name', 'spt-src-eth0').ShortestPathTo(Metadata('Name', 'spt-dst-eth0'), Metadata('RelationType', 'layer2')).Flows().Has('Network', '169.254.37.33').Dedup()"
+			gremlin := g.G.Context(c.time).V().Has("Name", "spt-src-eth0").ShortestPathTo(g.Metadata("Name", "spt-dst-eth0"), g.Metadata("RelationType", "layer2")).Flows().Has("Network", "169.254.37.33").Dedup()
 			flows, err := c.gh.GetFlows(gremlin)
 			if err != nil {
 				return err
@@ -1840,9 +1768,9 @@ func TestFlowsWithShortestPath(t *testing.T) {
 	RunTest(t, test)
 }
 
-func printRawPackets(t *testing.T, gh *gclient.GremlinQueryHelper, query string) error {
+func printRawPackets(t *testing.T, gh *gclient.GremlinQueryHelper, query g.QueryString) error {
 	header := make(http.Header)
-	resp, err := gh.Request(query, header)
+	resp, err := gh.Request(query.String(), header)
 	if err != nil {
 		return err
 	}
@@ -1860,10 +1788,10 @@ func printRawPackets(t *testing.T, gh *gclient.GremlinQueryHelper, query string)
 	return nil
 }
 
-func getRawPackets(gh *gclient.GremlinQueryHelper, query string) ([]gopacket.Packet, error) {
+func getRawPackets(gh *gclient.GremlinQueryHelper, query g.QueryString) ([]gopacket.Packet, error) {
 	header := make(http.Header)
 	header.Set("Accept", "vnd.tcpdump.pcap")
-	resp, err := gh.Request(query, header)
+	resp, err := gh.Request(query.String(), header)
 	if err != nil {
 		return nil, err
 	}
@@ -1935,12 +1863,12 @@ func TestRawPackets(t *testing.T) {
 
 		checks: []CheckFunction{func(c *CheckContext) error {
 			gh := c.gh
-			node, err := gh.GetNode(`G.At("-1s").V().Has("Name", "rp-vm1-eth0").HasKey("TID")`)
+			node, err := gh.GetNode(g.G.At("-1s").V().Has("Name", "rp-vm1-eth0").HasKey("TID"))
 			if err != nil {
 				return err
 			}
 
-			query := fmt.Sprintf(`G.At("-1s").Flows().Has("NodeTID", "%s", "LayersPath", "Ethernet/IPv4/ICMPv4")`, node.Metadata()["TID"])
+			query := g.G.At("-1s").Flows().Has("NodeTID", node.Metadata()["TID"], "LayersPath", "Ethernet/IPv4/ICMPv4")
 
 			flows, err := gh.GetFlows(query)
 			if err != nil {
@@ -1952,18 +1880,18 @@ func TestRawPackets(t *testing.T) {
 			}
 
 			if flows[0].RawPacketsCaptured != 4 {
-				packets, err := getRawPackets(gh, query+".RawPackets()")
+				packets, err := getRawPackets(gh, query.RawPackets())
 				if err != nil {
 					return err
 				}
 				return fmt.Errorf("Should get 4 raw packets 2 echo/reply: %v, %+v", flows, packets)
 			}
 
-			if err = printRawPackets(t, gh, query+".RawPackets()"); err != nil {
+			if err = printRawPackets(t, gh, query.RawPackets()); err != nil {
 				return nil
 			}
 
-			packets, err := getRawPackets(gh, query+".RawPackets()")
+			packets, err := getRawPackets(gh, query.RawPackets())
 			if err != nil {
 				return err
 			}
@@ -1972,7 +1900,7 @@ func TestRawPackets(t *testing.T) {
 				return fmt.Errorf("Should get 4 pcap raw packets 2 echo/reply: %v, %+v", flows, packets)
 			}
 
-			replyPackets, err := getRawPackets(gh, query+".RawPackets().BPF('icmp[icmptype] == 0')")
+			replyPackets, err := getRawPackets(gh, query.RawPackets().BPF("icmp[icmptype] == 0"))
 			if err != nil {
 				return err
 			}
@@ -2010,7 +1938,7 @@ func TestFlowsWithIpv4Range(t *testing.T) {
 		},
 
 		setupFunction: func(c *TestContext) (err error) {
-			return ping(t, c, 4, "G.V().Has('Name', 'ipr-src-eth0')", "G.V().Has('Name', 'ipr-dst-eth0')", 10, 0)
+			return ping(t, c, 4, g.G.V().Has("Name", "ipr-src-eth0"), g.G.V().Has("Name", "ipr-dst-eth0"), 10, 0)
 		},
 
 		tearDownCmds: []helper.Cmd{
@@ -2022,15 +1950,11 @@ func TestFlowsWithIpv4Range(t *testing.T) {
 		},
 
 		captures: []TestCapture{
-			{gremlin: `G.V().Has('Name', 'ipr-src-eth0')`},
+			{gremlin: g.G.V().Has("Name", "ipr-src-eth0")},
 		},
 
 		checks: []CheckFunction{func(c *CheckContext) error {
-			g := "g"
-			if !c.time.IsZero() {
-				g += fmt.Sprintf(".Context(%d)", common.UnixMillis(c.time))
-			}
-			gremlin := g + ".Flows().Has('Network', Ipv4Range('169.254.40.0/24'))"
+			gremlin := g.G.Context(c.time).Flows().Has("Network", g.Ipv4Range("169.254.40.0/24"))
 			flows, err := c.gh.GetFlows(gremlin)
 			if err != nil {
 				return err
@@ -2063,22 +1987,19 @@ func TestOvsMirror(t *testing.T) {
 		},
 
 		captures: []TestCapture{
-			{gremlin: `g.V().Has("Name", "omir-if1", "Type", "ovsport")`},
+			{gremlin: g.G.V().Has("Name", "omir-if1", "Type", "ovsport")},
 		},
 
 		checks: []CheckFunction{func(c *CheckContext) error {
-			prefix := "g"
-			if !c.time.IsZero() {
-				prefix += fmt.Sprintf(".Context(%d)", common.UnixMillis(c.time))
-			}
+			prefix := g.G.Context(c.time)
 
 			gh := c.gh
-			orig, err := gh.GetNode(prefix + `.V().Has("Name", "omir-if1", "Type", "ovsport")`)
+			orig, err := gh.GetNode(prefix.V().Has("Name", "omir-if1", "Type", "ovsport"))
 			if err != nil {
 				return fmt.Errorf("Unable to find the expected ovsport: %s", err)
 			}
 
-			node, err := gh.GetNode(prefix + `.V().Has("Name", regex("mir.*"), "Type", "internal").HasKey("TID")`)
+			node, err := gh.GetNode(prefix.V().Has("Name", g.StartsWith("mir"), "Type", "internal").HasKey("TID"))
 			if err != nil {
 				return fmt.Errorf("Unable to find the expected Mirror interface: %s", err)
 			}
@@ -2089,14 +2010,14 @@ func TestOvsMirror(t *testing.T) {
 			}
 
 			if mirrorOf != string(orig.ID) {
-				aa, err := gh.GetNode(prefix + `.V("` + mirrorOf + `")`)
+				aa, err := gh.GetNode(prefix.V(mirrorOf))
 				if err != nil {
 					return fmt.Errorf("Unable to find the expected ovsport: %s", err)
 				}
 				return fmt.Errorf("Unable to find expected Mirror information of %v on mirror node %v != %v", orig, node, aa)
 			}
 
-			flows, err := gh.GetFlows(prefix + fmt.Sprintf(`.Flows("NodeTID", "%s", "LayersPath", "Ethernet/ARP")`, node.Metadata()["TID"].(string)))
+			flows, err := gh.GetFlows(prefix.Flows("NodeTID", node.Metadata()["TID"], "LayersPath", "Ethernet/ARP"))
 			if err != nil {
 				return err
 			}

--- a/tests/k8s_test.go
+++ b/tests/k8s_test.go
@@ -99,14 +99,14 @@ func tearDownFromConfigFile(ty, name string) []helper.Cmd {
 	}
 }
 
-func testNodeCreation(t *testing.T, setupCmds, tearDownCmds []helper.Cmd, ty, name g.ValueString) {
+func testNodeCreation(t *testing.T, setupCmds, tearDownCmds []helper.Cmd, ty, name interface{}) {
 	test := &Test{
 		mode:         OneShot,
 		retries:      3,
 		setupCmds:    append(tearDownCmds, setupCmds...),
 		tearDownCmds: tearDownCmds,
 		checks: []CheckFunction{func(c *CheckContext) error {
-			query := g.G.V().Has(g.Quote("Manager"), g.Quote("k8s"), g.Quote("Type"), ty, g.Quote("Name"), name)
+			query := g.G.V().Has("Manager", "k8s", "Type", ty, "Name", name)
 			fmt.Printf("Gremlin Query: %s\n", query)
 
 			nodes, err := c.gh.GetNodes(query.String())
@@ -125,21 +125,21 @@ func testNodeCreation(t *testing.T, setupCmds, tearDownCmds []helper.Cmd, ty, na
 }
 
 func TestK8sContainerNode(t *testing.T) {
-	testNodeCreation(t, setupFromDeploymnet("container"), tearDownFromDeployment("container"), g.Quote("container"), g.Quote(containerName))
+	testNodeCreation(t, setupFromDeploymnet("container"), tearDownFromDeployment("container"), "container", containerName)
 }
 
 func TestK8sPodNode(t *testing.T) {
-	testNodeCreation(t, setupFromDeploymnet("pod"), tearDownFromDeployment("pod"), g.Quote("pod"), g.StartsWith(podName))
+	testNodeCreation(t, setupFromDeploymnet("pod"), tearDownFromDeployment("pod"), "pod", g.StartsWith(podName))
 }
 
 func TestK8sNetworkPolicyNode(t *testing.T) {
-	testNodeCreation(t, setupFromConfigFile("networkpolicy", networkPolicyName), tearDownFromConfigFile("networkpolicy", networkPolicyName), g.Quote("networkpolicy"), g.Quote(networkPolicyName))
+	testNodeCreation(t, setupFromConfigFile("networkpolicy", networkPolicyName), tearDownFromConfigFile("networkpolicy", networkPolicyName), "networkpolicy", networkPolicyName)
 }
 
 func TestK8sNodeNode(t *testing.T) {
-	testNodeCreation(t, nil, nil, g.Quote("node"), g.Quote(nodeName))
+	testNodeCreation(t, nil, nil, "node", nodeName)
 }
 
 func TestK8sNamespaceNode(t *testing.T) {
-	testNodeCreation(t, setupFromConfigFile("namespace", namespaceName), tearDownFromConfigFile("namespace", namespaceName), g.Quote("namespace"), g.Quote(namespaceName))
+	testNodeCreation(t, setupFromConfigFile("namespace", namespaceName), tearDownFromConfigFile("namespace", namespaceName), "namespace", namespaceName)
 }

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -128,7 +128,7 @@ type TestContext struct {
 }
 
 type TestCapture struct {
-	gremlin    string
+	gremlin    g.QueryString
 	kind       string
 	bpf        string
 	rawPackets int
@@ -236,7 +236,7 @@ func RunTest(t *testing.T, test *Test) {
 	}()
 
 	for _, tc := range test.captures {
-		capture := types.NewCapture(tc.gremlin, tc.bpf)
+		capture := types.NewCapture(tc.gremlin.String(), tc.bpf)
 		capture.Type = tc.kind
 		capture.RawPacketLimit = tc.rawPackets
 		if err = client.Create("capture", capture); err != nil {
@@ -385,10 +385,10 @@ func pingRequest(t *testing.T, context *TestContext, packet *types.PacketParamsR
 	return context.client.Create("injectpacket", packet)
 }
 
-func ping(t *testing.T, context *TestContext, ipVersion int, src string, dst string, count int64, id int64) error {
+func ping(t *testing.T, context *TestContext, ipVersion int, src, dst g.QueryString, count int64, id int64) error {
 	packet := &types.PacketParamsReq{
-		Src:      src,
-		Dst:      dst,
+		Src:      src.String(),
+		Dst:      dst.String(),
 		Type:     fmt.Sprintf("icmp%d", ipVersion),
 		Count:    count,
 		ICMPID:   id,

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -36,6 +36,7 @@ import (
 	gclient "github.com/skydive-project/skydive/api/client"
 	"github.com/skydive-project/skydive/api/types"
 	"github.com/skydive-project/skydive/common"
+	g "github.com/skydive-project/skydive/gremlin"
 	shttp "github.com/skydive-project/skydive/http"
 	"github.com/skydive-project/skydive/logging"
 	"github.com/skydive-project/skydive/tests/helper"
@@ -156,10 +157,7 @@ type Test struct {
 }
 
 func (c *TestContext) getWholeGraph(t *testing.T, at time.Time) string {
-	gremlin := "G"
-	if !at.IsZero() {
-		gremlin += fmt.Sprintf(".Context(%d)", common.UnixMillis(at))
-	}
+	gremlin := g.G.V().Context(at)
 
 	switch helper.GraphOutputFormat {
 	case "ascii":
@@ -203,11 +201,7 @@ func (c *TestContext) getWholeGraph(t *testing.T, at time.Time) string {
 }
 
 func (c *TestContext) getAllFlows(t *testing.T, at time.Time) string {
-	gremlin := "G"
-	if !at.IsZero() {
-		gremlin += fmt.Sprintf(".Context(%d)", common.UnixMillis(at))
-	}
-	gremlin += ".V().Flows().Sort()"
+	gremlin := g.G.V().Context(at).Flows().Sort()
 
 	flows, err := c.gh.GetFlows(gremlin)
 	if err != nil {


### PR DESCRIPTION
The effect of this change should be functionality natural in it I extended the gremlins query builder which is essence enabled to replace strings such as:

```
gremlin := fmt.Sprintf(`G.Has("Type", "%s")`, ty)
```

With functions - such as:

```
gremlin := g.G.Has("Type", ty)
``` 