### PR TITLE
tests: fix pvc test minikube log warning (of unrecognized storageclass)

### DIFF
--- a/tests/k8s/persistentvolumeclaim.yaml
+++ b/tests/k8s/persistentvolumeclaim.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: skydive-test-persistentvolumeclaim
 spec:
-  storageClassName: manual
+  storageClassName: standard
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
after running the previous test and checking minikube log:

```
minikube log 2>&1 | tee minikube.log
```

we would get the following warning (which has now been eliminated):

```
Jul 21 12:54:20 dev localkube[1252]: I0721 12:54:20.221934    1252 event.go:218] Event(v1.ObjectReference{Kind:"PersistentVolumeClaim", Namespace:"default", Name:"skydive-test-persistentvolumeclaim", UID:"2f2ef8db-8ce5-11e8-9484-5254001c08b7", APIVersion:"v1", ResourceVersion:"385976", FieldPath:""}): type: 'Warning' reason: 'ProvisioningFailed' storageclass.storage.k8s.io "manual" not found
```