### PR TITLE
netlink: fix race condition when adding links

### DIFF
--- a/topology/probes/netlink/netlink.go
+++ b/topology/probes/netlink/netlink.go
@@ -460,6 +460,9 @@ func (u *NetNsNetLinkProbe) addLinkToTopology(link netlink.Link) {
 		metadata["BondMode"] = link.(*netlink.Bond).Mode.String()
 	}
 
+	u.Graph.Lock()
+	defer u.Graph.Unlock()
+
 	var intf *graph.Node
 
 	switch driver {


### PR DESCRIPTION
when running with '-race' against k8s code which is under `graph.Lock()` I discovered a RACE condition of READ by `topology.AddOwnershipLink(..)`  (topology/probes/netlink/netlink.go:242)

```
        if !topology.HaveOwnershipLink(u.Graph, u.Root, intf) {
                topology.AddOwnershipLink(u.Graph, u.Root, intf, nil)
        }
```