### PR TITLE
k8s: netpol support namespace <--> namespace(s) policy

### DIFF
--- a/tests/k8s/networkpolicy-ingress-allow-namespace.yaml
+++ b/tests/k8s/networkpolicy-ingress-allow-namespace.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: skydive-test-networkpolicy-ingress-allow-namespace-to
+  labels:
+    app: skydive-test-networkpolicy-ingress-allow-namespace-to
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: skydive-test-networkpolicy-ingress-allow-namespace-from
+  labels:
+    app: skydive-test-networkpolicy-ingress-allow-namespace-from
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: skydive-test-networkpolicy-ingress-allow-namespace
+  namespace: skydive-test-networkpolicy-ingress-allow-namespace-to
+spec:
+  podSelector:
+    matchLabels:
+  ingress:
+  - from:
+      - namespaceSelector:
+          matchLabels:
+            app: skydive-test-networkpolicy-ingress-allow-namespace-from

--- a/tests/k8s/networkpolicy-ingress-allow-pod.yaml
+++ b/tests/k8s/networkpolicy-ingress-allow-pod.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: skydive-test-networkpolicy-ingress-allow-pod-begin
+  name: skydive-test-networkpolicy-ingress-allow-pod-to
   labels:
-    app: skydive-test-networkpolicy-ingress-allow-pod-begin
+    app: skydive-test-networkpolicy-ingress-allow-pod-to
 spec:
   containers:
   - name: nginx
@@ -14,9 +14,9 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: skydive-test-networkpolicy-ingress-allow-pod-end
+  name: skydive-test-networkpolicy-ingress-allow-pod-from
   labels:
-    app: skydive-test-networkpolicy-ingress-allow-pod-end
+    app: skydive-test-networkpolicy-ingress-allow-pod-from
 spec:
   containers:
   - name: nginx
@@ -31,9 +31,9 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: skydive-test-networkpolicy-ingress-allow-pod-begin
+      app: skydive-test-networkpolicy-ingress-allow-pod-to
   ingress:
   - from:
       - podSelector:
           matchLabels:
-            app: skydive-test-networkpolicy-ingress-allow-pod-end
+            app: skydive-test-networkpolicy-ingress-allow-pod-from

--- a/tests/k8s_test.go
+++ b/tests/k8s_test.go
@@ -453,12 +453,12 @@ func testK8sNetworkPolicyObjectToObjectScenario(t *testing.T, policyType k8s.Pol
 					return err
 				}
 
-				begin, err := checkNodeCreation(t, c, resourceType, "Name", name+"-begin")
+				begin, err := checkNodeCreation(t, c, resourceType, "Name", name+"-to")
 				if err != nil {
 					return err
 				}
 
-				end, err := checkNodeCreation(t, c, resourceType, "Name", name+"-end")
+				end, err := checkNodeCreation(t, c, resourceType, "Name", name+"-from")
 				if err != nil {
 					return err
 				}
@@ -479,6 +479,10 @@ func testK8sNetworkPolicyObjectToObjectScenario(t *testing.T, policyType k8s.Pol
 
 func TestK8sNetworkPolicyAllowIngressPodToPodScenario(t *testing.T) {
 	testK8sNetworkPolicyObjectToObjectScenario(t, k8s.PolicyTypeIngress, k8s.PolicyTargetAllow, "pod")
+}
+
+func TestK8sNetworkPolicyAllowIngressNamespaceToNamepsaceScenario(t *testing.T) {
+	testK8sNetworkPolicyObjectToObjectScenario(t, k8s.PolicyTypeIngress, k8s.PolicyTargetAllow, "namespace")
 }
 
 func TestK8sServicePodScenario(t *testing.T) {


### PR DESCRIPTION
You can test the new code using:

```
kubectl create -f tests/k8s/networkpolicy-ingress-allow-namespace.yaml
```