### PR TITLE
k8s: netpol convert policy for namespace to pods

### DIFF
--- a/tests/k8s/networkpolicy-egress-allow.yaml
+++ b/tests/k8s/networkpolicy-egress-allow.yaml
@@ -1,3 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: skydive-test-networkpolicy-egress-allow
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/tests/k8s/networkpolicy-egress-deny.yaml
+++ b/tests/k8s/networkpolicy-egress-deny.yaml
@@ -1,3 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: skydive-test-networkpolicy-egress-deny
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/tests/k8s/networkpolicy-ingress-allow-namespace.yaml
+++ b/tests/k8s/networkpolicy-ingress-allow-namespace.yaml
@@ -2,8 +2,18 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: skydive-test-networkpolicy-ingress-allow-namespace-to
-  labels:
-    app: skydive-test-networkpolicy-ingress-allow-namespace-to
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: skydive-test-networkpolicy-ingress-allow-namespace-to
+  namespace: skydive-test-networkpolicy-ingress-allow-namespace-to
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
 ---
 apiVersion: v1
 kind: Namespace
@@ -11,6 +21,18 @@ metadata:
   name: skydive-test-networkpolicy-ingress-allow-namespace-from
   labels:
     app: skydive-test-networkpolicy-ingress-allow-namespace-from
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: skydive-test-networkpolicy-ingress-allow-namespace-from
+  namespace: skydive-test-networkpolicy-ingress-allow-namespace-from
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/tests/k8s/networkpolicy-ingress-allow.yaml
+++ b/tests/k8s/networkpolicy-ingress-allow.yaml
@@ -1,3 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: skydive-test-networkpolicy-ingress-allow
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/tests/k8s/networkpolicy-ingress-deny.yaml
+++ b/tests/k8s/networkpolicy-ingress-deny.yaml
@@ -1,3 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: skydive-test-networkpolicy-ingress-deny
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/tests/k8s/networkpolicy-namespace.yaml
+++ b/tests/k8s/networkpolicy-namespace.yaml
@@ -2,8 +2,18 @@ kind: Namespace
 apiVersion: v1
 metadata:
   name: skydive-test-networkpolicy-namespace
-  labels:
-    name: skydive-test-networkpolicy-namespace
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: skydive-test-networkpolicy-namespace
+  namespace: skydive-test-networkpolicy-namespace
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
 ---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1

--- a/tests/k8s_test.go
+++ b/tests/k8s_test.go
@@ -121,7 +121,8 @@ func checkEdgeNetworkPolicy(t *testing.T, c *CheckContext, from, to *graph.Node,
 	edgeArgs = append([]interface{}{
 		"PolicyType", ty,
 		"PolicyTarget", target,
-		"PolicyPoint", point}, edgeArgs...)
+		"PolicyPoint", point,
+	}, edgeArgs...)
 	return checkEdge(t, c, from, to, "networkpolicy", edgeArgs...)
 }
 
@@ -384,12 +385,12 @@ func TestK8sNetworkPolicyScenario1(t *testing.T) {
 					return err
 				}
 
-				namespace, err := checkNodeCreation(t, c, k8s.Manager, "namespace", "Name", name)
+				pod, err := checkNodeCreation(t, c, k8s.Manager, "pod", "Name", name)
 				if err != nil {
 					return err
 				}
 
-				if err = checkEdgeNetworkPolicy(t, c, networkpolicy, namespace, k8s.PolicyTypeIngress, k8s.PolicyTargetAllow, k8s.PolicyPointBegin); err != nil {
+				if err = checkEdgeNetworkPolicy(t, c, networkpolicy, pod, k8s.PolicyTypeIngress, k8s.PolicyTargetAllow, k8s.PolicyPointBegin); err != nil {
 					return err
 				}
 
@@ -442,12 +443,12 @@ func testK8sNetworkPolicyDefaultScenario(t *testing.T, policyType k8s.PolicyType
 					return err
 				}
 
-				ns, err := checkNodeCreation(t, c, k8s.Manager, "namespace", "Name", "default")
+				pod, err := checkNodeCreation(t, c, k8s.Manager, "pod", "Name", name)
 				if err != nil {
 					return err
 				}
 
-				if err = checkEdgeNetworkPolicy(t, c, np, ns, policyType, policyTarget, k8s.PolicyPointBegin); err != nil {
+				if err = checkEdgeNetworkPolicy(t, c, np, pod, policyType, policyTarget, k8s.PolicyPointBegin); err != nil {
 					return err
 				}
 
@@ -473,7 +474,7 @@ func TestK8sNetworkPolicyAllowEgressScenario(t *testing.T) {
 	testK8sNetworkPolicyDefaultScenario(t, k8s.PolicyTypeEgress, k8s.PolicyTargetAllow)
 }
 
-func testK8sNetworkPolicyObjectToObjectScenario(t *testing.T, policyType k8s.PolicyType, policyTarget k8s.PolicyTarget, resourceType, fileSuffix string, edgeArgs ...interface{}) {
+func testK8sNetworkPolicyObjectToObjectScenario(t *testing.T, policyType k8s.PolicyType, policyTarget k8s.PolicyTarget, fileSuffix string, edgeArgs ...interface{}) {
 	file := fmt.Sprintf("networkpolicy-%s-%s-%s", policyType, policyTarget, fileSuffix)
 	name := objName + "-" + file
 	testRunner(
@@ -487,12 +488,12 @@ func testK8sNetworkPolicyObjectToObjectScenario(t *testing.T, policyType k8s.Pol
 					return err
 				}
 
-				begin, err := checkNodeCreation(t, c, k8s.Manager, resourceType, "Name", name+"-to")
+				begin, err := checkNodeCreation(t, c, k8s.Manager, "pod", "Name", name+"-to")
 				if err != nil {
 					return err
 				}
 
-				end, err := checkNodeCreation(t, c, k8s.Manager, resourceType, "Name", name+"-from")
+				end, err := checkNodeCreation(t, c, k8s.Manager, "pod", "Name", name+"-from")
 				if err != nil {
 					return err
 				}
@@ -512,15 +513,15 @@ func testK8sNetworkPolicyObjectToObjectScenario(t *testing.T, policyType k8s.Pol
 }
 
 func TestK8sNetworkPolicyAllowIngressPodToPodScenario(t *testing.T) {
-	testK8sNetworkPolicyObjectToObjectScenario(t, k8s.PolicyTypeIngress, k8s.PolicyTargetAllow, "pod", "pod")
+	testK8sNetworkPolicyObjectToObjectScenario(t, k8s.PolicyTypeIngress, k8s.PolicyTargetAllow, "pod")
 }
 
 func TestK8sNetworkPolicyAllowIngressNamespaceToNamepsaceScenario(t *testing.T) {
-	testK8sNetworkPolicyObjectToObjectScenario(t, k8s.PolicyTypeIngress, k8s.PolicyTargetAllow, "namespace", "namespace")
+	testK8sNetworkPolicyObjectToObjectScenario(t, k8s.PolicyTypeIngress, k8s.PolicyTargetAllow, "namespace")
 }
 
 func TestK8sNetworkPolicyAllowIngressPodToPodPortsScenario(t *testing.T) {
-	testK8sNetworkPolicyObjectToObjectScenario(t, k8s.PolicyTypeIngress, k8s.PolicyTargetAllow, "pod", "ports", "Ports", ":80")
+	testK8sNetworkPolicyObjectToObjectScenario(t, k8s.PolicyTypeIngress, k8s.PolicyTargetAllow, "ports", "Ports", ":80")
 }
 
 func TestK8sServicePodScenario(t *testing.T) {


### PR DESCRIPTION
Prior to this change network-policy would either connect pods or namespaces, but so as to facilitate ipRange which may be used alongside namespaceSelector (as in the below policy) we need to revert to network-policy to always connect pods. (as ipRange my need to intersect with namespaceSelector). So now rather than connecting namespace we will connect all the pods within the respective namespace(s).

All tests have been converted to always create pods within namespaces and then check that edges have been created correctly between network-policy and pod(s).

Note that ipRange support has not been added within this PR and will be added in a future PR.

To test the correctness of this change run the k8s test.

```
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: test-network-policy
  namespace: default
spec:
  podSelector:
    matchLabels:
      role: db
  policyTypes:
  - Ingress
  ingress:
  - from:
    - ipBlock:
        cidr: 172.17.0.0/16
        except:
        - 172.17.1.0/24
    - namespaceSelector:
        matchLabels:
          project: myproject
```