### PR TITLE
auth: get ride of http basic auth

### DIFF
--- a/http/auth.go
+++ b/http/auth.go
@@ -144,7 +144,6 @@ func NewAuthenticationClient(url *url.URL, authOptions *AuthenticationOpts) *Aut
 }
 
 type AuthenticationBackend interface {
-	AuthType() string
 	Authenticate(username string, password string) (string, error)
 	Wrap(wrapped auth.AuthenticatedHandlerFunc) http.HandlerFunc
 }

--- a/http/keystone.go
+++ b/http/keystone.go
@@ -48,10 +48,6 @@ type User struct {
 	Name string `mapstructure:"name"`
 }
 
-func (b *KeystoneAuthenticationBackend) AuthType() string {
-	return "Basic"
-}
-
 func (b *KeystoneAuthenticationBackend) checkUserV2(client *gophercloud.ServiceClient, tokenID string) (string, error) {
 	result := tokens2.Get(client, tokenID)
 
@@ -184,7 +180,7 @@ func (b *KeystoneAuthenticationBackend) Wrap(wrapped auth.AuthenticatedHandlerFu
 			if err != nil {
 				logging.GetLogger().Warningf("Failed to check token: %s", err.Error())
 			}
-			unauthorized(w, r, b.AuthType())
+			unauthorized(w, r)
 		} else {
 			ar := &auth.AuthenticatedRequest{Request: *r, Username: username}
 			copyRequestVars(r, &ar.Request)

--- a/http/server.go
+++ b/http/server.go
@@ -251,18 +251,17 @@ func (s *Server) serveLogin(w http.ResponseWriter, r *http.Request) {
 				}
 				w.WriteHeader(http.StatusOK)
 			} else {
-				unauthorized(w, r, s.Auth.AuthType())
+				unauthorized(w, r)
 			}
 		} else {
-			unauthorized(w, r, s.Auth.AuthType())
+			unauthorized(w, r)
 		}
 	} else {
 		http.Redirect(w, r, "/", http.StatusFound)
 	}
 }
 
-func unauthorized(w http.ResponseWriter, r *http.Request, authType string) {
-	w.Header().Add("WWW-Authenticate", fmt.Sprintf(`%s realm="Skydive" charset="UTF-8"`, authType))
+func unauthorized(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusUnauthorized)
 	w.Write([]byte("401 Unauthorized\n"))
 }


### PR DESCRIPTION
This patch removes the support of the HTTP
part of our basic auth support as it causes
UI issue and authentification path inconsistency.

With this patch only the login endpoint using
the cookie returned as token is available.

Since this commit 81a691913310c2c019eb475bd64a760d8f6a6859
the python library relies on login and cookie.