### PR TITLE
devmode: explicitly install iptables 1.6.1

### DIFF
--- a/contrib/ansible/roles/skydive_dev/tasks/main.yml
+++ b/contrib/ansible/roles/skydive_dev/tasks/main.yml
@@ -9,6 +9,7 @@
     name: "{{ item }}"
     state: present
   with_items:
+     - iptables-1.6.1                   # iptables-1.6.2 not compatible with minikube-0.25.2
      - git
      - wget
      - unzip


### PR DESCRIPTION
We need iptables 1.6.1 as when using iptables 1.6.2 then minikube 0.25.2 fails (it has an issue with parameters passed to iptables-restore).

You can test this fix by creating a new devmode:

```
export PREPARE_BOX=true
vagrant up
vagrant ssh
vagrant@dev $ iptables -v
# expected to get 1.6.1 and not 1.6.2
```

Note that after accepting this PR you need to build a new skydive/skydive-dev image as the current skydive-dev image has iptables 1.6.2 bundled into it.