### PR TITLE
ui: enable fixed position (X,Y)

### DIFF
--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -393,6 +393,11 @@ ui:
     # default_highlight: "layer2"
     # Filter Gremlin expression used by default and applied on WebUI load.
     # default_filter: "layer2"
+    # Pre-defined boolean expression to select nodes with certain Metadata and change their view
+    # Pin to ceratin location.
+    # fixed_nodes:
+    #   - (Name=tor1): (X=300, Y=300)
+    #   - (Name=port2): (X=500, Y=500)
 
   # update rate of links in seconds
   bandwidth_update_rate: 5

--- a/statics/index.html
+++ b/statics/index.html
@@ -67,6 +67,7 @@
   <script src="/statics/js/components/rule-detail.js"></script>
   <script src="/statics/js/components/feature-table.js"></script>
   <script src="/statics/js/components/preference.js"></script>
+  <script src="/statics/js/components/fixed-pos-builder.js"></script>
 
   <!-- views -->
   <script src="/statics/js/components/login.js"></script>

--- a/statics/js/components/fixed-pos-builder.js
+++ b/statics/js/components/fixed-pos-builder.js
@@ -1,0 +1,173 @@
+function Expression() {
+}
+Expression.prototype.isNodeSelected = function (node) {
+    return true;
+}
+
+function EQExpression(metadata, val) {
+    Expression.call(this);
+    this.metadata = metadata;
+    this.value = val;
+}
+EQExpression.prototype = Object.create(Expression.prototype);
+EQExpression.prototype.isNodeSelected = function(node) {
+    return node.metadata[this.metadata] == this.value;
+}
+
+function NotEQExpression(metadata, val) {
+    Expression.call(this);
+    this.metadata = metadata;
+    this.value = val;
+}
+NotEQExpression.prototype = Object.create(Expression.prototype);
+NotEQExpression.prototype.isNodeSelected = function(node) {
+    return node.metadata[this.metadata] != this.value;
+}
+
+function NotExpression(expr) {
+    Expression.call(this);
+    this.expr1 = expr;
+}
+NotExpression.prototype = Object.create(Expression.prototype);
+NotExpression.prototype.isNodeSelected = function(node) {
+    return !(this.expr1.isNodeSelected(node));
+}
+
+function BinaryExpression(expr1, expr2) {
+    Expression.call(this);
+    this.expr1 = expr1;
+    this.expr2 = expr2;
+}
+BinaryExpression.prototype = Object.create(Expression.prototype);
+BinaryExpression.prototype.isNodeSelected = function(node){return false;}
+
+function OrBinaryExpression(expr1, expr2) {
+    BinaryExpression.call(this, expr1, expr2);
+}
+OrBinaryExpression.prototype = Object.create(Expression.prototype);
+OrBinaryExpression.prototype.isNodeSelected = function(node) {
+    return this.expr1.isNodeSelected(node) || this.expr2.isNodeSelected(node);
+}
+
+function AndBinaryExpression(expr1, expr2) {
+    BinaryExpression.call(this, expr1, expr2);
+}
+AndBinaryExpression.prototype = Object.create(Expression.prototype);
+AndBinaryExpression.prototype.isNodeSelected = function(node) {
+    return this.expr1.isNodeSelected(node) && this.expr2.isNodeSelected(node);
+}
+
+function parseExpr(str) {
+    str = str.trim(" ")
+    var leftBrCount = 0;
+    var index = 0;
+    if (str.length < 1) {
+        return new Expression();
+    }
+
+    if (str[index] == '(') {
+        leftBrCount = 1;
+        index++
+    } else if (str[index] == '!') {
+        return new NotExpression(parseExpr(str.slice(1)));
+    } else {
+        var op = str.indexOf("=");
+        if (op > 0 ) {
+            if (str[op-1] == "!") {
+                return new NotEQExpression(str.slice(0, op-1).trim(" "), str.slice(op+1).trim(" "))
+            } else {
+                return new EQExpression(str.split('=')[0].trim(" "), str.split('=')[1].trim(" "))
+            }
+        } else return new Expression();
+    }
+
+    // first character was '(' - now we find our
+    // if its closure is in the middle of the expression
+    while((leftBrCount != 0 ) && (index < str.length)) {
+        if (str[index] == '(') {
+            leftBrCount++;
+        } else if (str[index] == ')'){
+            leftBrCount--;
+        }
+            index++;
+    }
+
+    if (index < str.length) {
+        trimmedStr = str.slice(index).trim(" ")
+        if (trimmedStr.startsWith("&&")) {
+            return new AndBinaryExpression(parseExpr(str.slice(0, index)), parseExpr(trimmedStr.slice(2)));
+        }
+        if (trimmedStr.startsWith("||")) {
+            return new OrBinaryExpression(parseExpr(str.slice(0, index)), parseExpr(trimmedStr.slice(2)));
+        }
+    }
+    return parseExpr(str.slice(1, str.length-1))
+}
+
+// X=500, Y=600, color=blue
+function parseAction(str) {
+    str = str.replace( /[()]/g, '' );
+    actions=str.split(",");
+    var myActions = {};
+    for (var i=0; i<actions.length; i++) {
+        myActions[i] = [actions[i].split("=")[0].trim(" "), parseInt(actions[i].split("=")[1].trim(" "))];
+    }
+    return myActions;
+}
+
+function ConditionActionRule(expr, actions){
+    this.expr = expr
+    this.actions = actions
+}
+ConditionActionRule.prototype.RePaintNode = function (node, layout) {
+  var theNode = layout.nodes[node.id];
+  if (theNode == null) return
+
+  var hasFixedLocation = false;
+  for(act in this.actions) {
+     var command = {};
+     var i = 0;
+     for (elem in this.actions[act]){
+        command[i] = this.actions[act][elem];
+        i++;
+     }
+     switch(command[0]) {
+     case "X": {
+        theNode.x = command[1];
+        theNode.fx = node.x;
+        hasFixedLocation = true;
+     }
+     case "Y":{
+        theNode.y = command[1];
+        theNode.fy = node.y;
+        hasFixedLocation = true;
+     }
+     default:
+     }
+  }
+  if (hasFixedLocation) {
+     layout.pinNode(theNode);
+  }
+}
+
+function FixedPositionBuilder() {
+   this.cond_rules = []
+}
+FixedPositionBuilder.prototype.RePaintNode = function (node, layout) {
+        if (this.cond_rules == null) {
+            return;
+        }
+        for(var i=0; i< this.cond_rules.length; i++){
+           if (this.cond_rules[i].expr.isNodeSelected(node))
+           {
+                return this.cond_rules[i].RePaintNode(node, layout);
+           }
+        }
+        return;
+}
+FixedPositionBuilder.prototype.AddRule = function (condition, action) {
+    var exp = parseExpr(condition);
+    var actions = parseAction(action);
+    this.cond_rules.push(new ConditionActionRule(exp, actions));
+}
+

--- a/statics/js/components/graph-layout.js
+++ b/statics/js/components/graph-layout.js
@@ -222,6 +222,8 @@ var LinkLabelLatency = Vue.extend({
   },
 });
 
+
+
 var TopologyGraphLayout = function(vm, selector) {
   var self = this;
 
@@ -354,6 +356,7 @@ TopologyGraphLayout.prototype = {
   initD3Data: function() {
     this.nodes = {};
     this._nodes = {};
+    this.setFixedPlacementFromConfig();
 
     this.links = {};
     this._links = {};
@@ -416,6 +419,22 @@ TopologyGraphLayout.prototype = {
       }
     }
     return distance;
+  },
+
+  setFixedPlacementFromConfig: function() {
+   this.fixedPositionBuilder = new FixedPositionBuilder();
+   var pos = this.fixedPositionBuilder;
+   return $.when(this.vm.$getConfigValue('ui.topology.fixed_nodes'))
+       .then(function(favorites) {
+         if (!favorites) return;
+         console.log(favorites)
+         for(var n in favorites) {
+           for(var k in favorites[n]){
+              pos.AddRule(k, favorites[n][k]);
+           }
+         }
+         }
+         );
   },
 
   hideNode: function(d) {
@@ -1629,6 +1648,14 @@ TopologyGraphLayout.prototype = {
     this.simulation.nodes(nodes);
     this.simulation.force("link").links(links);
     this.simulation.alpha(1).restart();
+    this.reArrangeGraphNodes();
+  },
+
+  reArrangeGraphNodes: function () {
+    for (var i in this.nodes) {
+        var aNode = this.nodes[i];
+        this.fixedPositionBuilder.RePaintNode(aNode, this);
+    }
   },
 
   highlightLink: function(d) {


### PR DESCRIPTION
Change in config file:
   #topology:
   # Pin to ceratin location specified nodes
   # Nodes are selected via binary boolean expressions, where
   # '!', '&&', '||' operators are enabled.
   # Atoms of the expressions refer to values of Metadata fields.
      #fixed_nodes:
         #- (Name=tor1): (X=300, Y=300)
         #- (Name=port2): (X=500, Y=500)
As a result in the example: Skydive will pin all the nodes
with "Metadata.Name = tor1" to location [300, 300].
The same about port2.