### PR TITLE
K8s: fix deployment metadata

### DIFF
--- a/tests/k8s_test.go
+++ b/tests/k8s_test.go
@@ -167,7 +167,7 @@ func TestK8sContainerNode(t *testing.T) {
 }
 
 func TestK8sDeploymentNode(t *testing.T) {
-	testNodeCreationFromConfig(t, "deployment", objName+"-deployment")
+	testNodeCreationFromConfig(t, "deployment", objName+"-deployment", "Selector", "DesiredReplicas", "Replicas", "ReadyReplicas", "AvailableReplicas", "UnavailableReplicas")
 }
 
 func TestK8sIngressNode(t *testing.T) {

--- a/topology/probes/k8s/deployment.go
+++ b/topology/probes/k8s/deployment.go
@@ -40,11 +40,11 @@ type deployProbe struct {
 }
 
 func dumpDeployment(deploy *v1beta1.Deployment) string {
-	return fmt.Sprintf("deployment{Name: %s}", deploy.GetName())
+	return fmt.Sprintf("deployment{Namespace: %s, Name: %s}", deploy.Namespace, deploy.Name)
 }
 
 func (p *deployProbe) newMetadata(deploy *v1beta1.Deployment) graph.Metadata {
-	return newMetadata("deployment", deploy.Namespace, deploy.GetName(), deploy)
+	return newMetadata("deployment", deploy.Namespace, deploy.Name, deploy)
 }
 
 func deployUID(deploy *v1beta1.Deployment) graph.Identifier {
@@ -66,8 +66,8 @@ func (p *deployProbe) OnUpdate(oldObj, newObj interface{}) {
 		p.graph.Lock()
 		defer p.graph.Unlock()
 
-		if nsNode := p.graph.GetNode(deployUID(deploy)); nsNode != nil {
-			addMetadata(p.graph, nsNode, deploy)
+		if deployNode := p.graph.GetNode(deployUID(deploy)); deployNode != nil {
+			addMetadata(p.graph, deployNode, deploy)
 			logging.GetLogger().Debugf("Updated %s", dumpDeployment(deploy))
 		}
 	}
@@ -78,8 +78,8 @@ func (p *deployProbe) OnDelete(obj interface{}) {
 		p.graph.Lock()
 		defer p.graph.Unlock()
 
-		if nsNode := p.graph.GetNode(deployUID(deploy)); nsNode != nil {
-			p.graph.DelNode(nsNode)
+		if deployNode := p.graph.GetNode(deployUID(deploy)); deployNode != nil {
+			p.graph.DelNode(deployNode)
 			logging.GetLogger().Debugf("Deleted %s", dumpDeployment(deploy))
 		}
 	}

--- a/topology/probes/k8s/deployment.go
+++ b/topology/probes/k8s/deployment.go
@@ -44,7 +44,14 @@ func dumpDeployment(deploy *v1beta1.Deployment) string {
 }
 
 func (p *deployProbe) newMetadata(deploy *v1beta1.Deployment) graph.Metadata {
-	return newMetadata("deployment", deploy.Namespace, deploy.Name, deploy)
+	m := newMetadata("deployment", deploy.Namespace, deploy.Name, deploy)
+	m.SetFieldAndNormalize("Selector", deploy.Spec.Selector)
+	m.SetField("DesiredReplicas", int32ValueOrDefault(deploy.Spec.Replicas, 1))
+	m.SetField("Replicas", deploy.Status.Replicas)
+	m.SetField("ReadyReplicas", deploy.Status.ReadyReplicas)
+	m.SetField("AvailableReplicas", deploy.Status.AvailableReplicas)
+	m.SetField("UnavailableReplicas", deploy.Status.UnavailableReplicas)
+	return m
 }
 
 func deployUID(deploy *v1beta1.Deployment) graph.Identifier {

--- a/topology/probes/k8s/probe.go
+++ b/topology/probes/k8s/probe.go
@@ -42,6 +42,13 @@ func dumpObject(obj interface{}) string {
 	}
 }
 
+func int32ValueOrDefault(value *int32, defaultValue int32) int32 {
+	if value == nil {
+		return defaultValue
+	}
+	return *value
+}
+
 // Probe for tracking k8s events
 type Probe struct {
 	bundle *probe.ProbeBundle


### PR DESCRIPTION
Added new fields to deployment object, to tests run:

```
kubectl create -f tests/k8s/deployment.yaml
```