### PR TITLE
extending k8s hello-node test 

### DIFF
--- a/tests/k8s_test.go
+++ b/tests/k8s_test.go
@@ -135,6 +135,14 @@ func checkEdgeOwnership(t *testing.T, c *CheckContext, from, to *graph.Node, edg
 	return checkEdge(t, c, from, to, "ownership", edgeArgs...)
 }
 
+func checkEdgeAssociation(t *testing.T, c *CheckContext, from, to *graph.Node, edgeArgs ...interface{}) error {
+	return checkEdge(t, c, from, to, "association", edgeArgs...)
+}
+
+func checkEdgeService(t *testing.T, c *CheckContext, from, to *graph.Node, edgeArgs ...interface{}) error {
+	return checkEdge(t, c, from, to, "service", edgeArgs...)
+}
+
 func testRunner(t *testing.T, setupCmds, tearDownCmds []helper.Cmd, checks []CheckFunction) {
 	test := &Test{
 		mode:         Replay,
@@ -313,6 +321,21 @@ func TestHelloNodeScenario(t *testing.T) {
 					return err
 				}
 
+				service, err := checkNodeCreation(t, c, "service", "Name", "kubernetes")
+				if err != nil {
+					return err
+				}
+
+				replicaset, err := checkNodeCreation(t, c, "replicaset", "Name", g.Regex("%s-.*", "hello-node"))
+				if err != nil {
+					return err
+				}
+
+				node, err := checkNodeCreation(t, c, "node", "Name", nodeName)
+				if err != nil {
+					return err
+				}
+
 				pod, err := checkNodeCreation(t, c, "pod", "Name", g.Regex("%s-.*", "hello-node"))
 				if err != nil {
 					return err
@@ -327,6 +350,10 @@ func TestHelloNodeScenario(t *testing.T) {
 					return err
 				}
 
+				if err = checkEdgeOwnership(t, c, namespace, replicaset); err != nil {
+					return err
+				}
+
 				if err = checkEdgeOwnership(t, c, namespace, pod); err != nil {
 					return err
 				}
@@ -334,7 +361,16 @@ func TestHelloNodeScenario(t *testing.T) {
 				if err = checkEdgeOwnership(t, c, pod, container); err != nil {
 					return err
 				}
+
+				if err = checkEdgeService(t, c, service, pod); err != nil {
+					return err
+				}
+
+				if err = checkEdgeAssociation(t, c, node, pod); err != nil {
+					return err
+				}
 				return nil
+
 			},
 		},
 	)

--- a/topology/probes/k8s/pod.go
+++ b/topology/probes/k8s/pod.go
@@ -90,12 +90,12 @@ func (p *podProbe) newMetadata(pod *v1.Pod) graph.Metadata {
 	return m
 }
 
-func (p *podProbe) linkPodToNode(pod *v1.Pod, podNode *graph.Node) {
+func (p *podProbe) linkNodeToPod(pod *v1.Pod, podNode *graph.Node) {
 	nodeNodes, _ := p.nodeIndexer.Get(pod.Spec.NodeName)
 	if len(nodeNodes) == 0 {
 		return
 	}
-	linkPodToNode(p.graph, nodeNodes[0], podNode)
+	linkNodeToPod(p.graph, nodeNodes[0], podNode)
 }
 
 func (p *podProbe) onAdd(obj interface{}) {
@@ -111,7 +111,7 @@ func (p *podProbe) onAdd(obj interface{}) {
 		addOwnershipLink(p.graph, podNode, containerNode)
 	}
 
-	p.linkPodToNode(pod, podNode)
+	p.linkNodeToPod(pod, podNode)
 }
 
 func (p *podProbe) OnAdd(obj interface{}) {
@@ -142,7 +142,7 @@ func (p *podProbe) OnUpdate(oldObj, newObj interface{}) {
 	}
 
 	if oldPod.Spec.NodeName == "" && newPod.Spec.NodeName != "" {
-		p.linkPodToNode(newPod, podNode)
+		p.linkNodeToPod(newPod, podNode)
 	}
 
 	addMetadata(p.graph, podNode, newPod)
@@ -162,11 +162,11 @@ func (p *podProbe) OnDelete(obj interface{}) {
 
 func linkPodsToNode(g *graph.Graph, host *graph.Node, pods []*graph.Node) {
 	for _, pod := range pods {
-		linkPodToNode(g, host, pod)
+		linkNodeToPod(g, host, pod)
 	}
 }
 
-func linkPodToNode(g *graph.Graph, node, pod *graph.Node) {
+func linkNodeToPod(g *graph.Graph, node, pod *graph.Node) {
 	addLink(g, node, pod, newEdgeMetadata())
 }
 


### PR DESCRIPTION
The first change extends the test so that it will check the validity of all the edges of k8s.  For checking, simply run the test.
The second change is aesthetic, fixing func name according to the real direction of the edge.