### PR TITLE
K8s: netpol arrowheads

### DIFF
--- a/statics/css/graph-layout.css
+++ b/statics/css/graph-layout.css
@@ -105,11 +105,12 @@ circle.emphasized  {
   stroke-width: 2;
 }
 
-.links path.netpolicy {
-  stroke-dasharray: 20;
+.links path.networkpolicy {
+  stroke-dasharray: 5;
   stroke-dashoffset: 80;
   stroke: rgb(50, 109, 230);
-  stroke-width: 5;
+  stroke-width: 2;
+  opacity: 0.1;
 }
 
 .group {

--- a/statics/js/components/graph-layout.js
+++ b/statics/js/components/graph-layout.js
@@ -268,6 +268,38 @@ var TopologyGraphLayout = function(vm, selector) {
     .call(this.zoom)
     .on("dblclick.zoom", null);
 
+  var defsMarker = function(type, target) {
+    let id = "arrowhead-"+type+"-"+target
+
+    let refX = 1.65
+    let pathD = "M0,0 L0,0.3 L0.5,0.15 Z"
+    if (type === "egress") {
+      pathD = "M0.5,0 L0.5,0.3 L0,0.15 Z"
+    }
+
+    let color = "rgb(60, 179, 113, 0.4)"
+    if (target === "deny") {
+      color = "rgba(255, 99, 71, 0.4)"
+    }
+
+    self.svg.append("defs").append("marker")
+      .attr("id", id)
+      .attr("refX", refX)
+      .attr("refY", 0.15)
+      .attr("markerWidth", 1)
+      .attr("markerHeight", 1)
+      .attr("orient", "auto")
+      .attr("markerUnits", "strokeWidth")
+      .append("path")
+        .attr("fill", color)
+        .attr("d", pathD);
+  }
+
+  defsMarker("ingress", "deny");
+  defsMarker("ingress", "allow");
+  defsMarker("egress", "deny");
+  defsMarker("egress", "allow");
+
   this.g = this.svg.append("g");
 
   this.group = this.g.append("g").attr('class', 'groups').selectAll(".group");
@@ -1490,6 +1522,13 @@ TopologyGraphLayout.prototype = {
     this.tick();
   },
 
+  arrowhead: function(link) {
+    if (link.metadata.RelationType !== "networkpolicy") {
+      return "url(#arrowhead-none)";
+    }
+    return "url(#arrowhead-"+link.metadata.PolicyType+"-"+link.metadata.PolicyTarget+")";
+  },
+
   update: function() {
     var self = this;
 
@@ -1571,7 +1610,8 @@ TopologyGraphLayout.prototype = {
       .on("click", function(d) {self.onEdgeClick(d.link); })
       .on("mouseover", function(d) { self.highlightLink(d.link); })
       .on("mouseout", function(d) { self.unhighlightLink(d.link); })
-      .attr("class", this.linkWrapClass);
+      .attr("class", this.linkWrapClass)
+      .attr("marker-end", function(d) { return self.arrowhead(d.link); });
 
     this.linkWrap = linkWrapEnter.merge(this.linkWrap);
 

--- a/statics/js/components/graph-layout.js
+++ b/statics/js/components/graph-layout.js
@@ -289,7 +289,7 @@ var TopologyGraphLayout = function(vm, selector) {
   };
 
   this.loadBandwidthConfig()
-  self.bandwidth.intervalID = setInterval(self.updatelinkLatency.bind(self), self.bandwidth.updatePeriod);
+  self.bandwidth.intervalID = setInterval(self.updateLinkLabelHandler.bind(self), self.bandwidth.updatePeriod);
 };
 
 TopologyGraphLayout.prototype = {
@@ -1394,7 +1394,7 @@ TopologyGraphLayout.prototype = {
     return this.styleReturn(d, ["YellowGreen", "Yellow", "Tomato", ""]);
   },
 
-  updateLinkLabel: function() {
+  bindLinkLabelData: function() {
     this.linkLabel = this.linkLabel.data(Object.values(this.linkLabelData), function(d) { return d.id; });
   },
 
@@ -1428,48 +1428,46 @@ TopologyGraphLayout.prototype = {
     }
   },
 
-  updatelinkLatency: function() {
+  updateLinkLabelHandler: function() {
     var self = this;
 
     this.updateLinkLabelData();
-    this.updateLinkLabel();
-    var exit = this.linkLabel.exit();
+    this.bindLinkLabelData();
 
     // update links which don't have traffic
+    var exit = this.linkLabel.exit();
     exit.each(function(d) {
       self.g.select("#link-" + d.link.id)
-      .classed ("link-label-active", false)
-      .classed ("link-label-warning", false)
-      .classed ("link-label-alert", false)
+      .classed("link-label-active", false)
+      .classed("link-label-warning", false)
+      .classed("link-label-alert", false)
       .style("stroke-dasharray", "")
       .style("stroke-dashoffset", "")
       .style("animation", "")
       .style("stroke", "");
     });
-
     exit.remove();
 
-    var linkLabelEnter = this.linkLabel.enter()
+    var enter = this.linkLabel.enter()
       .append('text')
       .attr("id", function(d) { return "link-label-" + d.id; })
       .attr("class", "link-label");
-    linkLabelEnter.append('textPath')
+    enter.append('textPath')
       .attr("startOffset", "50%")
       .attr("xlink:href", function(d) { return "#link-" + d.link.id; } );
-
-    this.linkLabel = linkLabelEnter.merge(this.linkLabel);
+    this.linkLabel = enter.merge(this.linkLabel);
 
     this.linkLabel.select('textPath')
-      .classed ("link-label-active", function(d) { return d.active; })
-      .classed ("link-label-warning", function(d) { return d.warning; })
-      .classed ("link-label-alert",  function(d) { return d.alert; })
+      .classed("link-label-active", function(d) { return d.active; })
+      .classed("link-label-warning", function(d) { return d.warning; })
+      .classed("link-label-alert",  function(d) { return d.alert; })
       .text(function(d) { return d.text; });
 
     this.linkLabel.each(function(d) {
       self.g.select("#link-" + d.link.id)
-        .classed ("link-label-active", d.active)
-        .classed ("link-label-warning", d.warning)
-        .classed ("link-label-alert", d.alert)
+        .classed("link-label-active", d.active)
+        .classed("link-label-warning", d.warning)
+        .classed("link-label-alert", d.alert)
         .style("stroke-dasharray", self.styleStrokeDasharray(d))
         .style("stroke-dashoffset", self.styleStrokeDashoffset(d))
         .style("animation", self.styleAnimation(d))
@@ -1485,7 +1483,7 @@ TopologyGraphLayout.prototype = {
       return;
     delete this.linkLabelData[link.id];
 
-    this.updateLinkLabel();
+    this.bindLinkLabelData();
     this.linkLabel.exit().remove();
 
     // force a tick


### PR DESCRIPTION
NOTE: depends on merging of https://github.com/skydive-project/skydive/pull/1163 when changes the RelationType form `association` to  `networkpolicy` w/o the current PR will have no noticeable effect.

This PR enhances k8s networkpolicy edges by addressing:
- coloring - light blue dashed line to indicate a "networkpolicy" edge
- arrowhead - indicating egress (pointing away) / ingress (pointing towards) and deny (red) / allow (green)

To test this PR setup k8s in configuration:

```
analyzer:
  probes:
  - k8s
```

And then create the various policies and check UI:

```
kubectl create -f tests/k8s/networkpolicy-ingress-allow.yaml
kubectl create -f tests/k8s/networkpolicy-egress-allow.yaml
kubectl create -f tests/k8s/networkpolicy-ingress-deny.yaml
kubectl create -f tests/k8s/networkpolicy-egress-deny.yaml
```