### PR TITLE
ci: do not use login when logging to docker hub

### DIFF
--- a/scripts/ci/create-docker-image.sh
+++ b/scripts/ci/create-docker-image.sh
@@ -56,7 +56,7 @@ if [ -z "$DOCKER_PASSWORD" ]; then
     exit 1
 fi
 
-docker login -e "${DOCKER_EMAIL}" -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
+docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
 
 for arch in $ARCHES
 do


### PR DESCRIPTION
skip skydive-go-fmt
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-scale-tests
skip skydive-cdd-overview
skip skydive-unit-tests
skip skydive-compile-tests
skip skydive-k8s-tests