### PR TITLE
build: fix static build for Ubuntu 14.04 (dpkg-dev 1.17.5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ endif
 
 OS_DEB := $(shell test -f /etc/debian_version && echo -n Y)
 ifeq ($(OS_DEB),Y)
-	STATIC_DIR := $(shell dpkg-architecture --command sh -c 'echo /usr/lib/$$DEB_TARGET_MULTIARCH')
+	STATIC_DIR := $(shell dpkg-architecture -c 'sh' -c 'echo /usr/lib/$$DEB_BUILD_MULTIARCH')
 	STATIC_LIBS := \
 		libz.a \
 		liblzma.a \


### PR DESCRIPTION
The `dpkg-architecuture` options and environment variables changed between 14.04 to 16.04 (see below), fixed the build command to support both version now.

Ubuntu 16.04 (http://manpages.ubuntu.com/manpages/xenial/man1/dpkg-architecture.1.html)
Ubuntu 14.04 (http://manpages.ubuntu.com/manpages/trusty/man1/dpkg-architecture.1.html)

To test just build on both target version.