### PR TITLE
debian: support multiarchitecture using dpkg-architecture to discover path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ endif
 
 OS_DEB := $(shell test -f /etc/debian_version && echo -n Y)
 ifeq ($(OS_DEB),Y)
-	STATIC_DIR := /usr/lib/x86_64-linux-gnu
+	STATIC_DIR := $(shell dpkg-architecture --command sh -c 'echo /usr/lib/$$DEB_TARGET_MULTIARCH')
 	STATIC_LIBS := \
 		libz.a \
 		liblzma.a \


### PR DESCRIPTION

Was useful to get this running on Power.