### PR TITLE
ci: use different IPs for libvirt and virtualbox for vagrant…

### DIFF
--- a/scripts/ci/create-vagrant-boxes.sh
+++ b/scripts/ci/create-vagrant-boxes.sh
@@ -35,6 +35,7 @@ set -e
 [ -z "$PROVIDERS" ] && PROVIDERS="libvirt virtualbox"
 for provider in $PROVIDERS
 do
+    [ "$provider" = "virtualbox" ] && export PRIVATE_IP=192.168.99.10
     PREPARE_BOX=true vagrant up --provider=$provider ${KEEP_RESOURCES:+--no-destroy-on-error}
     [ "$provider" = "libvirt" ] && sudo chmod a+r /var/lib/libvirt/images/dev_dev.img || true
 


### PR DESCRIPTION
skip skydive-go-fmt
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-scale-tests
skip skydive-cdd-overview-tests
skip skydive-unit-tests
skip skydive-compile-tests
skip skydive-k8s-tests
skip skydive-ppc64le-tests