### PR TITLE
openflow: fix openflow rule modification

### DIFF
--- a/statics/js/components/rule-detail.js
+++ b/statics/js/components/rule-detail.js
@@ -266,6 +266,7 @@ var BridgeLayout = (function () {
   BridgeLayout.prototype.extract = function () {
     var itfs = {};
     var rules = [];
+    var rulesUUID = new Set();
     var children = this.graph.getTargets(this.bridge);
     for (var i = 0; i < children.length; i++) {
       var c = children[i];
@@ -279,10 +280,12 @@ var BridgeLayout = (function () {
           var rule = c.metadata;
           summarize(rule);
           rules.push(rule);
+          rulesUUID.add(rule.UUID);
       }
     }
     this.rules = rules;
     this.interfaces = itfs;
+    this.rulesUUID = rulesUUID;
   };
 
   /** Structure the information on the rules, classifying by tables and ports. */
@@ -570,9 +573,15 @@ Vue.component('rule-detail', {
         self.memoBridgeLayout = null;
       }
     };
+    var handleUpdate = function(n) {
+      if (n.metadata.Type == 'ofrule' && self.memoBridgeLayout.rulesUUID.has(n.metadata.UUID)) {
+        self.memoBridgeLayout = null;
+      }
+    };
     this.handler = {
       onEdgeAdded: handle,
-      onEdgeDeleted: handle
+      onEdgeDeleted: handle,
+      onNodeUpdated:handleUpdate
     };
     this.graph.addHandler(this.handler);
     this.unwatch = this.$store.watch(

--- a/topology/probes/ovsdb/ovs_of_test.go
+++ b/topology/probes/ovsdb/ovs_of_test.go
@@ -130,8 +130,8 @@ func TestFillUUID(t *testing.T) {
 		t.Error("Same UUID with distinct filter")
 	}
 	fillUUID(&rule3, prefix1)
-	if uuid == rule3.UUID {
-		t.Error("Same UUID with distinct cookie")
+	if uuid != rule3.UUID {
+		t.Error("Distinct UUID with only distinct cookie")
 	}
 	fillUUID(&rule4, prefix1)
 	if uuid == rule4.UUID {


### PR DESCRIPTION
Only rule addition and deletion were correctly handled.
This adds support for rule modification.
UUID do not include cookie as a rule with a distinct cookie but the same
filter will overwrite an existing rule.