### PR TITLE
Fix filename for downloaded capture

### DIFF
--- a/statics/js/api.js
+++ b/statics/js/api.js
@@ -15,7 +15,7 @@ var apiMixin = {
           // the agent
           return self.$downloadRawPackets(UUID, true);
         } else if (this.status === 200) {
-          var filename = UUID + 'pcap';
+          var filename = UUID + '.pcap';
           var type = xhr.getResponseHeader('Content-Type');
 
           var blob = new Blob([this.response], { type: type });


### PR DESCRIPTION
Changes the name from UUIDpcap to UUID.pcap

closes #812