### PR TITLE
ui: hide legend with URL param ?topology_legend_hide=true

### DIFF
--- a/statics/css/legend.css
+++ b/statics/css/legend.css
@@ -10,3 +10,13 @@
   min-width: 200px;
   max-width: 400px;
 }
+
+.topology-legend p {
+  width: 300px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  float: left;
+  clear: both;
+  margin: 0;
+}

--- a/statics/js/components/topology.js
+++ b/statics/js/components/topology.js
@@ -320,6 +320,10 @@ var TopologyComponent = {
       this.layout.linkLabelType = this.$route.query.link_label_type;
     }
 
+    if (typeof(this.$route.query.topology_legend_hide) !== "undefined") {
+      $('.topology-legend').remove();
+    }
+
     websocket.addConnectHandler(function() {
       if (self.topologyFilter !== '') {
         self.topologyFilterQuery();

--- a/statics/js/components/topology.js
+++ b/statics/js/components/topology.js
@@ -12,10 +12,10 @@ var TopologyComponent = {
         <div class="topology-d3">\
           <div class="topology-legend">\
             <strong>Topology view</strong></br>\
-            <span v-if="currTopologyFilter">{{currTopologyFilter}}</span>\
-            <span v-else>Full</span>\
-            <div v-if="topologyHumanTimeContext">{{topologyHumanTimeContext}}</div>\
-            <span v-else>Live</span>\
+            <p v-if="currTopologyFilter">{{currTopologyFilter}}</p>\
+            <p v-else>Full</p>\
+            <p v-if="topologyHumanTimeContext">{{topologyHumanTimeContext}}</p>\
+            <p v-else>Live</p>\
           </div>\
         </div>\
         <div id="topology-options">\
@@ -549,7 +549,7 @@ var TopologyComponent = {
     },
 
     getTopologyAbsTime: function() {
-      
+
       var time = new Date();
       if (this.topologyDate) time = new Date(this.topologyDate);
 


### PR DESCRIPTION
Have added an option to hide via UI parameter the topology legend .. why? because when using very large Gremlin expressions the legend grows and conceals a large part of the topology pane.