### PR TITLE
es: support different elasticsearch connections per index

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -161,6 +161,7 @@ func init() {
 	cfg.SetDefault("sflow.port_min", 6345)
 	cfg.SetDefault("sflow.port_max", 6355)
 
+	cfg.SetDefault("storage.elasticsearch.driver", "elasticsearch")
 	cfg.SetDefault("storage.elasticsearch.host", "127.0.0.1:9200")
 	cfg.SetDefault("storage.elasticsearch.maxconns", 10)
 	cfg.SetDefault("storage.elasticsearch.retry", 60)
@@ -169,10 +170,12 @@ func init() {
 	cfg.SetDefault("storage.elasticsearch.index_age_limit", 0)
 	cfg.SetDefault("storage.elasticsearch.index_entries_limit", 0)
 	cfg.SetDefault("storage.elasticsearch.indices_to_keep", 0)
+	cfg.SetDefault("storage.orientdb.driver", "orientdb")
 	cfg.SetDefault("storage.orientdb.addr", "http://localhost:2480")
 	cfg.SetDefault("storage.orientdb.database", "Skydive")
 	cfg.SetDefault("storage.orientdb.username", "root")
 	cfg.SetDefault("storage.orientdb.password", "root")
+	cfg.SetDefault("storage.memory.driver", "memory")
 
 	cfg.SetDefault("ui.theme", "dark")
 	cfg.SetDefault("ui.bandwidth_absolute_active", 1)

--- a/contrib/snort/snortSkydive.go
+++ b/contrib/snort/snortSkydive.go
@@ -223,7 +223,7 @@ func newSnortFlowEnhancer() *SnortFlowEnhancer {
 	mappings := esclient.Mappings{
 		{"snortMessage": []byte(snortMessageMapping)},
 	}
-	cfg := esclient.NewConfig("storage.elasticsearch")
+	cfg := esclient.NewConfig()
 	sfe.client, err = esclient.NewElasticSearchClient("snort", mappings, cfg)
 	if err != nil {
 		if err != io.EOF {

--- a/contrib/snort/snortSkydive.go
+++ b/contrib/snort/snortSkydive.go
@@ -193,11 +193,7 @@ func (sfe *SnortFlowEnhancer) parseSnortCMGX(reader *bufio.Reader) error {
 }
 
 func (sfe *SnortFlowEnhancer) Start() {
-	go sfe.client.Start("snort", []map[string][]byte{
-		{"snortMessage": []byte(snortMessageMapping)}},
-		esclient.ElasticLimits{},
-	)
-
+	go sfe.client.Start()
 	go sfe.run()
 }
 
@@ -224,7 +220,12 @@ func newSnortFlowEnhancer() *SnortFlowEnhancer {
 	sfe.running.Store(true)
 
 	var err error
-	sfe.client, err = esclient.NewElasticSearchClientFromConfig()
+	mappings := esclient.Mappings{
+		{"snortMessage": []byte(snortMessageMapping)},
+	}
+	indexCfg := esclient.NewIndexConfig("storage.elasticsearch")
+	connCfg := esclient.NewConnConfig("storage.elasticsearch")
+	sfe.client, err = esclient.NewElasticSearchClient("snort", mappings, indexCfg, connCfg)
 	if err != nil {
 		if err != io.EOF {
 			logging.GetLogger().Errorf("elasticsearch client error : %v", err)

--- a/contrib/snort/snortSkydive.go
+++ b/contrib/snort/snortSkydive.go
@@ -223,9 +223,8 @@ func newSnortFlowEnhancer() *SnortFlowEnhancer {
 	mappings := esclient.Mappings{
 		{"snortMessage": []byte(snortMessageMapping)},
 	}
-	indexCfg := esclient.NewIndexConfig("storage.elasticsearch")
-	connCfg := esclient.NewConnConfig("storage.elasticsearch")
-	sfe.client, err = esclient.NewElasticSearchClient("snort", mappings, indexCfg, connCfg)
+	cfg := esclient.NewConfig("storage.elasticsearch")
+	sfe.client, err = esclient.NewElasticSearchClient("snort", mappings, cfg)
 	if err != nil {
 		if err != io.EOF {
 			logging.GetLogger().Errorf("elasticsearch client error : %v", err)

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -63,7 +63,7 @@ analyzer:
 
   # Flow storage engine
   flow:
-    # Available: elasticsearch, orientdb
+    # Available: elasticsearch, orientdb, sample
     # backend: elasticsearch
 
     # maximum number of flows aggregated between two data store inserts
@@ -87,7 +87,7 @@ analyzer:
     # indices_to_keep: 0
 
   topology:
-    # graph backend : memory, elasticsearch, orientdb
+    # graph backend : memory, elasticsearch, orientdb, sample
     # backend: memory
 
     # Define static interfaces and links updating Skydive topology
@@ -244,8 +244,14 @@ opencontrail:
   # mpls_udp_port: 51234
 
 storage:
-  # Elasticsearch connection information.
+  # an example for user defined backend 'sample'.
+  # sample:
+  #   driver: elasticsearch, orientdb, memory
+  #   here add driver type specific fields.
+
+  # Elasticsearch backend information.
   elasticsearch:
+    # driver: elasticsearch
     # host: 127.0.0.1:9200
     # maxconns: 10
     # retry: 60
@@ -262,13 +268,18 @@ storage:
     # The number of indices to keep before deleting.
     # A value of 0 specifies no limit (i.e. indices will never be deleted)
     # indices_to_keep: 0
-
-  # OrientDB connection information
+    
+  # OrientDB backend information.
   orientdb:
+    # driver: orientdb
     # addr: http://127.0.0.1:2480
     # database: Skydive
     # username: root
     # password: hello
+
+  # Memory backend information.
+  memory:
+    # driver: memory
 
 logging:
   # level: INFO

--- a/flow/storage/elasticsearch/elasticsearch.go
+++ b/flow/storage/elasticsearch/elasticsearch.go
@@ -446,13 +446,7 @@ func (c *ElasticSearchStorage) SearchFlows(fsq filters.SearchQuery) (*flow.FlowS
 
 // Start the Database client
 func (c *ElasticSearchStorage) Start() {
-	limits := esclient.NewElasticLimitsFromConfig("analyzer.flow")
-	go c.client.Start("flows", []map[string][]byte{
-		{"metric": []byte(metricMapping)},
-		{"rawpacket": []byte(rawPacketMapping)},
-		{"flow": []byte(flowMapping)}},
-		limits,
-	)
+	go c.client.Start()
 }
 
 // Stop the Database client
@@ -462,7 +456,14 @@ func (c *ElasticSearchStorage) Stop() {
 
 // New creates a new ElasticSearch database client
 func New() (*ElasticSearchStorage, error) {
-	client, err := esclient.NewElasticSearchClientFromConfig()
+	indexCfg := esclient.NewIndexConfig("analyzer.flow")
+	connCfg := esclient.NewConnConfig("storage.elasticsearch")
+	mappings := esclient.Mappings{
+		{"metric": []byte(metricMapping)},
+		{"rawpacket": []byte(rawPacketMapping)},
+		{"flow": []byte(flowMapping)},
+	}
+	client, err := esclient.NewElasticSearchClient("flows", mappings, indexCfg, connCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/flow/storage/elasticsearch/elasticsearch.go
+++ b/flow/storage/elasticsearch/elasticsearch.go
@@ -456,14 +456,13 @@ func (c *ElasticSearchStorage) Stop() {
 
 // New creates a new ElasticSearch database client
 func New() (*ElasticSearchStorage, error) {
-	indexCfg := esclient.NewIndexConfig("analyzer.flow")
-	connCfg := esclient.NewConnConfig("storage.elasticsearch")
+	cfg := esclient.NewConfig("storage.elasticsearch")
 	mappings := esclient.Mappings{
 		{"metric": []byte(metricMapping)},
 		{"rawpacket": []byte(rawPacketMapping)},
 		{"flow": []byte(flowMapping)},
 	}
-	client, err := esclient.NewElasticSearchClient("flows", mappings, indexCfg, connCfg)
+	client, err := esclient.NewElasticSearchClient("flows", mappings, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/flow/storage/elasticsearch/elasticsearch.go
+++ b/flow/storage/elasticsearch/elasticsearch.go
@@ -455,8 +455,8 @@ func (c *ElasticSearchStorage) Stop() {
 }
 
 // New creates a new ElasticSearch database client
-func New() (*ElasticSearchStorage, error) {
-	cfg := esclient.NewConfig("storage.elasticsearch")
+func New(backend string) (*ElasticSearchStorage, error) {
+	cfg := esclient.NewConfig(backend)
 	mappings := esclient.Mappings{
 		{"metric": []byte(metricMapping)},
 		{"rawpacket": []byte(rawPacketMapping)},

--- a/flow/storage/orientdb/orientdb.go
+++ b/flow/storage/orientdb/orientdb.go
@@ -378,11 +378,12 @@ func (c *OrientDBStorage) Close() {
 }
 
 // New creates a new OrientDB database client
-func New() (*OrientDBStorage, error) {
-	addr := config.GetString("storage.orientdb.addr")
-	database := config.GetString("storage.orientdb.database")
-	username := config.GetString("storage.orientdb.username")
-	password := config.GetString("storage.orientdb.password")
+func New(backend string) (*OrientDBStorage, error) {
+	path := "storage." + backend
+	addr := config.GetString(path + ".addr")
+	database := config.GetString(path + ".database")
+	username := config.GetString(path + ".username")
+	password := config.GetString(path + ".password")
 
 	client, err := orient.NewClient(addr, database, username, password)
 	if err != nil {

--- a/flow/storage/storage.go
+++ b/flow/storage/storage.go
@@ -52,14 +52,15 @@ type Storage interface {
 
 // NewStorage creates a new flow storage based on the backend
 func NewStorage(backend string) (s Storage, err error) {
-	switch backend {
+	driver := config.GetString("storage." + backend + ".driver")
+	switch driver {
 	case "elasticsearch":
-		s, err = elasticsearch.New()
+		s, err = elasticsearch.New(backend)
 		if err != nil {
 			logging.GetLogger().Fatalf("Can't connect to ElasticSearch server: %v", err)
 		}
 	case "orientdb":
-		s, err = orientdb.New()
+		s, err = orientdb.New(backend)
 		if err != nil {
 			logging.GetLogger().Fatalf("Can't connect to OrientDB server: %v", err)
 		}
@@ -67,7 +68,7 @@ func NewStorage(backend string) (s Storage, err error) {
 		logging.GetLogger().Infof("Using no storage")
 		return
 	default:
-		err = fmt.Errorf("Storage type unknown: %s", backend)
+		err = fmt.Errorf("Flow backend driver '%s' not supported", driver)
 		logging.GetLogger().Critical(err.Error())
 		return
 	}

--- a/storage/elasticsearch/client.go
+++ b/storage/elasticsearch/client.go
@@ -59,8 +59,15 @@ type Config struct {
 	IndicesLimit int
 }
 
-func NewConfig(path string) Config {
+func NewConfig(name ...string) Config {
 	cfg := Config{}
+
+	path := "storage."
+	if len(name) > 0 {
+		path += name[0]
+	} else {
+		path += "elasticsearch"
+	}
 
 	cfg.ElasticHost = config.GetString(path + ".host")
 	cfg.MaxConns = config.GetInt(path + ".maxconns")

--- a/storage/elasticsearch/elasticsearch_test.go
+++ b/storage/elasticsearch/elasticsearch_test.go
@@ -27,121 +27,122 @@ const testMapping = `
 }`
 
 func (c *ElasticSearchClient) indexEntry(id int) (bool, error) {
-	return c.Index("test_type", fmt.Sprintf("id%d", id), "{\"key\": \"val\"}")
+	return c.Index("test_type", fmt.Sprintf("id%d", id), `{"key": "val"}`)
 }
 
-func (c *ElasticSearchClient) cleanupIndices(name string) error {
-	if _, err := c.connection.DeleteIndex(fmt.Sprintf("%s_%s*", indexPrefix, name)); err != nil {
+func (c *ElasticSearchClient) cleanupIndices() error {
+	if _, err := c.connection.DeleteIndex(fmt.Sprintf("%s_%s*", indexPrefix, c.name)); err != nil {
 		return fmt.Errorf(fmt.Sprintf("Failed to clear test indices: %s", err.Error()))
 	}
 	return nil
 }
 
-func getClient(name string, limits ElasticLimits, mappings []map[string][]byte) (*ElasticSearchClient, error) {
-	client, err := NewElasticSearchClientFromConfig()
+func getClient(name string, indexCfg IndexConfig, mappings Mappings) (*ElasticSearchClient, error) {
+	connCfg := NewConnConfig("storage.elasticsearch")
+	client, err := NewElasticSearchClient(name, mappings, indexCfg, connCfg)
 	if err != nil {
 		return nil, err
 	}
-	if err := client.cleanupIndices(name); err != nil {
+	if err := client.cleanupIndices(); err != nil {
 		return nil, err
 	}
-	client.Start(name, mappings, limits)
+	client.Start()
 
 	return client, nil
 }
 
 // test rolling elasticsearch indices based on count limit
 func TestElasticsearchShouldRollByCount(t *testing.T) {
-	limits := ElasticLimits{}
-	limits.EntriesLimit = 5
+	indexCfg := IndexConfig{}
+	indexCfg.EntriesLimit = 5
 
 	name := "should_roll_by_count_test"
 
-	client, err := getClient(name, limits, []map[string][]byte{})
+	client, err := getClient(name, indexCfg, Mappings{})
 	if err != nil {
 		t.Fatalf("Initialisation error: %s", err.Error())
 	}
 
-	for i := 1; i < limits.EntriesLimit; i++ {
+	for i := 1; i < indexCfg.EntriesLimit; i++ {
 		if _, err := client.indexEntry(i); err != nil {
 			t.Fatalf("Failed to index entry %d: %s", i, err.Error())
 		}
 		time.Sleep(1 * time.Second)
 		if client.shouldRollIndex() {
-			t.Fatalf("Index should not have rolled after %d entries (limit is %d)", i, limits.EntriesLimit)
+			t.Fatalf("Index should not have rolled after %d entries (limit is %d)", i, indexCfg.EntriesLimit)
 		}
 	}
 
-	if _, err = client.indexEntry(limits.EntriesLimit); err != nil {
-		t.Fatalf("Failed to index entry %d: %s", limits.EntriesLimit, err.Error())
+	if _, err = client.indexEntry(indexCfg.EntriesLimit); err != nil {
+		t.Fatalf("Failed to index entry %d: %s", indexCfg.EntriesLimit, err.Error())
 	}
 	time.Sleep(1 * time.Second)
 	if !client.shouldRollIndex() {
-		t.Fatalf("Index should have rolled after %d entries", limits.EntriesLimit)
+		t.Fatalf("Index should have rolled after %d entries", indexCfg.EntriesLimit)
 	}
 
-	if err := client.cleanupIndices(name); err != nil {
+	if err := client.cleanupIndices(); err != nil {
 		t.Fatalf(err.Error())
 	}
 }
 
 // test rolling elasticsearch indices based on age limit
 func TestElasticsearchShouldRollByAge(t *testing.T) {
-	limits := ElasticLimits{}
-	limits.AgeLimit = 5
+	indexCfg := IndexConfig{}
+	indexCfg.AgeLimit = 5
 	name := "should_roll_by_age_test"
 
-	client, err := getClient(name, limits, []map[string][]byte{})
+	client, err := getClient(name, indexCfg, Mappings{})
 	if err != nil {
 		t.Fatalf("Initialisation error: %s", err.Error())
 	}
 
-	time.Sleep(time.Duration(limits.AgeLimit-2) * time.Second)
+	time.Sleep(time.Duration(indexCfg.AgeLimit-2) * time.Second)
 	if client.shouldRollIndex() {
-		t.Fatalf("Index should not have rolled after %d seconds (limit is %d)", limits.AgeLimit-2, limits.AgeLimit)
+		t.Fatalf("Index should not have rolled after %d seconds (limit is %d)", indexCfg.AgeLimit-2, indexCfg.AgeLimit)
 	}
 
 	time.Sleep(4 * time.Second)
 	if !client.shouldRollIndex() {
-		t.Fatalf("Index should not have rolled after %d seconds (limit is %d)", limits.AgeLimit+2, limits.AgeLimit)
+		t.Fatalf("Index should not have rolled after %d seconds (limit is %d)", indexCfg.AgeLimit+2, indexCfg.AgeLimit)
 	}
 
-	if err := client.cleanupIndices(name); err != nil {
+	if err := client.cleanupIndices(); err != nil {
 		t.Fatalf(err.Error())
 	}
 }
 
 // test deletion of rolling elasticsearch indices
 func TestElasticsearchDelIndices(t *testing.T) {
-	limits := ElasticLimits{}
-	limits.IndicesLimit = 5
+	indexCfg := IndexConfig{}
+	indexCfg.IndicesLimit = 5
 	name := "del_indices_test"
 
-	client, err := getClient(name, limits, []map[string][]byte{})
+	client, err := getClient(name, indexCfg, Mappings{})
 	if err != nil {
 		t.Fatalf("Initialisation error: %s", err.Error())
 	}
 	firstIndex := client.index.path
 	time.Sleep(1 * time.Second)
 
-	for i := 1; i < limits.IndicesLimit; i++ {
+	for i := 1; i < indexCfg.IndicesLimit; i++ {
 		if err := client.RollIndex(); err != nil {
 			t.Fatalf("Failed to roll index %d: %s", i, err.Error())
 		}
 		time.Sleep(1 * time.Second)
 		indices := client.connection.GetCatIndexInfo(client.GetIndexAlias() + "_*")
 		if len(indices) != i+1 {
-			t.Fatalf("Should have had %d indices after %d rolls (limit is %d), but have %d", i+1, i, limits.IndicesLimit, len(indices))
+			t.Fatalf("Should have had %d indices after %d rolls (limit is %d), but have %d", i+1, i, indexCfg.IndicesLimit, len(indices))
 		}
 	}
 
 	if err = client.RollIndex(); err != nil {
-		t.Fatalf("Failed to roll index %d: %s", limits.IndicesLimit, err.Error())
+		t.Fatalf("Failed to roll index %d: %s", indexCfg.IndicesLimit, err.Error())
 	}
 	time.Sleep(1 * time.Second)
 	indices := client.connection.GetCatIndexInfo(client.GetIndexAlias() + "_*")
-	if len(indices) != limits.IndicesLimit {
-		t.Fatalf("Should have had %d indices after %d rolls (limit is %d), but have %d", limits.IndicesLimit, limits.IndicesLimit, limits.IndicesLimit, len(indices))
+	if len(indices) != indexCfg.IndicesLimit {
+		t.Fatalf("Should have had %d indices after %d rolls (limit is %d), but have %d", indexCfg.IndicesLimit, indexCfg.IndicesLimit, indexCfg.IndicesLimit, len(indices))
 	}
 
 	for _, esIndex := range indices {
@@ -150,7 +151,7 @@ func TestElasticsearchDelIndices(t *testing.T) {
 		}
 	}
 
-	if err := client.cleanupIndices(name); err != nil {
+	if err := client.cleanupIndices(); err != nil {
 		t.Fatalf(err.Error())
 	}
 
@@ -158,11 +159,11 @@ func TestElasticsearchDelIndices(t *testing.T) {
 
 // test mappings before and after rolling elasticsearch indices
 func TestElasticsearchMappings(t *testing.T) {
-	limits := ElasticLimits{}
+	indexCfg := IndexConfig{}
 	name := "mappings_test"
 	mapKey := "testmap"
 
-	client, err := getClient(name, limits, []map[string][]byte{{mapKey: []byte(testMapping)}})
+	client, err := getClient(name, indexCfg, Mappings{{mapKey: []byte(testMapping)}})
 	if err != nil {
 		t.Fatalf("Initialisation error: %s", err.Error())
 	}
@@ -191,7 +192,7 @@ func TestElasticsearchMappings(t *testing.T) {
 		}
 	}
 
-	if err := client.cleanupIndices(name); err != nil {
+	if err := client.cleanupIndices(); err != nil {
 		t.Fatalf(err.Error())
 	}
 }

--- a/storage/elasticsearch/elasticsearch_test.go
+++ b/storage/elasticsearch/elasticsearch_test.go
@@ -37,9 +37,8 @@ func (c *ElasticSearchClient) cleanupIndices() error {
 	return nil
 }
 
-func getClient(name string, indexCfg IndexConfig, mappings Mappings) (*ElasticSearchClient, error) {
-	connCfg := NewConnConfig("storage.elasticsearch")
-	client, err := NewElasticSearchClient(name, mappings, indexCfg, connCfg)
+func getClient(name string, mappings Mappings, cfg Config) (*ElasticSearchClient, error) {
+	client, err := NewElasticSearchClient(name, mappings, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -53,32 +52,32 @@ func getClient(name string, indexCfg IndexConfig, mappings Mappings) (*ElasticSe
 
 // test rolling elasticsearch indices based on count limit
 func TestElasticsearchShouldRollByCount(t *testing.T) {
-	indexCfg := IndexConfig{}
-	indexCfg.EntriesLimit = 5
+	cfg := NewConfig("storage.elasticsearch")
+	cfg.EntriesLimit = 5
 
 	name := "should_roll_by_count_test"
 
-	client, err := getClient(name, indexCfg, Mappings{})
+	client, err := getClient(name, Mappings{}, cfg)
 	if err != nil {
 		t.Fatalf("Initialisation error: %s", err.Error())
 	}
 
-	for i := 1; i < indexCfg.EntriesLimit; i++ {
+	for i := 1; i < cfg.EntriesLimit; i++ {
 		if _, err := client.indexEntry(i); err != nil {
 			t.Fatalf("Failed to index entry %d: %s", i, err.Error())
 		}
 		time.Sleep(1 * time.Second)
 		if client.shouldRollIndex() {
-			t.Fatalf("Index should not have rolled after %d entries (limit is %d)", i, indexCfg.EntriesLimit)
+			t.Fatalf("Index should not have rolled after %d entries (limit is %d)", i, cfg.EntriesLimit)
 		}
 	}
 
-	if _, err = client.indexEntry(indexCfg.EntriesLimit); err != nil {
-		t.Fatalf("Failed to index entry %d: %s", indexCfg.EntriesLimit, err.Error())
+	if _, err = client.indexEntry(cfg.EntriesLimit); err != nil {
+		t.Fatalf("Failed to index entry %d: %s", cfg.EntriesLimit, err.Error())
 	}
 	time.Sleep(1 * time.Second)
 	if !client.shouldRollIndex() {
-		t.Fatalf("Index should have rolled after %d entries", indexCfg.EntriesLimit)
+		t.Fatalf("Index should have rolled after %d entries", cfg.EntriesLimit)
 	}
 
 	if err := client.cleanupIndices(); err != nil {
@@ -88,23 +87,23 @@ func TestElasticsearchShouldRollByCount(t *testing.T) {
 
 // test rolling elasticsearch indices based on age limit
 func TestElasticsearchShouldRollByAge(t *testing.T) {
-	indexCfg := IndexConfig{}
-	indexCfg.AgeLimit = 5
+	cfg := NewConfig("storage.elasticsearch")
+	cfg.AgeLimit = 5
 	name := "should_roll_by_age_test"
 
-	client, err := getClient(name, indexCfg, Mappings{})
+	client, err := getClient(name, Mappings{}, cfg)
 	if err != nil {
 		t.Fatalf("Initialisation error: %s", err.Error())
 	}
 
-	time.Sleep(time.Duration(indexCfg.AgeLimit-2) * time.Second)
+	time.Sleep(time.Duration(cfg.AgeLimit-2) * time.Second)
 	if client.shouldRollIndex() {
-		t.Fatalf("Index should not have rolled after %d seconds (limit is %d)", indexCfg.AgeLimit-2, indexCfg.AgeLimit)
+		t.Fatalf("Index should not have rolled after %d seconds (limit is %d)", cfg.AgeLimit-2, cfg.AgeLimit)
 	}
 
 	time.Sleep(4 * time.Second)
 	if !client.shouldRollIndex() {
-		t.Fatalf("Index should not have rolled after %d seconds (limit is %d)", indexCfg.AgeLimit+2, indexCfg.AgeLimit)
+		t.Fatalf("Index should not have rolled after %d seconds (limit is %d)", cfg.AgeLimit+2, cfg.AgeLimit)
 	}
 
 	if err := client.cleanupIndices(); err != nil {
@@ -114,35 +113,35 @@ func TestElasticsearchShouldRollByAge(t *testing.T) {
 
 // test deletion of rolling elasticsearch indices
 func TestElasticsearchDelIndices(t *testing.T) {
-	indexCfg := IndexConfig{}
-	indexCfg.IndicesLimit = 5
+	cfg := NewConfig("storage.elasticsearch")
+	cfg.IndicesLimit = 5
 	name := "del_indices_test"
 
-	client, err := getClient(name, indexCfg, Mappings{})
+	client, err := getClient(name, Mappings{}, cfg)
 	if err != nil {
 		t.Fatalf("Initialisation error: %s", err.Error())
 	}
 	firstIndex := client.index.path
 	time.Sleep(1 * time.Second)
 
-	for i := 1; i < indexCfg.IndicesLimit; i++ {
+	for i := 1; i < cfg.IndicesLimit; i++ {
 		if err := client.RollIndex(); err != nil {
 			t.Fatalf("Failed to roll index %d: %s", i, err.Error())
 		}
 		time.Sleep(1 * time.Second)
 		indices := client.connection.GetCatIndexInfo(client.GetIndexAlias() + "_*")
 		if len(indices) != i+1 {
-			t.Fatalf("Should have had %d indices after %d rolls (limit is %d), but have %d", i+1, i, indexCfg.IndicesLimit, len(indices))
+			t.Fatalf("Should have had %d indices after %d rolls (limit is %d), but have %d", i+1, i, cfg.IndicesLimit, len(indices))
 		}
 	}
 
 	if err = client.RollIndex(); err != nil {
-		t.Fatalf("Failed to roll index %d: %s", indexCfg.IndicesLimit, err.Error())
+		t.Fatalf("Failed to roll index %d: %s", cfg.IndicesLimit, err.Error())
 	}
 	time.Sleep(1 * time.Second)
 	indices := client.connection.GetCatIndexInfo(client.GetIndexAlias() + "_*")
-	if len(indices) != indexCfg.IndicesLimit {
-		t.Fatalf("Should have had %d indices after %d rolls (limit is %d), but have %d", indexCfg.IndicesLimit, indexCfg.IndicesLimit, indexCfg.IndicesLimit, len(indices))
+	if len(indices) != cfg.IndicesLimit {
+		t.Fatalf("Should have had %d indices after %d rolls (limit is %d), but have %d", cfg.IndicesLimit, cfg.IndicesLimit, cfg.IndicesLimit, len(indices))
 	}
 
 	for _, esIndex := range indices {
@@ -159,11 +158,11 @@ func TestElasticsearchDelIndices(t *testing.T) {
 
 // test mappings before and after rolling elasticsearch indices
 func TestElasticsearchMappings(t *testing.T) {
-	indexCfg := IndexConfig{}
+	cfg := NewConfig("storage.elasticsearch")
 	name := "mappings_test"
 	mapKey := "testmap"
 
-	client, err := getClient(name, indexCfg, Mappings{{mapKey: []byte(testMapping)}})
+	client, err := getClient(name, Mappings{{mapKey: []byte(testMapping)}}, cfg)
 	if err != nil {
 		t.Fatalf("Initialisation error: %s", err.Error())
 	}

--- a/storage/elasticsearch/elasticsearch_test.go
+++ b/storage/elasticsearch/elasticsearch_test.go
@@ -52,7 +52,7 @@ func getClient(name string, mappings Mappings, cfg Config) (*ElasticSearchClient
 
 // test rolling elasticsearch indices based on count limit
 func TestElasticsearchShouldRollByCount(t *testing.T) {
-	cfg := NewConfig("storage.elasticsearch")
+	cfg := NewConfig()
 	cfg.EntriesLimit = 5
 
 	name := "should_roll_by_count_test"
@@ -87,7 +87,7 @@ func TestElasticsearchShouldRollByCount(t *testing.T) {
 
 // test rolling elasticsearch indices based on age limit
 func TestElasticsearchShouldRollByAge(t *testing.T) {
-	cfg := NewConfig("storage.elasticsearch")
+	cfg := NewConfig()
 	cfg.AgeLimit = 5
 	name := "should_roll_by_age_test"
 
@@ -113,7 +113,7 @@ func TestElasticsearchShouldRollByAge(t *testing.T) {
 
 // test deletion of rolling elasticsearch indices
 func TestElasticsearchDelIndices(t *testing.T) {
-	cfg := NewConfig("storage.elasticsearch")
+	cfg := NewConfig()
 	cfg.IndicesLimit = 5
 	name := "del_indices_test"
 
@@ -158,7 +158,7 @@ func TestElasticsearchDelIndices(t *testing.T) {
 
 // test mappings before and after rolling elasticsearch indices
 func TestElasticsearchMappings(t *testing.T) {
-	cfg := NewConfig("storage.elasticsearch")
+	cfg := NewConfig()
 	name := "mappings_test"
 	mapKey := "testmap"
 

--- a/topology/graph/elasticsearch.go
+++ b/topology/graph/elasticsearch.go
@@ -622,8 +622,8 @@ func newElasticSearchBackend(client elasticsearch.ElasticSearchClientInterface) 
 }
 
 // NewElasticSearchBackendFromConfig creates a new graph backend based on configuration file parameters
-func NewElasticSearchBackendFromConfig() (*ElasticSearchBackend, error) {
-	cfg := elasticsearch.NewConfig("storage.elasticsearch")
+func NewElasticSearchBackendFromConfig(backend string) (*ElasticSearchBackend, error) {
+	cfg := elasticsearch.NewConfig(backend)
 	mappings := elasticsearch.Mappings{
 		{"node": []byte(graphElementMapping)},
 		{"edge": []byte(graphElementMapping)},

--- a/topology/graph/elasticsearch.go
+++ b/topology/graph/elasticsearch.go
@@ -623,13 +623,12 @@ func newElasticSearchBackend(client elasticsearch.ElasticSearchClientInterface) 
 
 // NewElasticSearchBackendFromConfig creates a new graph backend based on configuration file parameters
 func NewElasticSearchBackendFromConfig() (*ElasticSearchBackend, error) {
-	indexCfg := elasticsearch.NewIndexConfig("storage.elasticsearch")
-	connCfg := elasticsearch.NewConnConfig("storage.elasticsearch")
+	cfg := elasticsearch.NewConfig("storage.elasticsearch")
 	mappings := elasticsearch.Mappings{
 		{"node": []byte(graphElementMapping)},
 		{"edge": []byte(graphElementMapping)},
 	}
-	client, err := elasticsearch.NewElasticSearchClient("topology", mappings, indexCfg, connCfg)
+	client, err := elasticsearch.NewElasticSearchClient("topology", mappings, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/topology/graph/elasticsearch_test.go
+++ b/topology/graph/elasticsearch_test.go
@@ -509,7 +509,7 @@ func initBackend(cfg elasticsearch.Config, name string) (*ElasticSearchBackend, 
 
 // test active nodes after rolling elasticsearch indices
 func TestElasticsearcActiveNodes(t *testing.T) {
-	cfg := elasticsearch.NewConfig("storage.elasticsearch")
+	cfg := elasticsearch.NewConfig()
 	cfg.EntriesLimit = 10
 	name := "test_nodes"
 	if err := delTestIndex(name); err != nil {
@@ -544,7 +544,7 @@ func TestElasticsearcActiveNodes(t *testing.T) {
 
 // test active edges after rolling elasticsearch indices
 func TestElasticsearcActiveEdges(t *testing.T) {
-	cfg := elasticsearch.NewConfig("storage.elasticsearch")
+	cfg := elasticsearch.NewConfig()
 	cfg.EntriesLimit = 10
 	name := "test_edges"
 	if err := delTestIndex(name); err != nil {

--- a/topology/graph/elasticsearch_test.go
+++ b/topology/graph/elasticsearch_test.go
@@ -486,16 +486,15 @@ func delTestIndex(name string) error {
 	return nil
 }
 
-func initBackend(indexCfg elasticsearch.IndexConfig, name string) (*ElasticSearchBackend, error) {
+func initBackend(cfg elasticsearch.Config, name string) (*ElasticSearchBackend, error) {
 	mappings := elasticsearch.Mappings{
 		{"node": []byte(graphElementMapping)},
 		{"edge": []byte(graphElementMapping)},
 	}
 
-	connCfg := elasticsearch.NewConnConfig("storage.elasticsearch")
-	connCfg.BulkMaxDocs = 1
+	cfg.BulkMaxDocs = 1
 
-	client, err := elasticsearch.NewElasticSearchClient(name, mappings, indexCfg, connCfg)
+	client, err := elasticsearch.NewElasticSearchClient(name, mappings, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -510,14 +509,14 @@ func initBackend(indexCfg elasticsearch.IndexConfig, name string) (*ElasticSearc
 
 // test active nodes after rolling elasticsearch indices
 func TestElasticsearcActiveNodes(t *testing.T) {
-	indexCfg := elasticsearch.NewIndexConfig("storage.elasticsearch")
-	indexCfg.EntriesLimit = 10
+	cfg := elasticsearch.NewConfig("storage.elasticsearch")
+	cfg.EntriesLimit = 10
 	name := "test_nodes"
 	if err := delTestIndex(name); err != nil {
 		t.Fatalf("Failed to clear test indices: %s", err.Error())
 	}
 
-	backend, err := initBackend(indexCfg, name)
+	backend, err := initBackend(cfg, name)
 	if err != nil {
 		t.Fatalf("Failed to create backend: %s", err.Error())
 	}
@@ -527,7 +526,7 @@ func TestElasticsearcActiveNodes(t *testing.T) {
 	node := mg.NewNode("aaa", nil, "host1")
 
 	g.NodeAdded(node)
-	for i := 1; i <= indexCfg.EntriesLimit+1; i++ {
+	for i := 1; i <= cfg.EntriesLimit+1; i++ {
 		time.Sleep(1 * time.Second)
 		g.SetMetadata(node, Metadata{"Temp": i})
 	}
@@ -545,14 +544,14 @@ func TestElasticsearcActiveNodes(t *testing.T) {
 
 // test active edges after rolling elasticsearch indices
 func TestElasticsearcActiveEdges(t *testing.T) {
-	indexCfg := elasticsearch.NewIndexConfig("storage.elasticsearch")
-	indexCfg.EntriesLimit = 10
+	cfg := elasticsearch.NewConfig("storage.elasticsearch")
+	cfg.EntriesLimit = 10
 	name := "test_edges"
 	if err := delTestIndex(name); err != nil {
 		t.Fatalf("Failed to clear test indices: %s", err.Error())
 	}
 
-	backend, err := initBackend(indexCfg, name)
+	backend, err := initBackend(cfg, name)
 	if err != nil {
 		t.Fatalf("Failed to create backend: %s", err.Error())
 	}
@@ -566,7 +565,7 @@ func TestElasticsearcActiveEdges(t *testing.T) {
 	g.NodeAdded(node1)
 	g.NodeAdded(node2)
 	g.EdgeAdded(edge)
-	for i := 1; i < indexCfg.EntriesLimit; i++ {
+	for i := 1; i < cfg.EntriesLimit; i++ {
 		time.Sleep(1 * time.Second)
 		g.SetMetadata(edge, Metadata{"Temp": i})
 	}

--- a/topology/graph/elasticsearch_test.go
+++ b/topology/graph/elasticsearch_test.go
@@ -28,7 +28,6 @@ import (
 	"net/http"
 	"reflect"
 	"sort"
-	"strings"
 	"testing"
 	"time"
 
@@ -36,10 +35,8 @@ import (
 	elastigo "github.com/mattbaird/elastigo/lib"
 
 	"github.com/skydive-project/skydive/common"
-	"github.com/skydive-project/skydive/config"
 	"github.com/skydive-project/skydive/filters"
 	"github.com/skydive-project/skydive/storage/elasticsearch"
-	"net/url"
 )
 
 type revisionArray []interface{}
@@ -145,7 +142,7 @@ func (f *fakeElasticsearchClient) Search(obj string, query string, index string)
 	f.searches = append(f.searches, query)
 	return f.searchResult, nil
 }
-func (f *fakeElasticsearchClient) Start(name string, mappings []map[string][]byte, limits elasticsearch.ElasticLimits) {
+func (f *fakeElasticsearchClient) Start() {
 }
 
 func newElasticsearchGraph(t *testing.T) (*Graph, *fakeElasticsearchClient) {
@@ -489,32 +486,21 @@ func delTestIndex(name string) error {
 	return nil
 }
 
-func initBackend(limits elasticsearch.ElasticLimits, name string) (*ElasticSearchBackend, error) {
-	elasticHost := config.GetString("storage.elasticsearch.host")
-	if !strings.HasPrefix(elasticHost, "http://") && !strings.HasPrefix(elasticHost, "https://") {
-		elasticHost = "http://" + elasticHost
+func initBackend(indexCfg elasticsearch.IndexConfig, name string) (*ElasticSearchBackend, error) {
+	mappings := elasticsearch.Mappings{
+		{"node": []byte(graphElementMapping)},
+		{"edge": []byte(graphElementMapping)},
 	}
 
-	url, err := url.Parse(elasticHost)
-	if err != nil || url.Port() == "" {
-		return nil, ErrBadConfig
-	}
+	connCfg := elasticsearch.NewConnConfig("storage.elasticsearch")
+	connCfg.BulkMaxDocs = 1
 
-	maxConns := config.GetInt("storage.elasticsearch.maxconns")
-	retrySeconds := config.GetInt("storage.elasticsearch.retry")
-	bulkMaxDocs := 1
-	bulkMaxDelay := config.GetInt("storage.elasticsearch.bulk_maxdelay")
-
-	client, err := elasticsearch.NewElasticSearchClient(url, maxConns, retrySeconds, bulkMaxDocs, bulkMaxDelay)
+	client, err := elasticsearch.NewElasticSearchClient(name, mappings, indexCfg, connCfg)
 	if err != nil {
 		return nil, err
 	}
 
-	client.Start(name, []map[string][]byte{
-		{"node": []byte(graphElementMapping)},
-		{"edge": []byte(graphElementMapping)}},
-		limits,
-	)
+	client.Start()
 
 	return &ElasticSearchBackend{
 		client:       client,
@@ -524,14 +510,14 @@ func initBackend(limits elasticsearch.ElasticLimits, name string) (*ElasticSearc
 
 // test active nodes after rolling elasticsearch indices
 func TestElasticsearcActiveNodes(t *testing.T) {
-	limits := elasticsearch.NewElasticLimitsFromConfig("storage.elasticsearch")
-	limits.EntriesLimit = 10
+	indexCfg := elasticsearch.NewIndexConfig("storage.elasticsearch")
+	indexCfg.EntriesLimit = 10
 	name := "test_nodes"
 	if err := delTestIndex(name); err != nil {
 		t.Fatalf("Failed to clear test indices: %s", err.Error())
 	}
 
-	backend, err := initBackend(limits, name)
+	backend, err := initBackend(indexCfg, name)
 	if err != nil {
 		t.Fatalf("Failed to create backend: %s", err.Error())
 	}
@@ -541,7 +527,7 @@ func TestElasticsearcActiveNodes(t *testing.T) {
 	node := mg.NewNode("aaa", nil, "host1")
 
 	g.NodeAdded(node)
-	for i := 1; i <= limits.EntriesLimit+1; i++ {
+	for i := 1; i <= indexCfg.EntriesLimit+1; i++ {
 		time.Sleep(1 * time.Second)
 		g.SetMetadata(node, Metadata{"Temp": i})
 	}
@@ -559,14 +545,14 @@ func TestElasticsearcActiveNodes(t *testing.T) {
 
 // test active edges after rolling elasticsearch indices
 func TestElasticsearcActiveEdges(t *testing.T) {
-	limits := elasticsearch.NewElasticLimitsFromConfig("storage.elasticsearch")
-	limits.EntriesLimit = 10
+	indexCfg := elasticsearch.NewIndexConfig("storage.elasticsearch")
+	indexCfg.EntriesLimit = 10
 	name := "test_edges"
 	if err := delTestIndex(name); err != nil {
 		t.Fatalf("Failed to clear test indices: %s", err.Error())
 	}
 
-	backend, err := initBackend(limits, name)
+	backend, err := initBackend(indexCfg, name)
 	if err != nil {
 		t.Fatalf("Failed to create backend: %s", err.Error())
 	}
@@ -580,7 +566,7 @@ func TestElasticsearcActiveEdges(t *testing.T) {
 	g.NodeAdded(node1)
 	g.NodeAdded(node2)
 	g.EdgeAdded(edge)
-	for i := 1; i < limits.EntriesLimit; i++ {
+	for i := 1; i < indexCfg.EntriesLimit; i++ {
 		time.Sleep(1 * time.Second)
 		g.SetMetadata(edge, Metadata{"Temp": i})
 	}

--- a/topology/graph/graph.go
+++ b/topology/graph/graph.go
@@ -1385,15 +1385,16 @@ func NewGraphFromConfig(backend GraphBackend) *Graph {
 // NewBackendByName creates a new graph backend based on the name
 // memory, orientdb, elasticsearch backend are supported
 func NewBackendByName(name string) (backend GraphBackend, err error) {
-	switch name {
+	driver := config.GetString("storage." + name + ".driver")
+	switch driver {
 	case "memory":
 		backend, err = NewMemoryBackend()
 	case "orientdb":
-		backend, err = NewOrientDBBackendFromConfig()
+		backend, err = NewOrientDBBackendFromConfig(name)
 	case "elasticsearch":
-		backend, err = NewElasticSearchBackendFromConfig()
+		backend, err = NewElasticSearchBackendFromConfig(name)
 	default:
-		return nil, errors.New("Config file is misconfigured, graph backend unknown: " + name)
+		return nil, errors.New(fmt.Sprintf("Toplogy backend driver '%s' not supported", driver))
 	}
 
 	if err != nil {

--- a/topology/graph/indexer.go
+++ b/topology/graph/indexer.go
@@ -76,7 +76,7 @@ func (i *GraphIndexer) cacheNode(n *Node, kv map[string]interface{}) {
 	} else {
 		// Node already was in the cache
 		if !i.appendOnly {
-			for h, _ := range hashes {
+			for h := range hashes {
 				if _, found := kv[h]; !found {
 					i.unindex(n.ID, h)
 				}
@@ -98,7 +98,7 @@ func (i *GraphIndexer) forgetNode(n *Node) {
 
 	if hashes, found := i.nodeToHashes[n.ID]; found {
 		delete(i.nodeToHashes, n.ID)
-		for h, _ := range hashes {
+		for h := range hashes {
 			delete(i.hashToValues[h], n.ID)
 		}
 

--- a/topology/graph/orientdb.go
+++ b/topology/graph/orientdb.go
@@ -390,10 +390,11 @@ func NewOrientDBBackend(addr string, database string, username string, password 
 }
 
 // NewOrientDBBackendFromConfig creates a new OrientDB database client based on configuration
-func NewOrientDBBackendFromConfig() (*OrientDBBackend, error) {
-	addr := config.GetString("storage.orientdb.addr")
-	database := config.GetString("storage.orientdb.database")
-	username := config.GetString("storage.orientdb.username")
-	password := config.GetString("storage.orientdb.password")
+func NewOrientDBBackendFromConfig(backend string) (*OrientDBBackend, error) {
+	path := "storage." + backend
+	addr := config.GetString(path + ".addr")
+	database := config.GetString(path + ".database")
+	username := config.GetString(path + ".username")
+	password := config.GetString(path + ".password")
 	return NewOrientDBBackend(addr, database, username, password)
 }


### PR DESCRIPTION
the following change adds the infra changes needed for pointing topology and flow each to a different ElasticSearch database (the extra change need to support this is extending the `skydive.yml` `analyzer.storage` to support flow connection and point to this path during `NewConnConfig` call (for flow). 

This would enable extra isolation between the two in productive environments.

For now default behavior (in which both flow and topology take connection configuration from `storage.elasticsearch` remains). 