### PR TITLE
k8s: fix dumpcluster() func

### DIFF
--- a/topology/probes/k8s/cluster.go
+++ b/topology/probes/k8s/cluster.go
@@ -63,7 +63,7 @@ func newClusterIndexer(g *graph.Graph) *graph.MetadataIndexer {
 }
 
 func dumpCluster(name string) string {
-	return fmt.Sprintf("cluster{'Name': %s}")
+	return fmt.Sprintf("cluster{'Name': %s}", name)
 }
 
 func (p *clusterProbe) newMetadata(name string) graph.Metadata {


### PR DESCRIPTION
Should pass 'make vet' now