### PR TITLE
k8s: fix node metadata of addresses

### DIFF
--- a/tests/k8s_test.go
+++ b/tests/k8s_test.go
@@ -190,7 +190,7 @@ func TestK8sNetworkPolicyNode(t *testing.T) {
 }
 
 func TestK8sNodeNode(t *testing.T) {
-	testNodeCreation(t, nil, nil, "node", nodeName, "Arch", "Cluster", "Hostname", "IP", "Labels", "OS")
+	testNodeCreation(t, nil, nil, "node", nodeName, "Arch", "Cluster", "Hostname", "InternalIP", "Labels", "OS")
 }
 
 func TestK8sPersistentVolumeNode(t *testing.T) {

--- a/topology/probes/k8s/node.go
+++ b/topology/probes/k8s/node.go
@@ -54,10 +54,8 @@ func (c *nodeProbe) newMetadata(node *v1.Node) graph.Metadata {
 	m.SetField("Cluster", node.ClusterName)
 	for _, a := range node.Status.Addresses {
 		switch a.Type {
-		case "Hostname":
-			m.SetField("Hostname", a.Address)
-		case "InternalIP":
-			m.SetField("IP", a.Address)
+		case "Hostname", "InternalIP", "ExternalIP":
+			m.SetField(string(a.Type), a.Address)
 		}
 	}
 	info := node.Status.NodeInfo


### PR DESCRIPTION
Now support the following addresses in k8s node metadata:
- Hostname
- InternalIP (formally IP)
- ExternalIP

test was updated accordingly