### PR TITLE
K8s tests retry

### DIFF
--- a/tests/k8s/pod.yaml
+++ b/tests/k8s/pod.yaml
@@ -4,26 +4,7 @@ metadata:
   name: skydive-test-pod
 spec:
   containers:
-  - name: skydive-test-pod-nginx
+  - name: nginx
     image: nginx
     ports:
     - containerPort: 80
-    volumeMounts:
-    - name: skydive-test-pod-workdir
-      mountPath: /usr/share/nginx/html
-  # These containers are run during pod initialization
-  initContainers:
-  - name: skydive-test-pod-install
-    image: busybox
-    command:
-    - wget
-    - "-O"
-    - "/work-dir/index.html"
-    - http://kubernetes.io
-    volumeMounts:
-    - name: skydive-test-pod-workdir
-      mountPath: "/work-dir"
-  dnsPolicy: Default
-  volumes:
-  - name: skydive-test-pod-workdir
-    emptyDir: {}

--- a/topology/probes/k8s/cluster.go
+++ b/topology/probes/k8s/cluster.go
@@ -45,6 +45,7 @@ func newClusterLinkedObjectIndexer(g *graph.Graph) *graph.MetadataIndexer {
 		filters.NewTermStringFilter("Manager", managerValue),
 		filters.NewOrFilter(
 			filters.NewTermStringFilter("Type", "namespace"),
+			filters.NewTermStringFilter("Type", "networkpolicy"),
 			filters.NewTermStringFilter("Type", "node"),
 			filters.NewTermStringFilter("Type", "persistentvolume"),
 			filters.NewTermStringFilter("Type", "persistentvolumeclaim"),
@@ -74,7 +75,6 @@ func (p *clusterProbe) newMetadata(name string) graph.Metadata {
 
 func (p *clusterProbe) linkObject(objNode, clusterNode *graph.Node) {
 	addOwnershipLink(p.graph, clusterNode, objNode)
-	logging.GetLogger().Debugf("Added link: %s -> %s", dumpGraphNode(clusterNode), dumpGraphNode(objNode))
 }
 
 func (p *clusterProbe) addNode(name string) {

--- a/topology/probes/k8s/namespace.go
+++ b/topology/probes/k8s/namespace.go
@@ -52,7 +52,6 @@ func newObjectIndexer(g *graph.Graph) *graph.MetadataIndexer {
 		filters.NewTermStringFilter("Type", "pod"),
 		filters.NewTermStringFilter("Type", "persistentvolume"),
 		filters.NewTermStringFilter("Type", "persistentvolumeclaim"),
-		filters.NewTermStringFilter("Type", "networkpolicy"),
 		filters.NewTermStringFilter("Type", "replicaset"),
 		filters.NewTermStringFilter("Type", "replicationcontroller"),
 		filters.NewTermStringFilter("Type", "service"),
@@ -95,7 +94,6 @@ func namespaceUID(ns *v1.Namespace) graph.Identifier {
 
 func (p *namespaceProbe) linkObject(objNode, nsNode *graph.Node) {
 	addOwnershipLink(p.graph, nsNode, objNode)
-	logging.GetLogger().Debugf("Added link: %s -> %s", dumpGraphNode(nsNode), dumpGraphNode(objNode))
 }
 
 func (p *namespaceProbe) OnAdd(obj interface{}) {

--- a/topology/probes/k8s/pod.go
+++ b/topology/probes/k8s/pod.go
@@ -124,9 +124,8 @@ func (p *podProbe) OnAdd(obj interface{}) {
 	p.graph.Lock()
 	defer p.graph.Unlock()
 
-	logging.GetLogger().Debugf("Creating node for %s", dumpPod(pod))
-
 	p.onAdd(obj)
+	logging.GetLogger().Debugf("Added %s", dumpPod(pod))
 }
 
 func (p *podProbe) OnUpdate(oldObj, newObj interface{}) {
@@ -143,22 +142,22 @@ func (p *podProbe) OnUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	logging.GetLogger().Debugf("Updating node for %s", dumpPod(newPod))
 	if oldPod.Spec.NodeName == "" && newPod.Spec.NodeName != "" {
 		p.linkPodToNode(newPod, podNode)
 	}
 
 	addMetadata(p.graph, podNode, newPod)
+	logging.GetLogger().Debugf("Updated %s", dumpPod(newPod))
 }
 
 func (p *podProbe) OnDelete(obj interface{}) {
 	if pod, ok := obj.(*v1.Pod); ok {
-		logging.GetLogger().Debugf("Deleting node for %s", dumpPod(pod))
 		p.graph.Lock()
 		if podNode := p.graph.GetNode(podUID(pod)); podNode != nil {
 			p.graph.DelNode(podNode)
 		}
 		p.graph.Unlock()
+		logging.GetLogger().Debugf("Deleted %s", dumpPod(pod))
 	}
 }
 

--- a/topology/probes/k8s/probe.go
+++ b/topology/probes/k8s/probe.go
@@ -23,11 +23,24 @@
 package k8s
 
 import (
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/skydive-project/skydive/config"
 	"github.com/skydive-project/skydive/logging"
 	"github.com/skydive-project/skydive/probe"
 	"github.com/skydive-project/skydive/topology/graph"
 )
+
+func dumpObject(obj interface{}) string {
+	switch obj := obj.(type) {
+	case *corev1.Namespace:
+		return dumpNamespace(obj)
+	case *corev1.Pod:
+		return dumpPod(obj)
+	default:
+		return "<nil>"
+	}
+}
 
 // Probe for tracking k8s events
 type Probe struct {


### PR DESCRIPTION
Eliminated entire-check retry mechanism (3 x 1sec) ; so now only relaying on a per gremlin-query retry (3 x 10sec). As having both retrys set would cause a multiplication of retries possibly having 9 retry attempt - with the new code only 3 retry attempts at max.