### PR TITLE
K8s netpol ports

### DIFF
--- a/tests/k8s/networkpolicy-ingress-allow-ports.yaml
+++ b/tests/k8s/networkpolicy-ingress-allow-ports.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: skydive-test-networkpolicy-ingress-allow-ports-to
+  labels:
+    app: skydive-test-networkpolicy-ingress-allow-ports-to
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: skydive-test-networkpolicy-ingress-allow-ports-from
+  labels:
+    app: skydive-test-networkpolicy-ingress-allow-ports-from
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: skydive-test-networkpolicy-ingress-allow-ports
+spec:
+  podSelector:
+    matchLabels:
+      app: skydive-test-networkpolicy-ingress-allow-ports-to
+  ingress:
+  - from:
+      - podSelector:
+          matchLabels:
+            app: skydive-test-networkpolicy-ingress-allow-ports-from
+    ports:
+      - port: 80


### PR DESCRIPTION
This PR adds the metadata field "Ports" to the links connecting networkpolicy to pod objects. Current implementation still has some limitations (as expressed by TODO within the patch)

To create a scenario which creates Ports: `:80` on edges run:

```
kubectl create -f tests/k8s/networkpolicy-ingress-allow-ports.yaml
```

NOTE: this PR depends on https://github.com/skydive-project/skydive/pull/1255