### PR TITLE
json: wrong json omitempty option in host cpu

### DIFF
--- a/agent/host.go
+++ b/agent/host.go
@@ -37,7 +37,7 @@ import (
 
 // CPUInfo defines host information
 type CPUInfo struct {
-	CPU        int64  `json:"CPU,omitempty"`
+	CPU        int64
 	VendorID   string `json:"VendorID,omitempty"`
 	Family     string `json:"Family,omitempty"`
 	Model      string `json:"Model,omitempty"`


### PR DESCRIPTION
cpu index is starting from zero but the omitempty option not
allowing to display the first index which is zero