### PR TITLE
opencontrail: retry during 8 seconds to get the port from vrouter

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -27,12 +27,24 @@ import "time"
 // Retry tries to execute the given function until a success applying a delay
 // between each try
 func Retry(fnc func() error, try int, delay time.Duration) error {
+	return retry(fnc, try, delay, 1)
+}
+
+// RetryExponential tries to execute the given function until a success applying a delay
+// between each try. The delay is doubled after each try. Its initial value is baseDelay.
+func RetryExponential(fnc func() error, try int, baseDelay time.Duration) error {
+	return retry(fnc, try, baseDelay, 2)
+}
+
+func retry(fnc func() error, try int, baseDelay time.Duration, factor int64) error {
 	var err error
+	delay := baseDelay
 	for i := 0; i < try; i++ {
 		if err = fnc(); err == nil {
 			return nil
 		}
 		time.Sleep(delay)
+		delay = time.Duration(factor * int64(delay))
 	}
 	return err
 }

--- a/topology/probes/opencontrail/opencontrail.go
+++ b/topology/probes/opencontrail/opencontrail.go
@@ -117,7 +117,8 @@ func getInterfaceFromIntrospect(host string, port int, name string) (col collect
 		}
 		return
 	}
-	err = common.Retry(getFromIntrospect, 3, 500*time.Millisecond)
+	// Retry during about 8 seconds
+	err = common.RetryExponential(getFromIntrospect, 5, 250*time.Millisecond)
 	return
 }
 


### PR DESCRIPTION
One slow machines (such as test VMs), the delay (1.5 seconds) was
sometimes to small. This commit increases it to 8 seconds and adds the
retry function RetryExponential. The delay is doubled after each try:
the more failures we have, the more we wait for retries.