### PR TITLE
ui: add automatic expand via launching context /topology?expand

### DIFF
--- a/statics/js/components/graph-layout.js
+++ b/statics/js/components/graph-layout.js
@@ -9,7 +9,15 @@ var TopologyGraphLayout = function(vm, selector) {
 
   this.queue = new Queue();
   this.queue.await(function() {
-    if (self.invalid) self.update();
+    if (self.invalid) {
+      if (self._autoExpand) {
+        while (self.toggleCollapseByLevel(false));
+        setTimeout(function() {
+          self.zoomFit();
+        }, 5000);
+      }
+      self.update();
+    }
     self.invalid = false;
   }).start(100);
 
@@ -1021,6 +1029,11 @@ TopologyGraphLayout.prototype = {
     this.update();
   },
 
+  autoExpand: function(auto) {
+    this._autoExpand = auto;
+    this.invalid = true;
+  },
+
   collapse: function(collapse) {
     this.collapsed = collapse;
     this.defaultCollpsed = collapse;
@@ -1040,7 +1053,7 @@ TopologyGraphLayout.prototype = {
   toggleCollapseByLevel: function(collapse) {
     if (collapse) {
       if (this.collapseLevel === 0) {
-        return;
+        return false;
       } else {
         this.collapseLevel--;
       }
@@ -1051,13 +1064,17 @@ TopologyGraphLayout.prototype = {
         var group = this.groups[i];
         if (group.level > maxLevel) maxLevel = group.level;
       }
-      if (maxLevel > 1 && (this.collapseLevel + 1) >= maxLevel) {
-        return;
+      if (maxLevel === 0) {
+        return false;
+      }
+      if ((this.collapseLevel + 1) >= maxLevel) {
+        return false;
       }
 
       this.collapseByLevel(this.collapseLevel, collapse, this.groups);
       this.collapseLevel++;
     }
+    return true;
   },
 
   collapseByLevel: function(level, collapse, groups) {

--- a/statics/js/components/topology.js
+++ b/statics/js/components/topology.js
@@ -236,11 +236,6 @@ var TopologyComponent = {
     }.bind(this));
 
     this.layout = new TopologyGraphLayout(this, ".topology-d3");
-    this.collapse();
-
-    websocket.addConnectHandler(function() {
-      self.collapse();
-    });
 
     this.graph.addHandler(this.layout);
     this.graph.addHandler(this);
@@ -292,6 +287,15 @@ var TopologyComponent = {
 
     if (typeof(this.$route.query.filter) !== "undefined") {
       this.topologyFilter = this.$route.query.filter;
+    }
+
+    if (typeof(this.$route.query.expand) !== "undefined") {
+      this.layout.autoExpand(true);
+    } else {
+      this.collapse();
+      websocket.addConnectHandler(function() {
+        self.collapse();
+      });
     }
 
     websocket.addConnectHandler(function() {


### PR DESCRIPTION
The expected result of launching with "expand" URL parameter is that on when layout is invalid - the following will happen:

- expands all levels
- performs a zoom fit (after some delay)


