### PR TITLE
Fix python2 compatibility with urllib

### DIFF
--- a/contrib/python/api/setup.cfg
+++ b/contrib/python/api/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = skydive-client
 url = https://github.com/skydive-project/skydive
-summary = Skydive Python 3 client library
+summary = Skydive Python client library
 description-file = README.md
 author = Sylvain Afchain
 author-email = safchain@gmail.com

--- a/contrib/python/api/skydive/rest/client.py
+++ b/contrib/python/api/skydive/rest/client.py
@@ -20,7 +20,10 @@
 #
 
 import json
-import urllib.request
+try:
+    import urllib.request as request
+except ImportError:
+    import urllib2 as request
 
 from skydive.graph import Node, Edge
 
@@ -34,10 +37,10 @@ class RESTClient:
         data = json.dumps(
             {"GremlinQuery": gremlin}
         )
-        req = urllib.request.Request("http://%s/api/topology" % self.endpoint,
-                                     data.encode(),
-                                     {'Content-Type': 'application/json'})
-        resp = urllib.request.urlopen(req)
+        req = request.Request("http://%s/api/topology" % self.endpoint,
+                              data.encode(),
+                              {'Content-Type': 'application/json'})
+        resp = request.urlopen(req)
         if resp.getcode() != 200:
             return
 


### PR DESCRIPTION
urllib.request is not supported on Python 2.7, modified to use urllib2
instead.