### PR TITLE
topology: add node/edge apis

### DIFF
--- a/api/server/edgerule.go
+++ b/api/server/edgerule.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package server
+
+import (
+	"github.com/nu7hatch/gouuid"
+
+	"github.com/skydive-project/skydive/api/types"
+	shttp "github.com/skydive-project/skydive/http"
+	"github.com/skydive-project/skydive/topology/graph"
+)
+
+// EdgeRuleResourceHandler describes a edge rule resource handler
+type EdgeRuleResourceHandler struct {
+	ResourceHandler
+}
+
+// EdgeRuleAPI based on BasicAPIHandler
+type EdgeRuleAPI struct {
+	BasicAPIHandler
+	Graph *graph.Graph
+}
+
+// Name returns resource name "edgerule"
+func (erh *EdgeRuleResourceHandler) Name() string {
+	return "edgerule"
+}
+
+// New creates a new EdgeRule
+func (erh *EdgeRuleResourceHandler) New() types.Resource {
+	id, _ := uuid.NewV4()
+
+	return &types.EdgeRule{
+		UUID: id.String(),
+	}
+}
+
+// RegisterEdgeRuleAPI registers an EdgeRule's API to a designated API Server
+func RegisterEdgeRuleAPI(apiServer *Server, g *graph.Graph, authBackend shttp.AuthenticationBackend) (*EdgeRuleAPI, error) {
+	era := &EdgeRuleAPI{
+		BasicAPIHandler: BasicAPIHandler{
+			ResourceHandler: &EdgeRuleResourceHandler{},
+			EtcdKeyAPI:      apiServer.EtcdKeyAPI,
+		},
+		Graph: g,
+	}
+	if err := apiServer.RegisterAPIHandler(era, authBackend); err != nil {
+		return nil, err
+	}
+
+	return era, nil
+}

--- a/api/server/noderule.go
+++ b/api/server/noderule.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package server
+
+import (
+	"github.com/nu7hatch/gouuid"
+
+	"github.com/skydive-project/skydive/api/types"
+	shttp "github.com/skydive-project/skydive/http"
+	"github.com/skydive-project/skydive/topology/graph"
+)
+
+// NodeRuleResourceHandler describes a node resource handler
+type NodeRuleResourceHandler struct {
+	ResourceHandler
+}
+
+// NodeRuleAPI based on BasicAPIHandler
+type NodeRuleAPI struct {
+	BasicAPIHandler
+	Graph *graph.Graph
+}
+
+// Name returns resource name "noderule"
+func (nrh *NodeRuleResourceHandler) Name() string {
+	return "noderule"
+}
+
+// New creates a new node rule
+func (nrh *NodeRuleResourceHandler) New() types.Resource {
+	id, _ := uuid.NewV4()
+
+	return &types.NodeRule{
+		UUID: id.String(),
+	}
+}
+
+func (nra *NodeRuleAPI) Create(r types.Resource) error {
+	return nra.BasicAPIHandler.Create(r)
+}
+
+// RegisterNodeRuleAPI register a new node rule api handler
+func RegisterNodeRuleAPI(apiServer *Server, g *graph.Graph, authBackend shttp.AuthenticationBackend) (*NodeRuleAPI, error) {
+	nra := &NodeRuleAPI{
+		BasicAPIHandler: BasicAPIHandler{
+			ResourceHandler: &NodeRuleResourceHandler{},
+			EtcdKeyAPI:      apiServer.EtcdKeyAPI,
+		},
+		Graph: g,
+	}
+	if err := apiServer.RegisterAPIHandler(nra, authBackend); err != nil {
+		return nil, err
+	}
+
+	return nra, nil
+}

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	shttp "github.com/skydive-project/skydive/http"
+	"github.com/skydive-project/skydive/topology/graph"
 )
 
 // Resource used as interface resources for each API
@@ -189,4 +190,43 @@ type Workflow struct {
 	Description   string          `yaml:"description"`
 	Parameters    []WorkflowParam `yaml:"parameters"`
 	Source        string          `valid:"isValidWorkflow" yaml:"source"`
+}
+
+// NodeRule describes a node rule
+type NodeRule struct {
+	UUID     string
+	Type     string `valid:"nonzero"`
+	Name     string `valid:"nonzero"`
+	Metadata graph.Metadata
+	Action   string `valid:"regexp=^(create|update)$"`
+	Query    string
+}
+
+// ID returns the node rule ID
+func (n *NodeRule) ID() string {
+	return n.UUID
+}
+
+// SetID set ID
+func (n *NodeRule) SetID(id string) {
+	n.UUID = id
+}
+
+// EdgeRule describes a edge rule
+type EdgeRule struct {
+	UUID         string
+	Src          string `valid:"isGremlinExpr"`
+	Dst          string `valid:"isGremlinExpr"`
+	RelationType string `valid:"regexp=^(layer2|ownership|both)$"`
+	Metadata     graph.Metadata
+}
+
+// ID returns the edge rule ID
+func (e *EdgeRule) ID() string {
+	return e.UUID
+}
+
+// SetID set ID
+func (e *EdgeRule) SetID(id string) {
+	e.UUID = id
 }

--- a/cmd/client/client.go
+++ b/cmd/client/client.go
@@ -58,6 +58,8 @@ func RegisterClientCommands(cmd *cobra.Command) {
 	cmd.AddCommand(TopologyCmd)
 	cmd.AddCommand(UserMetadataCmd)
 	cmd.AddCommand(WorkflowCmd)
+	cmd.AddCommand(NodeRuleCmd)
+	cmd.AddCommand(EdgeRuleCmd)
 }
 
 func init() {

--- a/cmd/client/edgerule.go
+++ b/cmd/client/edgerule.go
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package client
+
+import (
+	"os"
+
+	"github.com/skydive-project/skydive/api/client"
+	api "github.com/skydive-project/skydive/api/types"
+	"github.com/skydive-project/skydive/logging"
+	"github.com/skydive-project/skydive/topology/enhancers"
+	"github.com/skydive-project/skydive/topology/graph"
+	"github.com/skydive-project/skydive/validator"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	src          string
+	dst          string
+	relationType string
+)
+
+// EdgeRuleCmd skydive edge rule root command
+var EdgeRuleCmd = &cobra.Command{
+	Use:          "edge-rule",
+	Short:        "edge-rule",
+	Long:         "edge-rule",
+	SilenceUsage: false,
+}
+
+// EdgeRuleCreate skydive edge create command
+var EdgeRuleCreate = &cobra.Command{
+	Use:          "create",
+	Short:        "create",
+	Long:         "create",
+	SilenceUsage: false,
+
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := client.NewCrudClientFromConfig(&AuthenticationOpts)
+		if err != nil {
+			logging.GetLogger().Error(err.Error())
+			os.Exit(1)
+		}
+
+		m, err := usertopology.DefToMetadata(metadata, graph.Metadata{"RelationType": relationType})
+		if err != nil {
+			logging.GetLogger().Error(err.Error())
+			os.Exit(1)
+		}
+
+		edge := &api.EdgeRule{
+			Src:          src,
+			Dst:          dst,
+			RelationType: relationType,
+			Metadata:     m,
+		}
+
+		if err = validator.Validate(edge); err != nil {
+			logging.GetLogger().Error(err.Error())
+			os.Exit(1)
+		}
+
+		if err = client.Create("edgerule", &edge); err != nil {
+			logging.GetLogger().Error(err.Error())
+			os.Exit(1)
+		}
+
+		printJSON(edge)
+	},
+}
+
+// EdgeRuleGet skydive edge get command
+var EdgeRuleGet = &cobra.Command{
+	Use:          "get",
+	Short:        "get",
+	Long:         "get",
+	SilenceUsage: false,
+
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			cmd.Usage()
+			os.Exit(1)
+		}
+	},
+
+	Run: func(cmd *cobra.Command, args []string) {
+		var edge api.EdgeRule
+		client, err := client.NewCrudClientFromConfig(&AuthenticationOpts)
+		if err != nil {
+			logging.GetLogger().Error(err.Error())
+			os.Exit(1)
+		}
+		if err := client.Get("edgerule", args[0], &edge); err != nil {
+			logging.GetLogger().Error(err.Error())
+			os.Exit(1)
+		}
+		printJSON(&edge)
+	},
+}
+
+// EdgeRuleList skydive edge list command
+var EdgeRuleList = &cobra.Command{
+	Use:          "list",
+	Short:        "list",
+	Long:         "list",
+	SilenceUsage: false,
+
+	Run: func(cmd *cobra.Command, args []string) {
+		var edges map[string]api.EdgeRule
+		client, err := client.NewCrudClientFromConfig(&AuthenticationOpts)
+		if err != nil {
+			logging.GetLogger().Error(err.Error())
+			os.Exit(1)
+		}
+
+		if err := client.List("edgerule", &edges); err != nil {
+			logging.GetLogger().Error(err.Error())
+			os.Exit(1)
+		}
+		printJSON(edges)
+	},
+}
+
+// EdgeRuleDelete skydive edge delete command
+var EdgeRuleDelete = &cobra.Command{
+	Use:          "delete",
+	Short:        "delete",
+	Long:         "delete",
+	SilenceUsage: false,
+
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			cmd.Usage()
+			os.Exit(1)
+		}
+	},
+
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := client.NewCrudClientFromConfig(&AuthenticationOpts)
+		if err != nil {
+			logging.GetLogger().Error(err.Error())
+			os.Exit(1)
+		}
+
+		for _, id := range args {
+			if err := client.Delete("edgerule", id); err != nil {
+				logging.GetLogger().Error(err.Error())
+			}
+		}
+	},
+}
+
+func addCreateEdgeRuleFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&src, "src", "", "", "src node gremlin expression")
+	cmd.Flags().StringVarP(&dst, "dst", "", "", "dst node gremlin expression")
+	cmd.Flags().StringVarP(&relationType, "relationtype", "", "", "relation type: 'layer2', 'ownership' and 'both'")
+	cmd.Flags().StringVarP(&metadata, "metadata", "", "", "edge metadata")
+}
+
+func init() {
+	EdgeRuleCmd.AddCommand(EdgeRuleCreate)
+	EdgeRuleCmd.AddCommand(EdgeRuleList)
+	EdgeRuleCmd.AddCommand(EdgeRuleGet)
+	EdgeRuleCmd.AddCommand(EdgeRuleDelete)
+
+	addCreateEdgeRuleFlags(EdgeRuleCreate)
+}

--- a/cmd/client/noderule.go
+++ b/cmd/client/noderule.go
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package client
+
+import (
+	"os"
+
+	"github.com/skydive-project/skydive/api/client"
+	api "github.com/skydive-project/skydive/api/types"
+	"github.com/skydive-project/skydive/logging"
+	"github.com/skydive-project/skydive/topology/enhancers"
+	"github.com/skydive-project/skydive/topology/graph"
+	"github.com/skydive-project/skydive/validator"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	nodeName string
+	nodeType string
+	metadata string
+	query    string
+	action   string
+)
+
+// NodeRuleCmd skydive node rule root command
+var NodeRuleCmd = &cobra.Command{
+	Use:          "node-rule",
+	Short:        "node-rule",
+	Long:         "node-rule",
+	SilenceUsage: false,
+}
+
+// NodeRuleCreate skydive node create command
+var NodeRuleCreate = &cobra.Command{
+	Use:          "create",
+	Short:        "create",
+	Long:         "create",
+	SilenceUsage: false,
+
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := client.NewCrudClientFromConfig(&AuthenticationOpts)
+		if err != nil {
+			logging.GetLogger().Error(err.Error())
+			os.Exit(1)
+		}
+
+		m, err := usertopology.DefToMetadata(metadata, graph.Metadata{})
+		if err != nil {
+			logging.GetLogger().Error(err.Error())
+			os.Exit(1)
+		}
+
+		node := &api.NodeRule{
+			Type:     nodeType,
+			Name:     nodeName,
+			Metadata: m,
+			Query:    query,
+			Action:   action,
+		}
+
+		if err = validator.Validate(node); err != nil {
+			logging.GetLogger().Error(err.Error())
+			os.Exit(1)
+		}
+
+		if err = client.Create("noderule", &node); err != nil {
+			logging.GetLogger().Error(err.Error())
+			os.Exit(1)
+		}
+
+		printJSON(node)
+	},
+}
+
+// NodeRuleGet skydive node get command
+var NodeRuleGet = &cobra.Command{
+	Use:          "get",
+	Short:        "get",
+	Long:         "get",
+	SilenceUsage: false,
+
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			cmd.Usage()
+			os.Exit(1)
+		}
+	},
+
+	Run: func(cmd *cobra.Command, args []string) {
+		var node api.NodeRule
+		client, err := client.NewCrudClientFromConfig(&AuthenticationOpts)
+		if err != nil {
+			logging.GetLogger().Error(err.Error())
+			os.Exit(1)
+		}
+		if err := client.Get("noderule", args[0], &node); err != nil {
+			logging.GetLogger().Error(err.Error())
+			os.Exit(1)
+		}
+		printJSON(&node)
+	},
+}
+
+// NodeRuleList skydive node list command
+var NodeRuleList = &cobra.Command{
+	Use:          "list",
+	Short:        "list",
+	Long:         "list",
+	SilenceUsage: false,
+
+	Run: func(cmd *cobra.Command, args []string) {
+		var nodes map[string]api.NodeRule
+		client, err := client.NewCrudClientFromConfig(&AuthenticationOpts)
+		if err != nil {
+			logging.GetLogger().Error(err.Error())
+			os.Exit(1)
+		}
+
+		if err := client.List("noderule", &nodes); err != nil {
+			logging.GetLogger().Error(err.Error())
+			os.Exit(1)
+		}
+		printJSON(nodes)
+	},
+}
+
+// NodeRuleDelete skydive node delete command
+var NodeRuleDelete = &cobra.Command{
+	Use:          "delete",
+	Short:        "delete",
+	Long:         "delete",
+	SilenceUsage: false,
+
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			cmd.Usage()
+			os.Exit(1)
+		}
+	},
+
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := client.NewCrudClientFromConfig(&AuthenticationOpts)
+		if err != nil {
+			logging.GetLogger().Error(err.Error())
+			os.Exit(1)
+		}
+
+		for _, id := range args {
+			if err := client.Delete("noderule", id); err != nil {
+				logging.GetLogger().Error(err.Error())
+			}
+		}
+	},
+}
+
+func addCreateNodeRuleFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&nodeName, "name", "", "", "node name")
+	cmd.Flags().StringVarP(&nodeType, "type", "", "", "node type")
+	cmd.Flags().StringVarP(&metadata, "metadata", "", "", "node metadata, key value pairs. 'k1=v1, k2=v2'")
+	cmd.Flags().StringVarP(&query, "query", "", "", "gremlin query")
+	cmd.Flags().StringVarP(&action, "action", "", "", "action: create or update")
+}
+
+func init() {
+	NodeRuleCmd.AddCommand(NodeRuleCreate)
+	NodeRuleCmd.AddCommand(NodeRuleList)
+	NodeRuleCmd.AddCommand(NodeRuleGet)
+	NodeRuleCmd.AddCommand(NodeRuleDelete)
+
+	addCreateNodeRuleFlags(NodeRuleCreate)
+}

--- a/rbac/policy.csv
+++ b/rbac/policy.csv
@@ -18,6 +18,10 @@ p, admin, websocket, /ws/flow, allow
 p, admin, websocket, /ws/publisher, allow
 p, admin, websocket, /ws/replication, allow
 p, admin, websocket, /ws/subscriber, allow
+p, admin, noderule, read, allow
+p, admin, noderule, write, allow
+p, admin, edgerule, read, allow
+p, admin, edgerule, write, allow
 
 p, guest, alert, read, deny
 p, guest, alert, write, deny

--- a/topology/enhancers/topology_manager.go
+++ b/topology/enhancers/topology_manager.go
@@ -1,0 +1,313 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package usertopology
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/nu7hatch/gouuid"
+
+	apiServer "github.com/skydive-project/skydive/api/server"
+	"github.com/skydive-project/skydive/api/types"
+	"github.com/skydive-project/skydive/common"
+	"github.com/skydive-project/skydive/etcd"
+	ge "github.com/skydive-project/skydive/gremlin/traversal"
+	"github.com/skydive-project/skydive/logging"
+	"github.com/skydive-project/skydive/topology"
+	"github.com/skydive-project/skydive/topology/graph"
+)
+
+// TopologyManager describes topology manager
+type TopologyManager struct {
+	*etcd.MasterElector
+	graph.DefaultGraphListener
+	watcher1    apiServer.StoppableWatcher
+	watcher2    apiServer.StoppableWatcher
+	nodeHandler *apiServer.NodeRuleAPI
+	edgeHandler *apiServer.EdgeRuleAPI
+	graph       *graph.Graph
+}
+
+func DefToMetadata(def string, metadata graph.Metadata) (graph.Metadata, error) {
+	if def == "" {
+		return metadata, nil
+	}
+
+	for _, pair := range strings.Split(def, ",") {
+		pair = strings.TrimSpace(pair)
+
+		kv := strings.Split(pair, "=")
+		if len(kv)%2 != 0 {
+			return nil, fmt.Errorf("attributes must be defined by pair k=v: %v", def)
+		}
+		key := strings.Trim(kv[0], `"`)
+		value := strings.Trim(kv[1], `"`)
+
+		common.SetField(metadata, key, value)
+	}
+
+	return metadata, nil
+}
+
+// OnStartAsMaster event
+func (tm *TopologyManager) OnStartAsMaster() {
+}
+
+// OnStartAsSlave event
+func (tm *TopologyManager) OnStartAsSlave() {
+}
+
+// OnSwitchToMaster event
+func (tm *TopologyManager) OnSwitchToMaster() {
+	tm.syncTopology()
+}
+
+// OnSwitchToSlave event
+func (tm *TopologyManager) OnSwitchToSlave() {
+}
+
+func (tm *TopologyManager) syncTopology() {
+	nodes := tm.nodeHandler.Index()
+	edges := tm.edgeHandler.Index()
+
+	for _, node := range nodes {
+		n := node.(*types.NodeRule)
+		tm.handleCreateNode(n)
+	}
+
+	for _, edge := range edges {
+		e := edge.(*types.EdgeRule)
+		tm.createEdge(e)
+	}
+}
+
+func (tm *TopologyManager) createEdge(edge *types.EdgeRule) error {
+	src := tm.getNodes(edge.Src)
+	dst := tm.getNodes(edge.Dst)
+	if len(src) < 1 || len(dst) < 1 {
+		logging.GetLogger().Errorf("Source or Destination node not found")
+		return errors.New("Source or Destination node not found")
+	}
+
+	switch edge.RelationType {
+	case "layer2":
+		if !topology.HaveLayer2Link(tm.graph, src[0], dst[0]) {
+			topology.AddLayer2Link(tm.graph, src[0], dst[0], edge.Metadata)
+		}
+	case "ownership":
+		if !topology.HaveOwnershipLink(tm.graph, src[0], dst[0]) {
+			topology.AddOwnershipLink(tm.graph, src[0], dst[0], nil)
+		}
+	case "both":
+		if !topology.HaveLayer2Link(tm.graph, src[0], dst[0]) {
+			topology.AddLayer2Link(tm.graph, src[0], dst[0], edge.Metadata)
+		}
+		if !topology.HaveOwnershipLink(tm.graph, src[0], dst[0]) {
+			topology.AddOwnershipLink(tm.graph, src[0], dst[0], nil)
+		}
+	}
+	return nil
+}
+
+func (tm *TopologyManager) createNode(node *types.NodeRule) error {
+	u, _ := uuid.NewV5(uuid.NamespaceOID, []byte(node.Type+node.Name))
+	id := graph.Identifier(u.String())
+	common.SetField(node.Metadata, "TID", id)
+
+	if _, ok := node.Metadata["Name"]; !ok {
+		common.SetField(node.Metadata, "Name", node.Name)
+	}
+
+	//check node already exist
+	if n := tm.graph.GetNode(id); n != nil {
+		return nil
+	}
+
+	if node.Type == "fabric" {
+		common.SetField(node.Metadata, "Probe", node.Type)
+	}
+
+	tm.graph.NewNode(id, node.Metadata, "")
+	return nil
+}
+
+func (tm *TopologyManager) updateMetadata(query string, mdata graph.Metadata) error {
+	nodes := tm.getNodes(query)
+	for _, n := range nodes {
+		mt := tm.graph.StartMetadataTransaction(n)
+		for k, v := range mdata {
+			mt.AddMetadata("UserMetadata."+k, v)
+		}
+		mt.Commit()
+	}
+	return nil
+}
+
+func (tm *TopologyManager) deleteMetadata(query string, mdata graph.Metadata) error {
+	nodes := tm.getNodes(query)
+	for _, n := range nodes {
+		mt := tm.graph.StartMetadataTransaction(n)
+		for k := range mdata {
+			mt.DelMetadata("UserMetadata." + k)
+		}
+		mt.Commit()
+	}
+
+	tm.syncTopology()
+	return nil
+}
+
+func (tm *TopologyManager) handleCreateNode(node *types.NodeRule) error {
+	switch strings.ToLower(node.Action) {
+	case "create":
+		return tm.createNode(node)
+	case "update":
+		return tm.updateMetadata(node.Query, node.Metadata)
+	default:
+		logging.GetLogger().Errorf("Query format is wrong. supported prefixes: create and update")
+		return errors.New("Query format is wrong")
+	}
+}
+
+/*This needs to be replaced by gremlin + JS query*/
+func (tm *TopologyManager) getNodes(gremlinQuery string) []*graph.Node {
+	res, err := ge.TopologyGremlinQuery(tm.graph, gremlinQuery)
+	if err != nil {
+		return nil
+	}
+
+	var nodes []*graph.Node
+	for _, value := range res.Values() {
+		switch value.(type) {
+		case *graph.Node:
+			nodes = append(nodes, value.(*graph.Node))
+		case []*graph.Node:
+			nodes = append(nodes, value.([]*graph.Node)...)
+		}
+	}
+	return nodes
+}
+
+func (tm *TopologyManager) handleNodeRuleRequest(action string, resource types.Resource) error {
+	node := resource.(*types.NodeRule)
+	switch action {
+	case "create", "set":
+		return tm.handleCreateNode(node)
+	case "delete":
+		switch strings.ToLower(node.Action) {
+		case "create":
+			u, _ := uuid.NewV5(uuid.NamespaceOID, []byte(node.Type+node.Name))
+			id := graph.Identifier(u.String())
+			if n := tm.graph.GetNode(id); n != nil {
+				tm.graph.DelNode(n)
+			}
+		case "update":
+			tm.deleteMetadata(node.Query, node.Metadata)
+		}
+	}
+	return nil
+}
+
+func (tm *TopologyManager) handleEdgeRuleRequest(action string, resource types.Resource) {
+	edge := resource.(*types.EdgeRule)
+	switch action {
+	case "create", "set":
+		tm.createEdge(edge)
+	case "delete":
+		src := tm.getNodes(edge.Src)
+		dst := tm.getNodes(edge.Dst)
+		if len(src) < 1 || len(dst) < 1 {
+			logging.GetLogger().Errorf("Source or Destination node not found")
+			return
+		}
+		if link := tm.graph.GetFirstLink(src[0], dst[0], graph.Metadata{"RelationType": edge.RelationType}); link != nil {
+			tm.graph.DelEdge(link)
+		}
+	}
+}
+
+func (tm *TopologyManager) onAPIWatcherEvent(action string, id string, resource types.Resource) {
+	switch resource.(type) {
+	case *types.NodeRule:
+		tm.graph.Lock()
+		if err := tm.handleNodeRuleRequest(action, resource); err != nil {
+			tm.nodeHandler.BasicAPIHandler.Delete(id)
+		}
+		tm.graph.Unlock()
+	case *types.EdgeRule:
+		tm.graph.Lock()
+		tm.handleEdgeRuleRequest(action, resource)
+		tm.graph.Unlock()
+	}
+}
+
+// OnNodeAdded event
+func (tm *TopologyManager) OnNodeAdded(n *graph.Node) {
+	tm.syncTopology()
+}
+
+// OnNodeUpdated event
+func (tm *TopologyManager) OnNodeUpdated(n *graph.Node) {
+	tm.syncTopology()
+}
+
+// Start start the topology manager
+func (tm *TopologyManager) Start() {
+	tm.MasterElector.StartAndWait()
+
+	tm.watcher1 = tm.nodeHandler.AsyncWatch(tm.onAPIWatcherEvent)
+	tm.watcher2 = tm.edgeHandler.AsyncWatch(tm.onAPIWatcherEvent)
+
+	tm.graph.AddEventListener(tm)
+}
+
+// Stop stop the topology manager
+func (tm *TopologyManager) Stop() {
+	tm.watcher1.Stop()
+	tm.watcher2.Stop()
+
+	tm.MasterElector.Stop()
+
+	tm.graph.RemoveEventListener(tm)
+}
+
+// NewTopologyManager returns new topology manager
+func NewTopologyManager(etcdClient *etcd.Client, nodeHandler *apiServer.NodeRuleAPI, edgeHandler *apiServer.EdgeRuleAPI, g *graph.Graph) *TopologyManager {
+	elector := etcd.NewMasterElectorFromConfig(common.AnalyzerService, "topology-manager", etcdClient)
+
+	tm := &TopologyManager{
+		MasterElector: elector,
+		nodeHandler:   nodeHandler,
+		edgeHandler:   edgeHandler,
+		graph:         g,
+	}
+
+	elector.AddEventListener(tm)
+
+	tm.graph.Lock()
+	tm.syncTopology()
+	tm.graph.Unlock()
+	return tm
+}

--- a/topology/enhancers/user_metadata.go
+++ b/topology/enhancers/user_metadata.go
@@ -20,7 +20,7 @@
  *
  */
 
-package metadata
+package usertopology
 
 import (
 	"github.com/skydive-project/skydive/api/server"


### PR DESCRIPTION
sample command to create a fabric node:
```
skydive client node create --name="node1" --type="fabric" --query="create:" --metadata="fd=sdf"
skydive client node create --name="node2" --type="fabric" --query="create:" --metadata="fds=sdf"
skydive client edge create --src="g.v().has('Name', 'node1')" --dst="g.v().has('Name', 'node2')" --realtiontype="both"
skydive client edge create --src="g.v().has('Name', 'lo', 'State', 'UP')" --dst="g.v().has('Name', 'node1')" --realtiontype="layer2"
```
