### PR TITLE
Disable elasticsearch by default in devstack plugin

### DIFF
--- a/devstack/plugin.sh
+++ b/devstack/plugin.sh
@@ -53,10 +53,10 @@ SKYDIVE_OVSDB_REMOTE_PORT=${SKYDIVE_OVSDB_REMOTE_PORT:-}
 SKYDIVE_LOGLEVEL=${SKYDIVE_LOGLEVEL:-INFO}
 
 # Storage used by the analyzer to store flows
-SKYDIVE_FLOWS_STORAGE=${SKYDIVE_FLOWS_STORAGE:-"elasticsearch"}
+SKYDIVE_FLOWS_STORAGE=${SKYDIVE_FLOWS_STORAGE:-"memory"}
 
 # Storage used by the analyzer to store the graph
-SKYDIVE_GRAPH_STORAGE=${SKYDIVE_GRAPH_STORAGE:-"elasticsearch"}
+SKYDIVE_GRAPH_STORAGE=${SKYDIVE_GRAPH_STORAGE:-"memory"}
 
 # List of public interfaces for the agents to register in fabric
 # ex: "devstack1/eth0 devstack2/eth1"

--- a/scripts/ci/devstack/run-devstack.sh
+++ b/scripts/ci/devstack/run-devstack.sh
@@ -78,6 +78,10 @@ enable_service skydive-analyzer skydive-agent
 
 SKYDIVE_ANALYZER_LISTEN=0.0.0.0:8082
 SKYDIVE_AGENT_LISTEN=0.0.0.0:8081
+
+SKYDIVE_FLOWS_STORAGE=elasticsearch
+SKYDIVE_GRAPH_STORAGE=elasticsearch
+
 EOF
 
 ./stack.sh


### PR DESCRIPTION
Use the memory backend instead and save memory on the default
deployment. Most people is confused and believes that elasticsearch
is a mandatory component of a deployment, while it's not.

With this change I hope I can drive a wider usage in the openstack community.