### PR TITLE
K8s service links

### DIFF
--- a/tests/k8s/service-pod.yaml
+++ b/tests/k8s/service-pod.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: skydive-test-service-pod
+spec:
+  selector:
+    app: skydive-test-service-pod
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 9376
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: skydive-test-service-pod
+  labels:
+    app: skydive-test-service-pod
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 9376

--- a/tests/k8s_test.go
+++ b/tests/k8s_test.go
@@ -232,7 +232,7 @@ func TestK8sReplicationControllerNode(t *testing.T) {
 }
 
 func TestK8sServiceNode(t *testing.T) {
-	testNodeCreationFromConfig(t, "service", objName+"-service")
+	testNodeCreationFromConfig(t, "service", objName+"-service", "Ports", "ClusterIP", "ServiceType", "SessionAffinity", "LoadBalancerIP", "ExternalName")
 }
 
 func TestK8sStatefulSetNode(t *testing.T) {

--- a/tests/k8s_test.go
+++ b/tests/k8s_test.go
@@ -405,3 +405,32 @@ func TestK8sNetworkPolicyDenyEgressScenario(t *testing.T) {
 func TestK8sNetworkPolicyAllowEgressScenario(t *testing.T) {
 	testK8sNetworkPolicyDefaultScenario(t, k8s.PolicyTypeEgress, k8s.PolicyTargetAllow)
 }
+
+func TestK8sServicePodScenario(t *testing.T) {
+	file := "service-pod"
+	name := objName + "-" + file
+	testRunner(
+		t,
+		setupFromConfigFile(file),
+		tearDownFromConfigFile(file),
+		[]CheckFunction{
+			func(c *CheckContext) error {
+				service, err := checkNodeCreation(t, c, "service", "Name", name)
+				if err != nil {
+					return err
+				}
+
+				pod, err := checkNodeCreation(t, c, "pod", "Name", name)
+				if err != nil {
+					return err
+				}
+
+				if err = checkEdge(t, c, service, pod, "service"); err != nil {
+					return err
+				}
+
+				return nil
+			},
+		},
+	)
+}

--- a/topology/probes/k8s/service.go
+++ b/topology/probes/k8s/service.go
@@ -30,13 +30,18 @@ import (
 	"github.com/skydive-project/skydive/topology/graph"
 
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
 
 type serviceProbe struct {
 	defaultKubeCacheEventHandler
+	graph.DefaultGraphListener
 	*kubeCache
-	graph *graph.Graph
+	podCache              *kubeCache
+	graph                 *graph.Graph
+	podIndexerByNamespace *graph.MetadataIndexer
 }
 
 func dumpService(srv *v1.Service) string {
@@ -58,13 +63,56 @@ func serviceUID(srv *v1.Service) graph.Identifier {
 	return graph.Identifier(srv.GetUID())
 }
 
+func (p *serviceProbe) filterPodByLabels(in []interface{}, srv *v1.Service) (out []interface{}) {
+	selector, _ := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: srv.Spec.Selector})
+	for _, pod := range in {
+		pod := pod.(*v1.Pod)
+		if srv.Namespace == pod.Namespace && selector.Matches(labels.Set(pod.Labels)) {
+			out = append(out, pod)
+		}
+	}
+	return
+}
+
+func (p *serviceProbe) selectedPods(srv *v1.Service) (nodes []*graph.Node) {
+	pods := p.podCache.list()
+	pods = p.filterPodByLabels(pods, srv)
+	for _, pod := range pods {
+		pod := pod.(*v1.Pod)
+		if podNode := p.graph.GetNode(podUID(pod)); podNode != nil {
+			nodes = append(nodes, podNode)
+		}
+	}
+	logging.GetLogger().Debugf("found %d pods", len(nodes))
+	return
+}
+
+func (p *serviceProbe) newEdgeMetadata() graph.Metadata {
+	m := newEdgeMetadata()
+	m.SetField("RelationType", "service")
+	return m
+}
+
+func (p *serviceProbe) updateLinksForPod(srv *v1.Service, srvNode, podNode *graph.Node) {
+	addLink(p.graph, srvNode, podNode, p.newEdgeMetadata())
+	// TODO: handle deletion of stale links
+	// TODO: support srv.Spec.Ports
+}
+
+func (p *serviceProbe) updateLinks(srv *v1.Service, srvNode *graph.Node) {
+	for _, podNode := range p.selectedPods(srv) {
+		p.updateLinksForPod(srv, srvNode, podNode)
+	}
+}
+
 func (p *serviceProbe) OnAdd(obj interface{}) {
 	if srv, ok := obj.(*v1.Service); ok {
 		p.graph.Lock()
 		defer p.graph.Unlock()
 
-		newNode(p.graph, serviceUID(srv), p.newMetadata(srv))
+		srvNode := newNode(p.graph, serviceUID(srv), p.newMetadata(srv))
 		logging.GetLogger().Debugf("Added %s", dumpService(srv))
+		p.updateLinks(srv, srvNode)
 	}
 }
 
@@ -76,6 +124,7 @@ func (p *serviceProbe) OnUpdate(oldObj, newObj interface{}) {
 		if srvNode := p.graph.GetNode(serviceUID(srv)); srvNode != nil {
 			addMetadata(p.graph, srvNode, srv)
 			logging.GetLogger().Debugf("Updated %s", dumpService(srv))
+			p.updateLinks(srv, srvNode)
 		}
 	}
 }
@@ -92,12 +141,39 @@ func (p *serviceProbe) OnDelete(obj interface{}) {
 	}
 }
 
+func (p *serviceProbe) onNodeUpdated(podNode *graph.Node) {
+	logging.GetLogger().Debugf("update links: %s", dumpGraphNode(podNode))
+
+	for _, srv := range p.kubeCache.list() {
+		srv := srv.(*v1.Service)
+		logging.GetLogger().Debugf("refreshing %s", dumpService(srv))
+		srvNode := p.graph.GetNode(serviceUID(srv))
+		if srvNode == nil {
+			logging.GetLogger().Debugf("can't find %s", dumpService(srv))
+			continue
+		}
+		p.updateLinksForPod(srv, srvNode, podNode)
+	}
+}
+
+func (p *serviceProbe) OnNodeAdded(node *graph.Node) {
+	p.onNodeUpdated(node)
+}
+
+func (p *serviceProbe) OnNodeUpdated(node *graph.Node) {
+	p.onNodeUpdated(node)
+}
+
 func (p *serviceProbe) Start() {
 	p.kubeCache.Start()
+	p.podIndexerByNamespace.AddEventListener(p)
+	p.podIndexerByNamespace.Start()
 }
 
 func (p *serviceProbe) Stop() {
 	p.kubeCache.Stop()
+	p.podIndexerByNamespace.RemoveEventListener(p)
+	p.podIndexerByNamespace.Stop()
 }
 
 func newServiceKubeCache(handler cache.ResourceEventHandler) *kubeCache {
@@ -107,7 +183,9 @@ func newServiceKubeCache(handler cache.ResourceEventHandler) *kubeCache {
 func newServiceProbe(g *graph.Graph) probe.Probe {
 	p := &serviceProbe{
 		graph: g,
+		podIndexerByNamespace: newObjectIndexerByNamespace(g, "pod"),
 	}
 	p.kubeCache = newServiceKubeCache(p)
+	p.podCache = newPodKubeCache(p)
 	return p
 }


### PR DESCRIPTION
create links between `service` to `pod`, can be tested running:

```
kubectl create -f tests/k8s/service-pod.yaml
```

*NOTE*: depends on https://github.com/skydive-project/skydive/pull/1241