### PR TITLE
docker/ci: create-docker-image.sh remove bashism

### DIFF
--- a/scripts/ci/create-docker-image.sh
+++ b/scripts/ci/create-docker-image.sh
@@ -17,8 +17,8 @@ VERSION=${TAG#v}
 [ -n "$VERSION" ] && DOCKER_TAG=$VERSION || DOCKER_TAG=latest
 
 # See if a server forms part of DOCKER_IMAGE, e.g. DOCKER_IMAGE=registry.ng.bluemix.net:8080/skydive/skydive
-if [[ "$DOCKER_IMAGE" =~ /[^/]*/[^/]* ]]; then
-    DOCKER_SERVER=${DOCKER_IMAGE%/[^/]*/[^/]*}
+if [ "${DOCKER_IMAGE%/*/*}" != "${DOCKER_IMAGE}" ]; then
+    DOCKER_SERVER=${DOCKER_IMAGE%/*/*}
 fi
 
 if [ -n "$PUSH_RUN" ]; then


### PR DESCRIPTION
Running under dash generates the error:

scripts/ci/create-docker-image.sh: 20: scripts/ci/create-docker-image.sh: [[: not found

Replaced as the pattern /*/* doesn't match the D1 case is left unchanged:

$ D1=skydive/skydive
$ D2=registry.ng.bluemix.net:8080/skydive/skydive
$ echo ${D1%/*/*}
skydive/skydive
$ echo ${D2%/*/*}
registry.ng.bluemix.net:8080