### PR TITLE
k8s: test use objects with unique prefix

### DIFF
--- a/tests/k8s/container.yaml
+++ b/tests/k8s/container.yaml
@@ -4,16 +4,16 @@ metadata:
   name: skydive-test-container
 spec:
   containers:
-  - name: skydive-test
+  - name: skydive-test-container
     image: nginx
     ports:
     - containerPort: 80
     volumeMounts:
-    - name: workdir
+    - name: skydive-test-container-workdir
       mountPath: /usr/share/nginx/html
   # These containers are run during pod initialization
   initContainers:
-  - name: install
+  - name: skydive-test-container-install
     image: busybox
     command:
     - wget
@@ -21,9 +21,9 @@ spec:
     - "/work-dir/index.html"
     - http://kubernetes.io
     volumeMounts:
-    - name: workdir
+    - name: skydive-test-container-workdir
       mountPath: "/work-dir"
   dnsPolicy: Default
   volumes:
-  - name: workdir
+  - name: skydive-test-container-workdir
     emptyDir: {}

--- a/tests/k8s/daemonset.yaml
+++ b/tests/k8s/daemonset.yaml
@@ -1,24 +1,24 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: skydive-test
+  name: skydive-test-daemonset
   namespace: kube-system
   labels:
-    k8s-app: fluentd-logging
+    k8s-app: skydive-test-daemonset-fluentd-logging
 spec:
   selector:
     matchLabels:
-      name: fluentd-elasticsearch
+      name: skydive-test-daemonset-fluentd-elasticsearch
   template:
     metadata:
       labels:
-        name: fluentd-elasticsearch
+        name: skydive-test-daemonset-fluentd-elasticsearch
     spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       containers:
-      - name: fluentd-elasticsearch
+      - name: skydive-test-daemonset-fluentd-elasticsearch
         image: k8s.gcr.io/fluentd-elasticsearch:1.20
         resources:
           limits:
@@ -27,16 +27,16 @@ spec:
             cpu: 100m
             memory: 200Mi
         volumeMounts:
-        - name: varlog
+        - name: skydive-test-daemonset-varlog
           mountPath: /var/log
-        - name: varlibdockercontainers
+        - name: skydive-test-daemonset-varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
       terminationGracePeriodSeconds: 30
       volumes:
-      - name: varlog
+      - name: skydive-test-daemonset-varlog
         hostPath:
           path: /var/log
-      - name: varlibdockercontainers
+      - name: skydive-test-daemonset-varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers

--- a/tests/k8s/deployment.yaml
+++ b/tests/k8s/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: skydive-test
+  name: skydive-test-deployment
   labels:
     app: nginx
 spec:
@@ -15,7 +15,7 @@ spec:
         app: nginx
     spec:
       containers:
-      - name: nginx
+      - name: skydive-test-deployment-nginx
         image: nginx:1.7.9
         ports:
         - containerPort: 80

--- a/tests/k8s/ingress.yaml
+++ b/tests/k8s/ingress.yaml
@@ -1,8 +1,8 @@
 kind: Ingress
 apiVersion: extensions/v1beta1
 metadata:
-  name: skydive-test
+  name: skydive-test-ingress
 spec:
   backend:
-    serviceName: testsvc
+    serviceName: skydive-test-ingress-testsvc
     servicePort: 1080

--- a/tests/k8s/job.yaml
+++ b/tests/k8s/job.yaml
@@ -1,14 +1,14 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: skydive-test
+  name: skydive-test-job
 spec:
   template:
     metadata:
       name: countdown
     spec:
       containers:
-      - name: counter
+      - name: skydive-test-job-counter
         image: centos:7
         command:
          - "bin/bash"

--- a/tests/k8s/namespace.yaml
+++ b/tests/k8s/namespace.yaml
@@ -1,6 +1,6 @@
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: skydive-test
+  name: skydive-test-namespace
   labels:
-    name: skydive-test
+    name: skydive-test-namespace

--- a/tests/k8s/networkpolicy.yaml
+++ b/tests/k8s/networkpolicy.yaml
@@ -2,6 +2,6 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   namespace: default
-  name: skydive-test
+  name: skydive-test-networkpolicy
 spec:
   podSelector: {}

--- a/tests/k8s/pod.yaml
+++ b/tests/k8s/pod.yaml
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: skydive-test
+  name: skydive-test-pod
 spec:
   containers:
-  - name: nginx
+  - name: skydive-test-pod-nginx
     image: nginx
     ports:
     - containerPort: 80
     volumeMounts:
-    - name: workdir
+    - name: skydive-test-pod-workdir
       mountPath: /usr/share/nginx/html
   # These containers are run during pod initialization
   initContainers:
-  - name: install
+  - name: skydive-test-pod-install
     image: busybox
     command:
     - wget
@@ -21,9 +21,9 @@ spec:
     - "/work-dir/index.html"
     - http://kubernetes.io
     volumeMounts:
-    - name: workdir
+    - name: skydive-test-pod-workdir
       mountPath: "/work-dir"
   dnsPolicy: Default
   volumes:
-  - name: workdir
+  - name: skydive-test-pod-workdir
     emptyDir: {}

--- a/tests/k8s/replicaset.yaml
+++ b/tests/k8s/replicaset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
-  name: skydive-test
+  name: skydive-test-replicaset
   labels:
     app: guestbook
     tier: frontend
@@ -21,7 +21,7 @@ spec:
         tier: frontend
     spec:
       containers:
-      - name: php-redis
+      - name: skydive-test-replicaset-php-redis
         image: gcr.io/google_samples/gb-frontend:v3
         resources:
           requests:

--- a/tests/k8s/service.yaml
+++ b/tests/k8s/service.yaml
@@ -1,7 +1,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: skydive-test
+  name: skydive-test-service
 spec:
   ports:
   - protocol: TCP

--- a/tests/k8s/statefulset.yaml
+++ b/tests/k8s/statefulset.yaml
@@ -1,44 +1,44 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nginx
+  name: skydive-test-statefulset-nginx
   labels:
-    app: nginx
+    app: skydive-test-statefulset-nginx
 spec:
   ports:
   - port: 80
-    name: web
+    name: skydive-test-statefulset
   clusterIP: None
   selector:
-    app: nginx
+    app: skydive-test-statefulset-nginx
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: web
+  name: skydive-test-statefulset
 spec:
-  serviceName: "nginx"
+  serviceName: "skydive-test-statefulset-nginx"
   replicas: 2
   selector:
     matchLabels:
-      app: nginx
+      app: skydive-test-statefulset-nginx
   template:
     metadata:
       labels:
-        app: nginx
+        app: skydive-test-statefulset-nginx
     spec:
       containers:
-      - name: nginx
+      - name: skydive-test-statefulset-nginx
         image: k8s.gcr.io/nginx-slim:0.8
         ports:
         - containerPort: 80
-          name: web
+          name: skydive-test-statefulset-web
         volumeMounts:
-        - name: www
+        - name: skydive-test-statefulset-www
           mountPath: /usr/share/nginx/html
   volumeClaimTemplates:
   - metadata:
-      name: www
+      name: skydive-test-statefulset-www
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:

--- a/tests/k8s_test.go
+++ b/tests/k8s_test.go
@@ -41,26 +41,14 @@ func k8sConfigFile(name string) string {
 }
 
 const (
-	manager  = "k8s"
-	objName  = "skydive-test"
-	k8sRetry = 10
-	k8sDelay = time.Second
+	clusterName = "cluster"
+	k8sRetry    = 10
+	k8sDelay    = time.Second
+	manager     = "k8s"
+	objName     = "skydive-test"
 )
 
-var (
-	nodeName, _       = os.Hostname()
-	podName           = objName
-	containerName     = objName
-	daemonSetName     = objName
-	deploymentName    = objName
-	ingressName       = objName
-	jobName           = objName
-	networkPolicyName = objName
-	namespaceName     = objName
-	replicaSetName    = objName
-	serviceName       = objName
-	clusterName       = "cluster"
-)
+var nodeName, _ = os.Hostname()
 
 func setupFromConfigFile(ty, name string) []helper.Cmd {
 	return []helper.Cmd{
@@ -149,31 +137,31 @@ func TestK8sClusterNode(t *testing.T) {
 }
 
 func TestK8sContainerNode(t *testing.T) {
-	testNodeCreationFromConfig(t, "container", containerName)
+	testNodeCreationFromConfig(t, "container", objName+"-container")
 }
 
 func TestK8sDeploymentNode(t *testing.T) {
-	testNodeCreationFromConfig(t, "deployment", deploymentName)
+	testNodeCreationFromConfig(t, "deployment", objName+"-deployment")
 }
 
 func TestK8sIngressNode(t *testing.T) {
-	testNodeCreationFromConfig(t, "ingress", ingressName)
+	testNodeCreationFromConfig(t, "ingress", objName+"-ingress")
 }
 
 func TestK8sJobNode(t *testing.T) {
-	testNodeCreationFromConfig(t, "job", jobName)
+	testNodeCreationFromConfig(t, "job", objName+"-job")
 }
 
 func TestK8sNamespaceNode(t *testing.T) {
-	testNodeCreationFromConfig(t, "namespace", namespaceName)
+	testNodeCreationFromConfig(t, "namespace", objName+"-namespace")
 }
 
 func TestK8sDaemonSetNode(t *testing.T) {
-	testNodeCreationFromConfig(t, "daemonset", daemonSetName)
+	testNodeCreationFromConfig(t, "daemonset", objName+"-daemonset")
 }
 
 func TestK8sNetworkPolicyNode(t *testing.T) {
-	testNodeCreationFromConfig(t, "networkpolicy", networkPolicyName)
+	testNodeCreationFromConfig(t, "networkpolicy", objName+"-networkpolicy")
 }
 
 func TestK8sNodeNode(t *testing.T) {
@@ -189,11 +177,11 @@ func TestK8sPersistentVolumeClaimNode(t *testing.T) {
 }
 
 func TestK8sPodNode(t *testing.T) {
-	testNodeCreationFromConfig(t, "pod", podName)
+	testNodeCreationFromConfig(t, "pod", objName+"-pod")
 }
 
 func TestK8sReplicaSetNode(t *testing.T) {
-	testNodeCreationFromConfig(t, "replicaset", replicaSetName)
+	testNodeCreationFromConfig(t, "replicaset", objName+"-replicaset")
 }
 
 func TestK8sReplicationControllerNode(t *testing.T) {
@@ -201,11 +189,11 @@ func TestK8sReplicationControllerNode(t *testing.T) {
 }
 
 func TestK8sServiceNode(t *testing.T) {
-	testNodeCreationFromConfig(t, "service", serviceName)
+	testNodeCreationFromConfig(t, "service", objName+"-service")
 }
 
 func TestK8sStatefulSetNode(t *testing.T) {
-	testNodeCreationFromConfig(t, "statefulset", "web")
+	testNodeCreationFromConfig(t, "statefulset", objName+"-statefulset")
 }
 
 /* -- test multi-node scenarios -- */


### PR DESCRIPTION
this changes introduces unique naming of objects each test creates, to ensure that when run in parallel one test does not conflict with another test.

To verify no degradations were introduced - we need to verify k8s functional passes 
