### PR TITLE
oflow: Nice formatting of actions in rules using OpenFlow1.3

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -155,6 +155,7 @@ func init() {
 
 	cfg.SetDefault("ovs.ovsdb", "unix:///var/run/openvswitch/db.sock")
 	cfg.SetDefault("ovs.oflow.enable", false)
+	cfg.SetDefault("ovs.oflow.openflow_versions", []string{"OpenFlow10"})
 
 	cfg.SetDefault("sflow.port_min", 6345)
 	cfg.SetDefault("sflow.port_max", 6355)

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -199,6 +199,15 @@ ovs:
     # Enable the parsing of openflow rules (disabled by default)
     # enable: false
 
+    # Openflow versions used by ovs-ofctl when queries are made to the
+    # switch. 1.0 should always be supported. 1.3 gives a nicer output and
+    # it is recommended to add it if it is supported.
+    # 1.4 can be broken on some switch, 1.5 and 1.6 are still considered
+    # as experimental.
+    # openflow_versions:
+    #  - OpenFlow10
+
+
     # The probe can connect to remote bridge over TLS (ssl url).
     # The default value is empty for those options.
     # Path to the private key file (TLS connection)

--- a/topology/probes/ovsdb/ovs_of.go
+++ b/topology/probes/ovsdb/ovs_of.go
@@ -348,7 +348,10 @@ func completeEvent(ctx context.Context, o *OvsOfProbe, event *Event, prefix stri
 	// the priority is provided. Another approach would be to use the shortest filter as it is the more generic
 	expected := countElements(oldrule.Filter)
 	filter := makeFilter(oldrule)
-	command, err1 := o.makeCommand([]string{"ovs-ofctl", "dump-flows"}, bridge, filter)
+	versions := strings.Join(config.GetStringSlice("ovs.oflow.openflow_versions"), ",")
+	command, err1 := o.makeCommand(
+		[]string{"ovs-ofctl", "-O", versions, "dump-flows"},
+		bridge, filter)
 	if err1 != nil {
 		return err1
 	}


### PR DESCRIPTION
By default, ovs-ofctl only use 1.0 protocol. In that configuration, setting registers is
considered as an OpenFlow extension and the syntax is hard to read.
We introduce a configuration switch and set it to a reasonnable default.

Closes #973