### PR TITLE
'make debug' static assets are loaded from disk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ skydive.yml: etc/skydive.yml.default
 
 .PHONY: debug
 debug: GOFLAGS+=-gcflags='-N -l'
+debug: GO_BINDATA_FLAGS+=-debug
 debug: skydive.cleanup skydive skydive.yml
 
 define skydive_debug


### PR DESCRIPTION
To check the feature:

```
$ cd /home/vagrant/go/src/github.com/skydive-projects/skydive
$ # this binds statics/index.html (and friends) into skydive
$ make                                                

$ # map assets to statics directory as follows
$ vim skydive.yml                                
...
ui:
  assets: /home/vagrant/go/src/github.com/skydive-projects/skydive/statics
...

$ # change the file to *new*
$ vim statics/index.html                                
$ skydive analyzer -c skydive.yml 
$ # check content of index.html is *new*
$ curl localhost:8082                                     
```

