### PR TITLE
dependency: gopkg.in/fsnotify.v1 -> github.com/fsnotify/fsnotify

### DIFF
--- a/topology/probes/netns/netns.go
+++ b/topology/probes/netns/netns.go
@@ -35,7 +35,7 @@ import (
 	"syscall"
 	"time"
 
-	"gopkg.in/fsnotify.v1"
+	"github.com/fsnotify/fsnotify"
 
 	"github.com/skydive-project/skydive/common"
 	"github.com/skydive-project/skydive/config"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2437,12 +2437,6 @@
 			"revisionTime": "2016-12-22T12:58:16Z"
 		},
 		{
-			"checksumSHA1": "WCpgePNKiUKt0S0VE/e5kF5OnzU=",
-			"comment": "v1.2.9",
-			"path": "gopkg.in/fsnotify.v1",
-			"revision": "8611c35ab31c1c28aa903d33cf8b6e44a399b09e"
-		},
-		{
 			"checksumSHA1": "1sTwddC+3MJeObnzpIPWnXs6oM4=",
 			"path": "gopkg.in/httprequest.v1",
 			"revision": "93f8fee4081f01ea23d258bdbbcdd319f668d718",


### PR DESCRIPTION

Change as per notice here: https://github.com/go-fsnotify/fsnotify

github.com/fsnotify/fsnotify was already in github.com/fsnotify/fsnotify