### PR TITLE
ci: fix copr build

### DIFF
--- a/contrib/packaging/rpm/skydive.spec
+++ b/contrib/packaging/rpm/skydive.spec
@@ -9,7 +9,7 @@
 %define gotest() go test -compiler gc -ldflags "${LDFLAGS:-}" %{?**};
 %endif
 
-%define extracttag() %(eval "echo %1 | cut -d '-' -f 2-")
+%define extracttag() %(eval "echo %1 | cut -s -d '-' -f 2-")
 %define extractversion() %(eval "echo %1 | cut -d '-' -f 1")
 %define normalize() %(eval "echo %1 | tr '-' '.'")
 
@@ -19,7 +19,9 @@
 
 %if %{defined fullver}
 %define vertag %extracttag %{fullver}
+%if "%{vertag}" != ""
 %define tag %normalize 0.%{vertag}
+%endif
 %endif
 
 %{!?fullver:%global fullver 0.18.0}

--- a/scripts/ci/build-copr.sh
+++ b/scripts/ci/build-copr.sh
@@ -24,7 +24,8 @@ token = $COPR_TOKEN
 copr_url = https://copr.fedorainfracloud.org
 EOF
 
-contrib/packaging/rpm/generate-skydive-bootstrap.sh -s -r ${TAG}
+gitdir=$(cd "$(dirname "$0")/../.."; pwd)
+make -s -C $gitdir srpm
 
 if [ -n "$DRY_RUN" ]; then
     echo "Running in dry run mode. Do not build package."


### PR DESCRIPTION
skip skydive-go-fmt skip skydive-functional-tests-backend-elasticsearch skip skydive-functional-tests-backend-orientdb skip skydive-scale-tests skip skydive-selenium-tests skip skydive-unit-tests skip skydive-compile-tests skip skydive-k8s-tests