### PR TITLE
release: bump to 0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.19.0] - 2018-08-08
+### Added
+- Gremlin:
+  - Add `descendants` to retrieve both parents and children
+  - Add `As` and `Select` steps to get the union of a set of nodes
+  - Allow queries on booleans
+- New JavaScript API
+  - Support for browsers, NPM or the Skydive embedded JS engine
+  - Convert command line shell to JavaScript
+- Add API to upload and execute workflows
+- Add support for Power architecture:
+  - Build Docker images
+  - Test architecture on our CI
+- Retrieve OpenContrail routing tables
+
+### Changed
+- Improved Elasticseach backend:
+  - Add support for rolling indices
+  - Bump minimal version to 5.5
+- Retrieve more Kubernetes metadata and create dedicated section on the Web UI for it
+- Performance improvements using `easyjson`
+- Allow using different authentication backends for API and for internal communications
+- TripleO: move to config-download mechanism
+
 ## [0.18.0] - 2018-06-18
 ### Added
 - Add `RBAC` mechanism

--- a/contrib/ansible/roles/skydive_common/defaults/main.yml
+++ b/contrib/ansible/roles/skydive_common/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-skydive_release: v0.18.0
+skydive_release: v0.19.0
 skydive_docker_registry: docker.io
 skydive_docker_image_tag: latest
 skydive_config_file: /etc/skydive/skydive.yml

--- a/contrib/packaging/rpm/skydive.spec
+++ b/contrib/packaging/rpm/skydive.spec
@@ -31,7 +31,7 @@
 %endif
 %endif
 
-%{!?fullver:%global fullver 0.18.0}
+%{!?fullver:%global fullver 0.19.0}
 %define version %{extractversion %{fullver}}
 %{!?tag:%global tag 1}
 
@@ -231,6 +231,9 @@ fi
 %attr(0644,root,root) %{_mandir}/man8/skydive-selinux.8.*
 
 %changelog
+* Wed Aug 8 2018 Sylvain Baubeau <sbaubeau@redhat.com> - 0.19.0-1
+- Bump to version 0.19.0
+
 * Mon Jun 18 2018 Sylvain Baubeau <sbaubeau@redhat.com> - 0.18.0-1
 - Bump to version 0.18.0
 - Add SElinux policy

--- a/contrib/packaging/rpm/skydive.te.fedora
+++ b/contrib/packaging/rpm/skydive.te.fedora
@@ -1,4 +1,4 @@
-policy_module(skydive, 0.18.0)
+policy_module(skydive, 0.19.0)
 
 ########################################
 #

--- a/contrib/packaging/rpm/skydive.te.rhel
+++ b/contrib/packaging/rpm/skydive.te.rhel
@@ -1,4 +1,4 @@
-policy_module(skydive, 0.18.0)
+policy_module(skydive, 0.19.0)
 
 ########################################
 #


### PR DESCRIPTION
skip skydive-go-fmt
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-scale-tests
skip skydive-cdd-overview-tests
skip skydive-unit-tests
skip skydive-compile-tests
skip skydive-k8s-tests