### PR TITLE
Tests precleanup flag

### DIFF
--- a/tests/k8s_test.go
+++ b/tests/k8s_test.go
@@ -121,7 +121,8 @@ func testRunner(t *testing.T, setupCmds, tearDownCmds []helper.Cmd, checks []Che
 	test := &Test{
 		mode:         OneShot,
 		retries:      1,
-		setupCmds:    append(tearDownCmds, setupCmds...),
+		preCleanup:   true,
+		setupCmds:    setupCmds,
 		tearDownCmds: tearDownCmds,
 		checks:       checks,
 	}

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -165,6 +165,7 @@ type Test struct {
 	tearDownFunction func(c *TestContext) error
 	captures         []TestCapture
 	injections       []TestInjection
+	preCleanup       bool
 	retries          int
 	mode             int
 	checks           []CheckFunction
@@ -273,6 +274,9 @@ func RunTest(t *testing.T, test *Test) {
 	}
 
 	t.Log("Executing setup commands")
+	if test.preCleanup {
+		helper.ExecCmds(t, test.tearDownCmds...)
+	}
 	helper.ExecCmds(t, test.setupCmds...)
 
 	context := &TestContext{
@@ -347,6 +351,9 @@ func RunTest(t *testing.T, test *Test) {
 	context.setupTime = time.Now()
 
 	t.Log("Executing setup function")
+	if test.preCleanup && test.tearDownFunction != nil {
+		test.tearDownFunction(context)
+	}
 	if test.setupFunction != nil {
 		if err = test.setupFunction(context); err != nil {
 			g := context.getWholeGraph(t, context.setupTime)


### PR DESCRIPTION
add Test.preCleanup flag when set to `true` will run tearDown before running setup.

the k8s_tests make use of the flags, all other test have not changed (as flag is false by default).