### PR TITLE
ui: fix 'not a function' error

### DIFF
--- a/statics/js/components/capture-list.js
+++ b/statics/js/components/capture-list.js
@@ -2,7 +2,7 @@
 
 var Capture = {
 
-  mixins: [apiMixin],
+  mixins: [apiMixin, notificationMixin],
 
   props: {
 
@@ -120,7 +120,7 @@ var Capture = {
 
 Vue.component('capture-list', {
 
-  mixins: [apiMixin],
+  mixins: [apiMixin, notificationMixin],
 
   components: {
     'capture': Capture,


### PR DESCRIPTION
if any error in capture get, list and delete
we are getting  not a function error for error notification