### PR TITLE
graph: fix ownership link override

### DIFF
--- a/packet_injector/inject_packet.go
+++ b/packet_injector/inject_packet.go
@@ -138,14 +138,14 @@ func forgePacket(packetType string, layerType gopacket.LayerType, srcMAC, dstMAC
 
 	buffer := gopacket.NewSerializeBuffer()
 	if err := gopacket.SerializeLayers(buffer, options, l...); err != nil {
-		return nil, nil, fmt.Errorf("Error while generating %s packet: %s", packetType, err.Error())
+		return nil, nil, fmt.Errorf("Error while generating %s packet: %s", packetType, err)
 	}
 
 	packetData := buffer.Bytes()
 	return packetData, gopacket.NewPacket(packetData, layerType, gopacket.Default), nil
 }
 
-// InjectPacket inject some packets based on the graph
+// InjectPackets inject some packets based on the graph
 func InjectPackets(pp *PacketInjectionParams, g *graph.Graph, chnl *channels) (string, error) {
 	srcIP := getIP(pp.SrcIP)
 	if srcIP == nil {
@@ -234,16 +234,16 @@ func InjectPackets(pp *PacketInjectionParams, g *graph.Graph, chnl *channels) (s
 		for i := int64(0); i < pp.Count; i++ {
 			select {
 			case <-c:
-				logging.GetLogger().Debugf("Injection stoped on interface %s", ifName)
+				logging.GetLogger().Debugf("Injection stopped on interface %s", ifName)
 				break stopInjection
 			default:
 				logging.GetLogger().Debugf("Injecting packet on interface %s", ifName)
 
 				if _, err := rawSocket.Write(packetData); err != nil {
 					if err == syscall.ENXIO {
-						logging.GetLogger().Warningf("Write error: %s", err.Error())
+						logging.GetLogger().Warningf("Write error on interface %s: %s", ifName, err)
 					} else {
-						logging.GetLogger().Errorf("Write error: %s", err.Error())
+						logging.GetLogger().Errorf("Write error on interface %s: %s", ifName, err)
 					}
 				}
 

--- a/tests/flow_test.go
+++ b/tests/flow_test.go
@@ -997,8 +997,8 @@ func TestICMP(t *testing.T) {
 				increment: true,
 			},
 			{
-				from:  g.G.V().Has("Name", "icmp-intf1", "Type", "internal"),
-				to:    g.G.V().Has("Name", "icmp-intf2", "Type", "internal"),
+				from:  g.G.V().Has("Name", "icmp-vm1").Out().Has("Name", "icmp-intf1", "Type", "internal"),
+				to:    g.G.V().Has("Name", "icmp-vm2").Out().Has("Name", "icmp-intf2", "Type", "internal"),
 				count: 1,
 				id:    456,
 				ipv6:  true,

--- a/topology/graph/graph.go
+++ b/topology/graph/graph.go
@@ -1101,10 +1101,10 @@ func (g *Graph) Unlink(n1 *Node, n2 *Node) {
 	}
 }
 
-// GetFirstLink get Link between the parent and the child node or nil
+// GetFirstLink get Link between the parent and the child node
 func (g *Graph) GetFirstLink(parent, child *Node, metadata Metadata) *Edge {
 	for _, e := range g.GetNodeEdges(parent, metadata) {
-		if e.GetChild() == child.ID {
+		if e.child == child.ID {
 			return e
 		}
 	}

--- a/topology/probes/netlink/netlink.go
+++ b/topology/probes/netlink/netlink.go
@@ -273,7 +273,9 @@ func (u *NetNsNetLinkProbe) addOvsLinkToTopology(link netlink.Link, m graph.Meta
 
 	intf := u.Graph.LookupFirstNode(graph.NewGraphElementFilter(filter))
 	if intf != nil {
-		topology.AddOwnershipLink(u.Graph, u.Root, intf, nil)
+		if !topology.HaveOwnershipLink(u.Graph, u.Root, intf) {
+			topology.AddOwnershipLink(u.Graph, u.Root, intf, nil)
+		}
 	}
 
 	return intf

--- a/topology/probes/ovsdb/ovsdb.go
+++ b/topology/probes/ovsdb/ovsdb.go
@@ -407,8 +407,8 @@ func (o *OvsdbProbe) OnOvsInterfaceAdd(monitor *ovsdb.OvsMonitor, uuid string, r
 		}
 
 		puuid, _ := port.GetFieldString("UUID")
-		if brige, ok := o.portToBridge[puuid]; ok {
-			o.linkIntfTOBridge(brige, intf)
+		if bridge, ok := o.portToBridge[puuid]; ok {
+			o.linkIntfTOBridge(bridge, intf)
 		}
 	}
 }


### PR DESCRIPTION
This patch fixes the ownership link
overide mechanism that is involved
in ovsdb and netlink probes.