### PR TITLE
host: Reporting DMI structures

### DIFF
--- a/contrib/packaging/rpm/skydive.spec
+++ b/contrib/packaging/rpm/skydive.spec
@@ -85,6 +85,7 @@ Requires:         %{name} = %{version}-%{release}
 Requires(post):   systemd %{selinux_semanage_pkg}
 Requires(preun):  systemd
 Requires(postun): systemd %{selinux_semanage_pkg}
+Requires:         dmidecode
 
 %description agent
 The Skydive agent has to be started on each node where the topology and

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -931,6 +931,12 @@
 			"revision": "5d2041e26a699eaca682e2ea41c8f891e1060444"
 		},
 		{
+			"checksumSHA1": "D2Aijfk0Ccbw5ftQF3RVTTSPQbk=",
+			"path": "github.com/dselans/dmidecode",
+			"revision": "65c3f9d819108e993ede783bdecbc7d28748cbd9",
+			"revisionTime": "2018-08-14T05:30:09Z"
+		},
+		{
 			"checksumSHA1": "g3z4plpw9F/ho3hdJb+X/bN/OgE=",
 			"path": "github.com/emicklei/go-restful",
 			"revision": "68c9750c36bb8cb433f1b88c807b4b30df4acc40",


### PR DESCRIPTION
This patch is about adding DMI capabilities to skydive.

It offer users an option to get what are the hardware capabilities of a particular node.
This usually includes the vendor/product/serial numbers, bios versions, DIMM detection and many other items.
A simple laptop usually expose more than 600 items.

There was several options to make the implementation:
- ochapman/godmi
    it offer nice structures but is really outdate (4yo)
    we need accurate DMI information for supporting recent systems

- go-smbios
    easy to use but doesn't provides any human readable output
    it only reports the row values that have to be analyzed against the DMI specification of that particular version
    A sample output looks like : &{{7 19 1} [1 128 1 32 0 32 0 64 0 64 0 0 5 4 7] [L1-Cache]}

- paulstuart/dmijson
    it parses dmidecode but goes through a json structure which isn't really needed here

- dselans/dmidecode
    this is the one selected for this patch.
    it parses dmidecode and offer simple structures to parse
    then we recreate a dynamic structure to add into the metadata
    Pros:
    - it uses dmidecode which is up to date regarding the specification, vendors are usually contributing too
    Cons:
    - it parses dmidecode output, which is string based and could break over time

This light patch was enough to report the full DMI tables into the metadata.

Signed-off-by: Erwan Velu <erwan@redhat.com>