### PR TITLE
agent/host: Using lshw to report hardware

### DIFF
--- a/agent/host.go
+++ b/agent/host.go
@@ -23,9 +23,11 @@
 package agent
 
 import (
+	"encoding/json"
 	"errors"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/shirou/gopsutil/cpu"
@@ -50,6 +52,62 @@ type CPUInfo struct {
 	Mhz        int64  `json:"Mhz,omitempty"`
 	CacheSize  int64  `json:"CacheSize,omitempty"`
 	Microcode  string `json:"Microcode,omitempty"`
+}
+
+// extractClassAndID to report class and ID from the children node
+func extractClassAndID(children map[string]interface{}) (string, string) {
+	var foundID string
+	var foundClass string
+	for objectName, objectValue := range children {
+		switch objectValue.(type) {
+		case string:
+			if objectName == "class" {
+				foundClass = objectValue.(string)
+			}
+			if objectName == "id" {
+				foundID = objectValue.(string)
+			}
+			// Once we discover the class and ID, let's return them
+			if (len(foundID) > 0) && (len(foundClass) > 0) {
+				return foundClass, foundID
+			}
+		}
+	}
+	return "", ""
+}
+
+// parseLshw to rename children nodes inside the lshw data structure
+func parseLshw(items map[string]interface{}) {
+	// For each object of the LSHW structure
+	for objectName, objectValue := range items {
+		switch objectValue.(type) {
+		case []interface{}:
+			// Only consider object that have children
+			if objectName != "children" {
+				continue
+			}
+			// When we have children
+			for _, child := range objectValue.([]interface{}) {
+				_, validChildType := child.(map[string]interface{})
+				if validChildType {
+					// For each child
+					class, ID := extractClassAndID(child.(map[string]interface{}))
+					// Extract from the child the class and ID to rename it
+					if len(class) > 0 {
+						if items[class] == nil {
+							items[class] = []map[string]interface{}{}
+						}
+						// Let's create a new child with the name of the class and add an entry with the ID and point it to the actual child
+						items[class] = append(items[class].([]map[string]interface{}), map[string]interface{}{ID: child})
+						// Delete the actual entry so we renamed it
+						delete(items, objectName)
+						// Do the same parsing with the current child as he could have some 'children' nodes
+						parseLshw(child.(map[string]interface{}))
+					}
+				}
+			}
+		}
+	}
 }
 
 // createRootNode creates a graph.Node based on the host properties and aims to have an unique ID
@@ -81,32 +139,6 @@ func createRootNode(g *graph.Graph) (*graph.Node, error) {
 		m.SetField("IsolatedCPU", isolated)
 	}
 
-	cpuInfo, err := cpu.Info()
-	if err != nil {
-		return nil, err
-	}
-
-	var cpus []*CPUInfo
-	for _, cpu := range cpuInfo {
-		c := &CPUInfo{
-			CPU:        int64(cpu.CPU),
-			VendorID:   cpu.VendorID,
-			Family:     cpu.Family,
-			Model:      cpu.Model,
-			Stepping:   int64(cpu.Stepping),
-			PhysicalID: cpu.PhysicalID,
-			CoreID:     cpu.CoreID,
-			Cores:      int64(cpu.Cores),
-			ModelName:  cpu.ModelName,
-			Mhz:        int64(cpu.Mhz),
-			CacheSize:  int64(cpu.CacheSize),
-			Microcode:  cpu.Microcode,
-		}
-		cpus = append(cpus, c)
-	}
-
-	m.SetField("CPU", cpus)
-
 	hostInfo, err := host.Info()
 	if err != nil {
 		return nil, err
@@ -132,6 +164,40 @@ func createRootNode(g *graph.Graph) (*graph.Node, error) {
 	}
 	if hostInfo.VirtualizationRole != "" {
 		m.SetField("VirtualizationRole", hostInfo.VirtualizationRole)
+	}
+
+	var lshwMap map[string]interface{}
+	lshw, err := exec.Command("lshw", "-quiet", "-json").Output()
+	if err == nil {
+		err = json.Unmarshal(lshw, &lshwMap)
+		if err == nil {
+			parseLshw(lshwMap)
+			m.SetField("Hardware", lshwMap)
+		}
+	} else {
+		cpuInfo, err := cpu.Info()
+		if err != nil {
+			return nil, err
+		}
+		var cpus []*CPUInfo
+		for _, cpu := range cpuInfo {
+			c := &CPUInfo{
+				CPU:        int64(cpu.CPU),
+				VendorID:   cpu.VendorID,
+				Family:     cpu.Family,
+				Model:      cpu.Model,
+				Stepping:   int64(cpu.Stepping),
+				PhysicalID: cpu.PhysicalID,
+				CoreID:     cpu.CoreID,
+				Cores:      int64(cpu.Cores),
+				ModelName:  cpu.ModelName,
+				Mhz:        int64(cpu.Mhz),
+				CacheSize:  int64(cpu.CacheSize),
+				Microcode:  cpu.Microcode,
+			}
+			cpus = append(cpus, c)
+		}
+		m.SetField("CPU", cpus)
 	}
 
 	return g.NewNode(graph.GenID(), m), nil


### PR DESCRIPTION
This commit is about using lshw tooling to report the hardware
information of nodes.

The JSON output of lshw is parsed and a little bit adjusted to rename
'children' nodes into user-readable types.

As lshw provides much more cpu info that the actual code,
the existing CPU reporting is only used when lshw is not available.

Signed-off-by: Erwan Velu <erwan@redhat.com>