### PR TITLE
tests: add opencontrail functional tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,10 @@ ifeq ($(WITH_HELM), true)
   BUILDTAGS+=helm
 endif
 
+ifeq ($(WITH_OPENCONTRAIL), true)
+  BUILDTAGS+=opencontrail
+endif
+
 .PHONY: all install
 all install: skydive
 

--- a/scripts/ci/opencontrail-tests.nix
+++ b/scripts/ci/opencontrail-tests.nix
@@ -1,0 +1,32 @@
+{ pkgs ? import <nixpkgs> {}
+, nixpkgsContrailPath ? pkgs.fetchFromGitHub {
+    owner = "nlewo";
+    repo = "nixpkgs-contrail";
+    rev = "d1bcfa3527e838b6cbc542b4aac5a8dd47db90e3";
+    sha256 = "03kp134rbc7mmxf7vhbhp80a1dacbyj3q0db5mg3w7wmrkwvjmlc";
+  }
+}:
+
+let
+  contrailPkgs = import nixpkgsContrailPath {};
+
+  skydiveTestFunctionals = pkgs.stdenv.mkDerivation {
+    name = "skydive-test-functionals";
+    phases = [ "installPhase" "fixupPhase" ];
+    installPhase = "cp ${../../tests/functionals} $out";
+    # This could be avoid by using a static linked test binary.
+    preFixup = let
+      libPath = pkgs.lib.makeLibraryPath [ pkgs.libpcap pkgs.libxml2 ];
+    in ''
+      ${pkgs.patchelf}/bin/patchelf --set-interpreter ${pkgs.stdenv.glibc}/lib/ld-linux-x86-64.so.2 --set-rpath "${libPath}" $out
+    '';
+  };
+
+  testScript = ''
+    $machine->waitUntilSucceeds("curl -s http://localhost:8083/Snh_ShowBgpNeighborSummaryReq | grep machine | grep -q Established");
+    $machine->succeed("${skydiveTestFunctionals} -test.run TestOpenContrail -standalone");
+  '';
+
+in 
+  contrailPkgs.contrail32.test.allInOne.override { inherit testScript; }
+  // { inherit skydiveTestFunctionals; }

--- a/scripts/ci/opencontrail-tests.nix
+++ b/scripts/ci/opencontrail-tests.nix
@@ -14,7 +14,7 @@ let
     name = "skydive-test-functionals";
     phases = [ "installPhase" "fixupPhase" ];
     installPhase = "cp ${../../tests/functionals} $out";
-    # This could be avoid by using a static linked test binary.
+    # This could be avoided by using a static linked test binary.
     preFixup = let
       libPath = pkgs.lib.makeLibraryPath [ pkgs.libpcap pkgs.libxml2 ];
     in ''
@@ -23,6 +23,7 @@ let
   };
 
   testScript = ''
+    # This is to wait until OpenContrail is ready
     $machine->waitUntilSucceeds("curl -s http://localhost:8083/Snh_ShowBgpNeighborSummaryReq | grep machine | grep -q Established");
     $machine->succeed("${skydiveTestFunctionals} -test.run TestOpenContrail -standalone");
   '';

--- a/scripts/ci/run-opencontrail-tests.sh
+++ b/scripts/ci/run-opencontrail-tests.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Install Nix if not present
+if ! type -p nix >/dev/null
+then
+    curl https://nixos.org/nix/install | sh
+    . $HOME/.nix-profile/etc/profile.d/nix.sh
+fi
+
+make test.functionals.compile WITH_OPENCONTRAIL=true
+
+# For development or debug purposes, the Contrail VM can
+# be launched in an interactive mode.
+# $ nix-build scripts/ci/opencontrail-tests.nix -A driver
+# This creates scripts that just run the VM. It is then possible to
+# ssh it to manually run the test suite.
+# For more information: https://nixos.org/nixos/manual/index.html#sec-running-nixos-tests
+nix-build scripts/ci/opencontrail-tests.nix --no-out-link \
+  --substituters "https://opencontrail.cachix.org https://cache.nixos.org" \
+  --option trusted-public-keys "opencontrail.cachix.org-1:QCsZCHATxFVRRHdilxc1qiV2QmiPV02NTs10oVkf+UQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+
+# Remove the test script from the store to save space
+nix-store --delete $(nix-build scripts/ci/opencontrail-tests.nix --no-out-link -A skydiveTestFunctionals)

--- a/tests/opencontrail_test.go
+++ b/tests/opencontrail_test.go
@@ -13,18 +13,17 @@ import (
 func TestOpenContrailTopology(t *testing.T) {
 	test := &Test{
 		setupCmds: []helper.Cmd{
-			{"contrail-create-network.py default-domain:default-project:vn1", false},
-			{"netns-daemon-start -n default-domain:default-project:vn1 vm1", false},
+			{"contrail-create-network.py default-domain:default-project:vn1", true},
+			{"netns-daemon-start -n default-domain:default-project:vn1 vm1", true},
 		},
 		tearDownCmds: []helper.Cmd{
 			// We should delete the net
-			{"netns-daemon-stop vm1", false},
+			{"netns-daemon-stop vm1", true},
 		},
 
 		checks: []CheckFunction{func(c *CheckContext) error {
 			gh := c.gh
-			gremlin := g.G
-			gremlin = gremlin.V().Has("Contrail")
+			gremlin := g.G.V().Has("Contrail")
 
 			nodes, err := gh.GetNodes(gremlin)
 			if err != nil {

--- a/tests/opencontrail_test.go
+++ b/tests/opencontrail_test.go
@@ -1,0 +1,43 @@
+// +build opencontrail
+
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	g "github.com/skydive-project/skydive/gremlin"
+	"github.com/skydive-project/skydive/tests/helper"
+)
+
+func TestOpenContrailTopology(t *testing.T) {
+	test := &Test{
+		setupCmds: []helper.Cmd{
+			{"contrail-create-network.py default-domain:default-project:vn1", false},
+			{"netns-daemon-start -n default-domain:default-project:vn1 vm1", false},
+		},
+		tearDownCmds: []helper.Cmd{
+			// We should delete the net
+			{"netns-daemon-stop vm1", false},
+		},
+
+		checks: []CheckFunction{func(c *CheckContext) error {
+			gh := c.gh
+			gremlin := g.G
+			gremlin = gremlin.V().Has("Contrail")
+
+			nodes, err := gh.GetNodes(gremlin)
+			if err != nil {
+				return err
+			}
+
+			if len(nodes) != 1 {
+				return fmt.Errorf("Expected 1 node, got %+v", nodes)
+			}
+
+			return nil
+		}},
+	}
+
+	RunTest(t, test)
+}

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -77,6 +77,7 @@ agent:
       - ovsdb
       - docker
       - lxd
+      - opencontrail
     netlink:
       metrics_update: 5
 

--- a/topology/probes/opencontrail/opencontrail.go
+++ b/topology/probes/opencontrail/opencontrail.go
@@ -267,7 +267,7 @@ func (mapper *OpenContrailProbe) OnNodeDeleted(n *graph.Node) {
 	if name == "" {
 		return
 	}
-	if n.ID == mapper.vHost.ID {
+	if mapper.vHost != nil && n.ID == mapper.vHost.ID {
 		logging.GetLogger().Debugf("Removed %s", name)
 		mapper.vHost = nil
 	}


### PR DESCRIPTION
The test uses a OpenContrail NixOS VM to run the OpenContrail Skydive
functional tests. This VM comes from the
github.com/nlewo/nixpkgs-contrail repository which uses it for its
packaging test suite.

To do:
- [x] use cachix to be sure build artefacts are existing
- [x] remove the functional test script from the local Nix cache
