### PR TITLE
ci: restart libvirtd after cleanup

### DIFF
--- a/scripts/ci/cleanup.sh
+++ b/scripts/ci/cleanup.sh
@@ -54,6 +54,7 @@ EOF
 
   virsh net-destroy vagrant0
   virsh net-destroy vagrant-libvirt
+  systemctl restart libvirtd
 
   rm -rf /tmp/skydive_agent* /tmp/skydive-etcd
 


### PR DESCRIPTION
skip skydive-go-fmt
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-scale-tests
skip skydive-cdd-overview-tests
skip skydive-unit-tests
skip skydive-compile-tests
skip skydive-k8s-tests
skip skydive-ppc64le-tests