### PR TITLE
python: use login endpoint for authentication

### DIFF
--- a/contrib/python/api/setup.py
+++ b/contrib/python/api/setup.py
@@ -12,7 +12,7 @@ def get_install_requires():
 
 
 setup(name='skydive-client',
-      version='0.4.2',
+      version='0.4.3',
       description='Skydive Python client library',
       url='http://github.com/skydive-project/skydive',
       author='Sylvain Afchain',


### PR DESCRIPTION
Always use /login endpoint in order to use
a token instead of basic auth.