### PR TITLE
ui: fix NaN error for node bandwidth

### DIFF
--- a/statics/js/components/topology.js
+++ b/statics/js/components/topology.js
@@ -692,7 +692,7 @@ var TopologyComponent = {
     },
 
     normalizeMetric: function(metric) {
-      if (metric.Start && metric.Last) {
+      if (metric.Start && metric.Last && (metric.Last - metric.Start) > 0) {
         bps = Math.floor(1000 * 8 * ((metric.RxBytes || 0) + (metric.TxBytes || 0)) / (metric.Last - metric.Start));
         metric["Bandwidth"] = bandwidthToString(bps);
       }


### PR DESCRIPTION
if the time is converted to string don't
calculate bandwidth to avoid NaN error