### PR TITLE
k8s: extend netpol for namespaces

### DIFF
--- a/tests/k8s/networkpolicy1.yaml
+++ b/tests/k8s/networkpolicy1.yaml
@@ -1,0 +1,14 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: skydive-test-networkpolicy1
+  labels:
+    name: skydive-test-networkpolicy1
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  namespace: skydive-test-networkpolicy1
+  name: skydive-test-networkpolicy1
+spec:
+  podSelector: {}

--- a/tests/k8s/networkpolicy2.yaml
+++ b/tests/k8s/networkpolicy2.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: skydive-test-networkpolicy2
+  labels:
+    app: skydive-test-networkpolicy2
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: skydive-test-networkpolicy2
+spec:
+  podSelector:
+    matchLabels:
+      app: skydive-test-networkpolicy2

--- a/tests/k8s_test.go
+++ b/tests/k8s_test.go
@@ -280,3 +280,61 @@ func TestHelloNodeScenario(t *testing.T) {
 		},
 	)
 }
+
+func TestK8sNetworkPolicyScenario1(t *testing.T) {
+	file := "networkpolicy1"
+	name := objName + "-" + file
+	testRunner(
+		t,
+		setupFromConfigFile(file),
+		tearDownFromConfigFile(file),
+		[]CheckFunction{
+			func(c *CheckContext) error {
+				networkpolicy, err := checkNodeCreation(t, c, "networkpolicy", "Name", name)
+				if err != nil {
+					return err
+				}
+
+				namespace, err := checkNodeCreation(t, c, "namespace", "Name", name)
+				if err != nil {
+					return err
+				}
+
+				if err = checkEdgeCreation(t, c, networkpolicy, namespace, "association"); err != nil {
+					return err
+				}
+
+				return nil
+			},
+		},
+	)
+}
+
+func TestK8sNetworkPolicyScenario2(t *testing.T) {
+	file := "networkpolicy2"
+	name := objName + "-" + file
+	testRunner(
+		t,
+		setupFromConfigFile(file),
+		tearDownFromConfigFile(file),
+		[]CheckFunction{
+			func(c *CheckContext) error {
+				networkpolicy, err := checkNodeCreation(t, c, "networkpolicy", "Name", name)
+				if err != nil {
+					return err
+				}
+
+				pod, err := checkNodeCreation(t, c, "pod", "Name", name)
+				if err != nil {
+					return err
+				}
+
+				if err = checkEdgeCreation(t, c, networkpolicy, pod, "association"); err != nil {
+					return err
+				}
+
+				return nil
+			},
+		},
+	)
+}

--- a/topology/probes/k8s/graph.go
+++ b/topology/probes/k8s/graph.go
@@ -73,6 +73,7 @@ func dumpGraphLink(parent, child *graph.Node) string {
 func addLink(g *graph.Graph, parent, child *graph.Node) *graph.Edge {
 	m := newEdgeMetadata()
 	if e := g.GetFirstLink(parent, child, m); e != nil {
+		logging.GetLogger().Debugf("Adding link: %s: exists - skipping", dumpGraphLink(parent, child))
 		return e
 	}
 
@@ -83,6 +84,7 @@ func addLink(g *graph.Graph, parent, child *graph.Node) *graph.Edge {
 func delLink(g *graph.Graph, parent, child *graph.Node) {
 	m := newEdgeMetadata()
 	if e := g.GetFirstLink(parent, child, m); e == nil {
+		logging.GetLogger().Debugf("Deleting link: %s: missing - skipping", dumpGraphLink(parent, child))
 		return
 	}
 	logging.GetLogger().Debugf("Deleting link: %s", dumpGraphLink(parent, child))


### PR DESCRIPTION
Now netpol object is associated with both pods and namespaces:
* networkpolicy --association --> namespace
* networkpolicy --association --> pod

So that association does not conflict with ownership networkpolicy objects are owned by the cluster (not namespace).

The code includes two new test scenarios which verify association links have been created correctly.

NOTE: this PR depends on first merging: https://github.com/skydive-project/skydive/pull/1178
NOTE: this PR depends on first merging: https://github.com/skydive-project/skydive/pull/1182