### PR TITLE
When client is running in a thread, an exception is thrown

### DIFF
--- a/contrib/python/api/skydive/websocket/client.py
+++ b/contrib/python/api/skydive/websocket/client.py
@@ -191,7 +191,12 @@ class WSClient(WebSocketClientProtocol):
         if self.cookies:
             factory.headers['Cookie'] = ';'.join(self.cookies)
 
-        self.loop = asyncio.get_event_loop()
+        try:
+            self.loop = asyncio.get_event_loop()
+        except RuntimeError:
+            self.loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self.loop)
+
         u = urlparse(self.endpoint)
 
         context = None


### PR DESCRIPTION
This is because there is no event_loop in threads by default, and in the
main thread it is created automatically.
This code resolves #929