### PR TITLE
k8s: fix daemonset metadata

### DIFF
--- a/tests/k8s/daemonset.yaml
+++ b/tests/k8s/daemonset.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: skydive-test-daemonset
-  namespace: kube-system
   labels:
     k8s-app: skydive-test-daemonset-fluentd-logging
 spec:

--- a/tests/k8s_test.go
+++ b/tests/k8s_test.go
@@ -183,7 +183,7 @@ func TestK8sNamespaceNode(t *testing.T) {
 }
 
 func TestK8sDaemonSetNode(t *testing.T) {
-	testNodeCreationFromConfig(t, "daemonset", objName+"-daemonset")
+	testNodeCreationFromConfig(t, "daemonset", objName+"-daemonset", "Labels", "DesiredNumberScheduled", "CurrentNumberScheduled", "NumberMisscheduled")
 }
 
 func TestK8sNetworkPolicyNode(t *testing.T) {

--- a/topology/probes/k8s/daemonset.go
+++ b/topology/probes/k8s/daemonset.go
@@ -40,11 +40,16 @@ type dsProbe struct {
 }
 
 func dumpDaemonSet(ds *v1beta1.DaemonSet) string {
-	return fmt.Sprintf("daemonset{Name: %s}", ds.GetName())
+	return fmt.Sprintf("daemonset{Namespace: %s, Name: %s}", ds.Namespace, ds.Name)
 }
 
 func (p *dsProbe) newMetadata(ds *v1beta1.DaemonSet) graph.Metadata {
-	return newMetadata("daemonset", ds.Namespace, ds.GetName(), ds)
+	m := newMetadata("daemonset", ds.Namespace, ds.Name, ds)
+	m.SetFieldAndNormalize("Labels", ds.Labels)
+	m.SetField("DesiredNumberScheduled", ds.Status.DesiredNumberScheduled)
+	m.SetField("CurrentNumberScheduled", ds.Status.CurrentNumberScheduled)
+	m.SetField("NumberMisscheduled", ds.Status.NumberMisscheduled)
+	return m
 }
 
 func dsUID(ds *v1beta1.DaemonSet) graph.Identifier {


### PR DESCRIPTION
Added metadata fields: Labels and Replica metrics which can be verified by:

```
kubectl create -f tests/k8s/daemonset.yaml
```

