### PR TITLE
k8s: add metadata to pv and pvc objects

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -267,6 +267,10 @@ func NormalizeValue(obj interface{}) interface{} {
 		for i, val := range v {
 			v[i] = NormalizeValue(val)
 		}
+	case string:
+		return v
+	case nil:
+		return ""
 	}
 	return deepcopy.Copy(obj)
 }

--- a/tests/k8s_test.go
+++ b/tests/k8s_test.go
@@ -199,11 +199,11 @@ func TestK8sNodeNode(t *testing.T) {
 }
 
 func TestK8sPersistentVolumeNode(t *testing.T) {
-	testNodeCreationFromConfig(t, "persistentvolume", objName+"-persistentvolume")
+	testNodeCreationFromConfig(t, "persistentvolume", objName+"-persistentvolume", "Capacity", "AccessModes", "VolumeMode", "ClaimRef", "StorageClassName", "Status")
 }
 
 func TestK8sPersistentVolumeClaimNode(t *testing.T) {
-	testNodeCreationFromConfig(t, "persistentvolumeclaim", objName+"-persistentvolumeclaim")
+	testNodeCreationFromConfig(t, "persistentvolumeclaim", objName+"-persistentvolumeclaim", "AccessModes", "VolumeName", "StorageClassName", "VolumeMode", "Status")
 }
 
 func TestK8sPodNode(t *testing.T) {

--- a/topology/probes/k8s/persistentvolume.go
+++ b/topology/probes/k8s/persistentvolume.go
@@ -40,11 +40,33 @@ type persistentVolumeProbe struct {
 }
 
 func dumpPersistentVolume(pv *v1.PersistentVolume) string {
-	return fmt.Sprintf("persistentvolume{Name: %s}", pv.GetName())
+	return fmt.Sprintf("persistentvolume{Name: %s}", pv.Name)
+}
+
+func persistentVolumeAccessModes(accessModes []v1.PersistentVolumeAccessMode) string {
+	if len(accessModes) > 0 {
+		return string(accessModes[0])
+	}
+	return ""
+}
+
+func persistentVolumeClaimRef(claimRef *v1.ObjectReference) string {
+	if claimRef != nil {
+		return claimRef.Name
+	}
+	return ""
 }
 
 func (p *persistentVolumeProbe) newMetadata(pv *v1.PersistentVolume) graph.Metadata {
-	return newMetadata("persistentvolume", pv.Namespace, pv.GetName(), pv)
+	m := newMetadata("persistentvolume", pv.Namespace, pv.Name, pv)
+	m.SetFieldAndNormalize("Capacity", pv.Spec.Capacity)
+
+	m.SetFieldAndNormalize("AccessModes", persistentVolumeAccessModes(pv.Spec.AccessModes))
+	m.SetFieldAndNormalize("VolumeMode", pv.Spec.VolumeMode)
+	m.SetFieldAndNormalize("ClaimRef", persistentVolumeClaimRef(pv.Spec.ClaimRef)) // FIXME: replace by link to PersistentVolumeClaim
+	m.SetFieldAndNormalize("StorageClassName", pv.Spec.StorageClassName)           // FIXME: replace by link to StorageClass
+	m.SetFieldAndNormalize("Status", pv.Status.Phase)
+	return m
 }
 
 func persistentVolumeUID(pv *v1.PersistentVolume) graph.Identifier {

--- a/topology/probes/k8s/persistentvolumeclaim.go
+++ b/topology/probes/k8s/persistentvolumeclaim.go
@@ -44,7 +44,13 @@ func dumpPersistentVolumeClaim(pvc *v1.PersistentVolumeClaim) string {
 }
 
 func (p *persistentVolumeClaimProbe) newMetadata(pvc *v1.PersistentVolumeClaim) graph.Metadata {
-	return newMetadata("persistentvolumeclaim", pvc.Namespace, pvc.GetName(), pvc)
+	m := newMetadata("persistentvolumeclaim", pvc.Namespace, pvc.GetName(), pvc)
+	m.SetFieldAndNormalize("AccessModes", persistentVolumeAccessModes(pvc.Spec.AccessModes))
+	m.SetFieldAndNormalize("VolumeName", pvc.Spec.VolumeName)             // FIXME: replace by link to PersistentVolume
+	m.SetFieldAndNormalize("StorageClassName", pvc.Spec.StorageClassName) // FIXME: replace by link to StorageClass
+	m.SetFieldAndNormalize("VolumeMode", pvc.Spec.VolumeMode)
+	m.SetFieldAndNormalize("Status", pvc.Status.Phase)
+	return m
 }
 
 func persistentVolumeClaimUID(pvc *v1.PersistentVolumeClaim) graph.Identifier {


### PR DESCRIPTION
Enriched `persistentvolume` and `persistentvolumeclaim` objects with metadata