### PR TITLE
flow: Added config vars to enable/disable capturing/injection

### DIFF
--- a/analyzer/server.go
+++ b/analyzer/server.go
@@ -231,7 +231,7 @@ func NewServerFromConfig() (*Server, error) {
 		return nil, err
 	}
 
-	captureAPIHandler, err := api.RegisterCaptureAPI(apiServer, g)
+	captureAPIHandler, err := api.RegisterCaptureAPI(apiServer, g, config.GetConfig().GetBool("analyzer.capture_enabled"))
 	if err != nil {
 		return nil, err
 	}
@@ -241,12 +241,12 @@ func NewServerFromConfig() (*Server, error) {
 		return nil, err
 	}
 
-	piAPIHandler, err := api.RegisterPacketInjectorAPI(g, apiServer)
+	piAPIHandler, err := api.RegisterPacketInjectorAPI(g, apiServer, config.GetConfig().GetBool("analyzer.packet_injection_enabled"))
 	if err != nil {
 		return nil, err
 	}
-
 	piClient := packet_injector.NewPacketInjectorClient(agentWSServer, etcdClient, piAPIHandler, g)
+
 	alertAPIHandler, err := api.RegisterAlertAPI(apiServer)
 	if err != nil {
 		return nil, err

--- a/api/server/capture.go
+++ b/api/server/capture.go
@@ -138,7 +138,7 @@ func (c *CaptureAPIHandler) Create(r types.Resource) error {
 }
 
 // RegisterCaptureAPI registers an new resource, capture
-func RegisterCaptureAPI(apiServer *Server, g *graph.Graph) (*CaptureAPIHandler, error) {
+func RegisterCaptureAPI(apiServer *Server, g *graph.Graph, enabled bool) (*CaptureAPIHandler, error) {
 	captureAPIHandler := &CaptureAPIHandler{
 		BasicAPIHandler: BasicAPIHandler{
 			ResourceHandler: &CaptureResourceHandler{},
@@ -146,8 +146,12 @@ func RegisterCaptureAPI(apiServer *Server, g *graph.Graph) (*CaptureAPIHandler, 
 		},
 		Graph: g,
 	}
-	if err := apiServer.RegisterAPIHandler(captureAPIHandler); err != nil {
-		return nil, err
+	if enabled {
+		if err := apiServer.RegisterAPIHandler(captureAPIHandler); err != nil {
+			return nil, err
+		}
+	} else {
+		apiServer.RegisterNotAllowedAPIHandler(captureAPIHandler)
 	}
 	return captureAPIHandler, nil
 }

--- a/api/server/packet_injector.go
+++ b/api/server/packet_injector.go
@@ -131,7 +131,7 @@ func (pi *PacketInjectorAPI) getNode(gremlinQuery string) *graph.Node {
 }
 
 // RegisterPacketInjectorAPI registers a new packet injector resource in the API
-func RegisterPacketInjectorAPI(g *graph.Graph, apiServer *Server) (*PacketInjectorAPI, error) {
+func RegisterPacketInjectorAPI(g *graph.Graph, apiServer *Server, enabled bool) (*PacketInjectorAPI, error) {
 	pia := &PacketInjectorAPI{
 		BasicAPIHandler: BasicAPIHandler{
 			ResourceHandler: &PacketInjectorResourceHandler{},
@@ -140,9 +140,13 @@ func RegisterPacketInjectorAPI(g *graph.Graph, apiServer *Server) (*PacketInject
 		Graph:      g,
 		TrackingId: make(chan string),
 	}
+	if enabled {
+		if err := apiServer.RegisterAPIHandler(pia); err != nil {
+			return nil, err
+		}
 
-	if err := apiServer.RegisterAPIHandler(pia); err != nil {
-		return nil, err
+	} else {
+		apiServer.RegisterNotAllowedAPIHandler(pia)
 	}
 	return pia, nil
 }

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -64,6 +64,13 @@ func writeError(w http.ResponseWriter, status int, err error) {
 	w.Write([]byte(err.Error()))
 }
 
+// RegisterNotAllowedAPIHandler registers a new handler for unpermitted use of API
+func (a *Server) RegisterNotAllowedAPIHandler(handler Handler) {
+	a.HTTPServer.Router.PathPrefix("/api/" + handler.Name()).HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	})
+}
+
 // RegisterAPIHandler registers a new handler for an API
 func (a *Server) RegisterAPIHandler(handler Handler) error {
 	name := handler.Name()

--- a/cmd/client/capture.go
+++ b/cmd/client/capture.go
@@ -29,10 +29,10 @@ import (
 	"github.com/skydive-project/skydive/api/client"
 	api "github.com/skydive-project/skydive/api/types"
 	"github.com/skydive-project/skydive/common"
+	"github.com/skydive-project/skydive/config"
 	"github.com/skydive-project/skydive/flow"
 	"github.com/skydive-project/skydive/logging"
 	"github.com/skydive-project/skydive/validator"
-
 	"github.com/spf13/cobra"
 )
 
@@ -83,8 +83,13 @@ var CaptureCreate = &cobra.Command{
 		capture.Type = captureType
 		capture.Port = port
 		capture.HeaderSize = headerSize
-		capture.RawPacketLimit = rawPacketLimit
 		capture.ExtraTCPMetric = extraTCPMetric
+
+		if !config.GetConfig().GetBool("analyzer.packet_capture_enabled") {
+			capture.RawPacketLimit = 0
+		} else {
+			capture.RawPacketLimit = rawPacketLimit
+		}
 		if err := validator.Validate(capture); err != nil {
 			logging.GetLogger().Error(err.Error())
 			os.Exit(1)

--- a/config/config.go
+++ b/config/config.go
@@ -77,7 +77,10 @@ func init() {
 	cfg.SetDefault("agent.topology.socketinfo.host_update", 10)
 	cfg.SetDefault("agent.X509_servername", "")
 
+	cfg.SetDefault("analyzer.capture_enabled", true)
 	cfg.SetDefault("analyzer.listen", "127.0.0.1:8082")
+	cfg.SetDefault("analyzer.packet_capture_enabled", true)
+	cfg.SetDefault("analyzer.packet_injection_enabled", true)
 	cfg.SetDefault("analyzer.replication.debug", false)
 	cfg.SetDefault("analyzer.ssh_enabled", false)
 	cfg.SetDefault("analyzer.storage.bulk_insert", 100)

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -52,6 +52,12 @@ analyzer:
   # Enable/disable ssh to hosts
   # ssh_enabled: false
 
+  # Enable/disable capturing (enabled by default)
+  # capture_enabled: true
+  # Enable packet capturing (enabled by default)
+  # packet_capture_enabled: true
+  # Enable/disable packet injection (enabled by default)
+  # packet_injection_enabled: true
   # Flow storage engine
   storage:
     # Available: elasticsearch, orientdb

--- a/flow/ondemand/client/client.go
+++ b/flow/ondemand/client/client.go
@@ -100,6 +100,9 @@ func (o *OnDemandProbeClient) registerProbes(nodes []interface{}, capture *types
 	toRegister := func(node *graph.Node, capture *types.Capture) (nodeID graph.Identifier, host string, register bool) {
 		o.graph.RLock()
 		defer o.graph.RUnlock()
+		if !config.GetConfig().GetBool("analyzer.capture_enabled") {
+			return
+		}
 
 		// check not already registered
 		o.RLock()
@@ -149,6 +152,7 @@ func (o *OnDemandProbeClient) registerProbes(nodes []interface{}, capture *types
 }
 
 func (o *OnDemandProbeClient) registerProbe(np nodeProbe) bool {
+
 	cq := ondemand.CaptureQuery{
 		NodeID:  np.id,
 		Capture: *np.capture,
@@ -381,6 +385,10 @@ func (o *OnDemandProbeClient) Stop() {
 
 // InvokeCaptureFromConfig invokes capture based on preconfigured selected SubGraph
 func (o *OnDemandProbeClient) InvokeCaptureFromConfig(ch *api.CaptureAPIHandler) {
+	is_capture_enabled := config.GetConfig().GetBool("analyzer.capture_enabled")
+	if !is_capture_enabled {
+		return
+	}
 	gremlin := config.GetString("analyzer.startup.capture_gremlin")
 	bpf := config.GetString("analyzer.startup.capture_bpf")
 	if gremlin == "" {

--- a/statics/js/api.js
+++ b/statics/js/api.js
@@ -89,6 +89,9 @@ var apiMixin = {
         method: 'GET',
       })
       .fail(function(e) {
+        if (e.status === 405) { // not allowed
+          return $.Deferred().promise([]);
+        }
         self.$error({message: 'Capture list error: ' + e.responseText});
         return e;
       });

--- a/statics/js/components/capture-form.js
+++ b/statics/js/components/capture-form.js
@@ -68,7 +68,7 @@ Vue.component('capture-form', {
                   <label for="capture-header-size">Header Size</label>\
                   <input id="capture-header-size" type="number" class="form-control input-sm" v-model="headerSize" min="0" />\
                 </div>\
-                <div class="form-group">\
+                <div class="form-group" v-if="isPacketCaptureEnabled">\
                   <label for="capture-raw-packets">Raw packets limit</label>\
                   <input id="capture-raw-packets" type="number" class="form-control input-sm" v-model="rawPackets" min="0" max="10"/>\
                 </div>\
@@ -85,13 +85,9 @@ Vue.component('capture-form', {
           <button type="button" class="btn btn-danger" @click="reset">Cancel</button>\
         </form>\
       </div>\
-      <button type="button"\
-              id="create-capture"\
-              class="btn btn-primary"\
-              v-else\
-              @click="visible = !visible">\
-        Create\
-      </button>\
+      <div v-else>\
+        <button type="button" id="create-capture" class="btn btn-primary" @click="visible = !visible"> Create</button>\
+      </div>\
     </transition>\
   ',
 
@@ -113,6 +109,7 @@ Vue.component('capture-form', {
       nodeType: "",
       typeAllowed: false,
       port: 0,
+      isPacketCaptureEnabled: true,
     };
   },
 
@@ -168,6 +165,15 @@ Vue.component('capture-form', {
       }
     }
 
+  },
+
+  mounted: function() {
+    var self = this;
+
+    $.when(this.$getConfigValue('analyzer.packet_capture_enabled').
+      then(function(packetCaptureEnabled) {
+        self.isPacketCaptureEnabled = packetCaptureEnabled;
+    }));
   },
 
   watch: {

--- a/statics/js/components/inject-form.js
+++ b/statics/js/components/inject-form.js
@@ -97,6 +97,7 @@ Vue.component('inject-form', {
   ',
 
   data: function() {
+
     return {
       node1: "",
       node2: "",

--- a/statics/js/components/topology.js
+++ b/statics/js/components/topology.js
@@ -144,12 +144,11 @@ var TopologyComponent = {
       </div>\
       <div id="right-panel" class="col-sm-5 fill">\
         <tabs v-if="isAnalyzer">\
-          <tab-pane title="Captures">\
+          <tab-pane title="Captures" v-if="isCaptureEnabled">\
             <capture-list></capture-list>\
             <capture-form v-if="topologyMode ===  \'live\'"></capture-form>\
           </tab-pane>\
-          <tab-pane title="Generator" v-if="topologyMode ===  \'live\'">\
-            <injection-list></injection-list>\
+          <tab-pane title="Generator" v-if="topologyMode ===  \'live\' && isPacketInjectEnabled">\
             <inject-form></inject-form>\
           </tab-pane>\
           <tab-pane title="Flows">\
@@ -240,6 +239,8 @@ var TopologyComponent = {
       isSSHEnabled: false,
       timeType: "absolute",
       topologyRelTime: "1m",
+      isCaptureEnabled: true,
+      isPacketInjectEnabled: true,
     };
   },
 
@@ -333,6 +334,16 @@ var TopologyComponent = {
     $.when(this.$getConfigValue('analyzer.ssh_enabled').
       then(function(sshEnabled) {
         self.isSSHEnabled = sshEnabled;
+    }));
+
+    $.when(this.$getConfigValue('analyzer.capture_enabled').
+      then(function(captureEnabled) {
+        self.isCaptureEnabled = captureEnabled;
+    }));
+
+    $.when(this.$getConfigValue('analyzer.packet_injection_enabled').
+      then(function(injectEnabled) {
+        self.isPacketInjectEnabled = injectEnabled;
     }));
   },
 


### PR DESCRIPTION
added config variables to enable/disable
traffic capturing and packet injection.
With this configurable limitations Skydive can
be used in two modes: as a sniffering and as
a monitoring tool.

co-author: Sylvain Afchain <safchain@gmail.com>