### PR TITLE
k8s: fix flapping tests (especially pod, container)

### DIFF
--- a/tests/k8s/container.yaml
+++ b/tests/k8s/container.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: skydive-test-container
+spec:
+  containers:
+  - name: skydive-test
+    image: nginx
+    ports:
+    - containerPort: 80
+    volumeMounts:
+    - name: workdir
+      mountPath: /usr/share/nginx/html
+  # These containers are run during pod initialization
+  initContainers:
+  - name: install
+    image: busybox
+    command:
+    - wget
+    - "-O"
+    - "/work-dir/index.html"
+    - http://kubernetes.io
+    volumeMounts:
+    - name: workdir
+      mountPath: "/work-dir"
+  dnsPolicy: Default
+  volumes:
+  - name: workdir
+    emptyDir: {}

--- a/tests/k8s/pod.yaml
+++ b/tests/k8s/pod.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: skydive-test
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
+    volumeMounts:
+    - name: workdir
+      mountPath: /usr/share/nginx/html
+  # These containers are run during pod initialization
+  initContainers:
+  - name: install
+    image: busybox
+    command:
+    - wget
+    - "-O"
+    - "/work-dir/index.html"
+    - http://kubernetes.io
+    volumeMounts:
+    - name: workdir
+      mountPath: "/work-dir"
+  dnsPolicy: Default
+  volumes:
+  - name: workdir
+    emptyDir: {}


### PR DESCRIPTION
k8s would fail sometimes as there was no mechanism to ensure skydive has seen the newly created k8s objects. A retry loop has been added to all k8s create object tests (10 retires with 1 second wait), eliminating this race and making the tests more stable.

If functional tests pass consistently again and again then this is indication the fix works as expected