### PR TITLE
Ui link latency 

### DIFF
--- a/statics/js/components/flow-table.js
+++ b/statics/js/components/flow-table.js
@@ -435,7 +435,7 @@ Vue.component('flow-table', {
         {
           name: ['RTT'],
           label: 'RTT ms',
-          show: false,
+          show: true,
         },
       ]
     };

--- a/statics/js/components/graph-layout.js
+++ b/statics/js/components/graph-layout.js
@@ -103,6 +103,14 @@ var LinkLabelLatency = Vue.extend({
       return this.$topologyQuery(query)
     },
 
+    flowQueryByNodeTID: function(nodeTID, limit) {
+      return this.flowQuery(nodeTID, undefined, limit);
+    },
+
+    flowQueryByNodeTIDandTrackingID: function(nodeTID, trackingID) {
+      return this.flowQuery(nodeTID, trackingID, 1);
+    },
+
     updateData: function(link) {
       var self = this;
 
@@ -116,11 +124,11 @@ var LinkLabelLatency = Vue.extend({
         return;
       }
 
-      this.flowQuery(a.TID, undefined, 10)
+      this.flowQueryByNodeTID(a.TID, 10)
         .then(function(flows) {
           for (let i in flows) {
             const aFlow = flows[i];
-            self.flowQuery(b.TID, aFlow.TrackingID, 1)
+            self.flowQueryByNodeTIDandTrackingID(b.TID, aFlow.TrackingID)
               .then(function(flows) {
                 if (flows.length !== 0) {
                   const bFlow = flows[0];

--- a/statics/js/components/graph-layout.js
+++ b/statics/js/components/graph-layout.js
@@ -122,8 +122,8 @@ var LinkLabelLatency = Vue.extend({
             const aFlow = flows[i];
             self.flowQuery(b.TID, aFlow.TrackingID, 1)
               .then(function(flows) {
-                for (let i in flows) {
-                  const bFlow = flows[i];
+                if (flows.length !== 0) {
+                  const bFlow = flows[0];
                   self.updateLatency(link, aFlow, bFlow);
                 }
               })

--- a/statics/js/components/topology.js
+++ b/statics/js/components/topology.js
@@ -299,6 +299,10 @@ var TopologyComponent = {
       });
     }
 
+    if (typeof(this.$route.query.link_label_type) !== "undefined") {
+      this.layout.linkLabelType = this.$route.query.link_label_type;
+    }
+
     websocket.addConnectHandler(function() {
       if (self.topologyFilter !== '') {
         self.topologyFilterQuery();

--- a/tests/selenium_test.go
+++ b/tests/selenium_test.go
@@ -83,8 +83,9 @@ func TestPacketInjectionCapture(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if len(rowData) != 7 {
-			return fmt.Errorf("By default 7 rows should be return, but got: %d", len(rowData))
+		const expectedRowCount = 8
+		if len(rowData) != expectedRowCount {
+			return fmt.Errorf("By default %d rows should be return, but got: %d", expectedRowCount, len(rowData))
 		}
 		txt, err := rowData[1].Text()
 		if err != nil {


### PR DESCRIPTION
Have added option to toggle to latency on link labels.

How to use? for now this is exposed via launch context or URL parameter: `link_label_type=latency` if not specified then the default is `bandwidth` as was before.

The calculation of latency is by calculating the delta between `Math.abs(ANode.RTT-BNode.RTT)/1000`, with the underlying assumption that clocks are synchronized between nodes.

So as not to stress the system only visible nodes which has Capture enabled participate in latency calculation.

A possible test setup:

```
sudo ./scripts/simple.sh start 10.0.0.1/24 10.0.0.2/24
sudo ifconfig vm1-eth0 10.0.0.1
sudo ifconfig vm2-eth0 10.0.0.2
sudo ip netns exec vm1 tc qdisc add dev eth0 root netem delay 100ms
sudo tc qdisc add dev vm1-eth0 root netem delay 200ms
sudo tc qdisc add dev vm2-eth0 root netem delay 400ms
sudo ip netns exec vm2 tc qdisc add dev eth0 root netem delay 800ms
```

You can now inject traffic running:

```
sudo ip netns vm1 ping 10.0.0.2 -c 1
```
