### PR TITLE
k8s: enhance node metadata

### DIFF
--- a/tests/k8s_test.go
+++ b/tests/k8s_test.go
@@ -177,7 +177,7 @@ func TestK8sNetworkPolicyNode(t *testing.T) {
 }
 
 func TestK8sNodeNode(t *testing.T) {
-	testNodeCreation(t, nil, nil, "node", nodeName)
+	testNodeCreation(t, nil, nil, "node", nodeName, "Arch", "Cluster", "Hostname", "IP", "Labels", "OS")
 }
 
 func TestK8sPersistentVolumeNode(t *testing.T) {


### PR DESCRIPTION
Added new fields in node (k8s)  object such as:
- IP
- Hostname
- Cluster
- Labels
- Arch
- OS

Extended tests to cover.