### PR TITLE
tests: fix opencontrail compilation

### DIFF
--- a/tests/opencontrail_test.go
+++ b/tests/opencontrail_test.go
@@ -24,7 +24,6 @@ func TestOpenContrailTopology(t *testing.T) {
 		mode: Replay,
 
 		checks: []CheckFunction{func(c *CheckContext) error {
-			gh := c.gh
 			gremlin := c.gremlin.V().Has("Contrail")
 
 			nodes, err := c.gh.GetNodes(gremlin)


### PR DESCRIPTION
skip skydive-go-fmt
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-scale-tests
skip skydive-cdd-overview-tests
skip skydive-unit-tests
skip skydive-compile-tests
skip skydive-k8s-tests
skip skydive-ppc64le-tests