### PR TITLE
k8s: insert endpoints to cluster's graph entity

### DIFF
--- a/topology/probes/k8s/cluster.go
+++ b/topology/probes/k8s/cluster.go
@@ -49,6 +49,7 @@ func newClusterLinkedObjectIndexer(g *graph.Graph) *graph.MetadataIndexer {
 			filters.NewTermStringFilter("Type", "node"),
 			filters.NewTermStringFilter("Type", "persistentvolume"),
 			filters.NewTermStringFilter("Type", "persistentvolumeclaim"),
+			filters.NewTermStringFilter("Type", "endpoints"),
 		),
 	)
 	m := graph.NewGraphElementFilter(filter)


### PR DESCRIPTION
Insert endpoints to the cluster's node in k8s graph.
For testing, use ``` make debug.analyzer ```.
