### PR TITLE
ansible: use ansible_hostname as host_id

### DIFF
--- a/contrib/ansible/roles/skydive_common/tasks/main.yml
+++ b/contrib/ansible/roles/skydive_common/tasks/main.yml
@@ -39,6 +39,11 @@
 
 - yedit:
     src: "{{ skydive_config_file }}"
+    key: host_id
+    value: "{{ ansible_hostname }}"
+
+- yedit:
+    src: "{{ skydive_config_file }}"
     key: analyzers
     value: "{{ analyzers.split(',') }}"
 


### PR DESCRIPTION
In order to have consistent host name
everywhere, otherwise we may have
fabric links not connected.