### PR TITLE
js: use new repo @fromschema/native instead deprecated vue-json-schema

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -11,7 +11,7 @@
     "qs": "^6.2.0",
     "typescript": "^2.7.1",
     "vue-form-generator": "^2.2.2",
-    "vue-json-schema": "^1.1.0"
+    "@formschema/native": "^1.1.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
npm WARN deprecated vue-json-schema@1.1.1: vue-json-schema has been moved to the FormSchema organization with the new name FormSchemaNative. Please use 'npm install @formschema/native' instead. More info: https://gitlab.com/formschema/native