### PR TITLE
k8s: generate defaults when k8s.probes is empty

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -136,7 +136,6 @@ func init() {
 	cfg.SetDefault("http.ws.enable_write_compression", true)
 
 	cfg.SetDefault("k8s.config_file", "/etc/skydive/kubeconfig")
-	cfg.SetDefault("k8s.probes", []string{"networkpolicy", "pod", "container", "node", "namespace"})
 
 	cfg.SetDefault("logging.backends", []string{"stderr"})
 	cfg.SetDefault("logging.color", true)

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -350,22 +350,24 @@ flow:
 k8s:
   # EXPERIMENTAL: k8s probe is still under development and should not be used
   # on production systems
-  #
+  
   # kubeconfig resolution order:
-  # if kubeconfig param is defined then use it
-  # else if $KUBECONFIG environment is define then use it
-  # else if $HOME/.kube/config file exists then use it
-  # else use empty configuration (for accessing from within the k8s cluster)
-  # Specify the path of k8s configuration YAML file
+  # - if config_file param is defined then use it;
+  # - else if $KUBECONFIG environment is define then use it;
+  # - else if $HOME/.kube/config file exists then use it;
+  # - else use empty configuration (for accessing from within the k8s cluster).
+
+  # specify the path of k8s configuration YAML file.
   # config_file: /etc/skydive/kubeconfig
 
-  # Sub probes provided by the k8s probe
+  # list of (sub) probes comprising k8s probe.
+  # if list is empty then will resolve to all existing (sub) probes.
   probes:
-  - networkpolicy
-  - pod
   - container
-  - node
   - namespace
+  - networkpolicy
+  - node
+  - pod
 
 ui:
   # Specify the extra assets folder. Javascript and CSS files present in this

--- a/topology/probes/k8s/container.go
+++ b/topology/probes/k8s/container.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/skydive-project/skydive/filters"
 	"github.com/skydive-project/skydive/logging"
+	"github.com/skydive-project/skydive/probe"
 	"github.com/skydive-project/skydive/topology/graph"
 
 	"k8s.io/api/core/v1"
@@ -198,7 +199,7 @@ func (c *containerProbe) Stop() {
 	c.kubeCache.Stop()
 }
 
-func newContainerProbe(g *graph.Graph) *containerProbe {
+func newContainerProbe(g *graph.Graph) probe.Probe {
 	c := &containerProbe{
 		graph:            g,
 		podIndexer:       newPodIndexerByName(g),

--- a/topology/probes/k8s/namespace.go
+++ b/topology/probes/k8s/namespace.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/skydive-project/skydive/filters"
 	"github.com/skydive-project/skydive/logging"
+	"github.com/skydive-project/skydive/probe"
 	"github.com/skydive-project/skydive/topology/graph"
 
 	"k8s.io/api/core/v1"
@@ -147,7 +148,7 @@ func newNamespaceKubeCache(handler cache.ResourceEventHandler) *kubeCache {
 	return newKubeCache(getClientset().Core().RESTClient(), &v1.Namespace{}, "namespaces", handler)
 }
 
-func newNamespaceProbe(g *graph.Graph) *namespaceProbe {
+func newNamespaceProbe(g *graph.Graph) probe.Probe {
 	p := &namespaceProbe{
 		graph:            g,
 		objectIndexer:    newObjectIndexer(g),

--- a/topology/probes/k8s/networkpolicy.go
+++ b/topology/probes/k8s/networkpolicy.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 
 	"github.com/skydive-project/skydive/logging"
+	"github.com/skydive-project/skydive/probe"
 	"github.com/skydive-project/skydive/topology/graph"
 
 	api "k8s.io/api/core/v1"
@@ -185,7 +186,7 @@ func newNetworkPolicyKubeCache(handler cache.ResourceEventHandler) *kubeCache {
 	return newKubeCache(getClientset().ExtensionsV1beta1().RESTClient(), &networking_v1.NetworkPolicy{}, "networkpolicies", handler)
 }
 
-func newNetworkPolicyProbe(g *graph.Graph) *networkPolicyProbe {
+func newNetworkPolicyProbe(g *graph.Graph) probe.Probe {
 	n := &networkPolicyProbe{
 		graph:      g,
 		podCache:   newPodKubeCache(nil),

--- a/topology/probes/k8s/node.go
+++ b/topology/probes/k8s/node.go
@@ -25,6 +25,7 @@ package k8s
 import (
 	"sync"
 
+	"github.com/skydive-project/skydive/probe"
 	"github.com/skydive-project/skydive/topology"
 	"github.com/skydive-project/skydive/topology/graph"
 
@@ -127,7 +128,7 @@ func newNodeKubeCache(handler cache.ResourceEventHandler) *kubeCache {
 	return newKubeCache(getClientset().Core().RESTClient(), &v1.Node{}, "nodes", handler)
 }
 
-func newNodeProbe(g *graph.Graph) *nodeProbe {
+func newNodeProbe(g *graph.Graph) probe.Probe {
 	c := &nodeProbe{
 		graph:       g,
 		hostIndexer: newHostIndexer(g),

--- a/topology/probes/k8s/pod.go
+++ b/topology/probes/k8s/pod.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/skydive-project/skydive/filters"
 	"github.com/skydive-project/skydive/logging"
+	"github.com/skydive-project/skydive/probe"
 	"github.com/skydive-project/skydive/topology/graph"
 
 	api "k8s.io/api/core/v1"
@@ -184,7 +185,7 @@ func newPodKubeCache(handler cache.ResourceEventHandler) *kubeCache {
 	return newKubeCache(getClientset().Core().RESTClient(), &api.Pod{}, "pods", handler)
 }
 
-func newPodProbe(g *graph.Graph) *podProbe {
+func newPodProbe(g *graph.Graph) probe.Probe {
 	p := &podProbe{
 		graph:            g,
 		containerIndexer: newContainerIndexer(g),


### PR DESCRIPTION
to test try:

(1)
```
analyzer:
  probes:
  - k8s
k8s:
  probes:
    # emptry
```
In this case we expect probes as listed in LOG to include: container, networkpolicy, namespace, networkpolicy, node, pod

(2)
Use some defaults

```
analyzer:
  probes:
  - k8s

k8s:
  probes: 
    node
```
In this case we expect LOG to indicate that only node probe of k8s is registered