### PR TITLE
[openflow] Openflow group tables support

### DIFF
--- a/tests/openflow_test.go
+++ b/tests/openflow_test.go
@@ -2,7 +2,11 @@ package tests
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/skydive-project/skydive/common"
 )
 
 type ruleCmd struct {
@@ -16,10 +20,10 @@ func checkTest(t *testing.T) {
 	}
 }
 
-func verify(c *CheckContext, expected []int) error {
+func verify(c *CheckContext, bridge string, expected []int) error {
 	for i, e := range expected {
 		actions := fmt.Sprintf(`resubmit(;%d)`, i+1)
-		gremlin := c.gremlin.V().Has("Type", "ovsbridge", "Name", "br-testof1").Out("Type", "ofrule").Has("actions", actions)
+		gremlin := c.gremlin.V().Has("Type", "ovsbridge", "Name", bridge).Out("Type", "ofrule").Has("actions", actions)
 		nodes, err := c.gh.GetNodes(gremlin)
 		if err != nil {
 			return err
@@ -32,20 +36,24 @@ func verify(c *CheckContext, expected []int) error {
 	return nil
 }
 
-func makeTest(t *testing.T, rules []ruleCmd, expected []int) {
+func makeTest(t *testing.T, suffix string, rules []ruleCmd, expected []int) {
 	checkTest(t)
+	bridge := "br-of" + suffix
+	intf1 := "intf1-" + suffix
+	intf2 := "intf2-" + suffix
 	setupCmds := []Cmd{
-		{"ovs-vsctl add-br br-testof1", true},
-		{"ovs-vsctl add-port br-testof1 intf1 -- set interface intf1 type=internal", true},
-		{"ovs-vsctl add-port br-testof1 intf2 -- set interface intf2 type=internal", true},
+		{"ovs-vsctl --if-exists del-br " + bridge, true},
+		{"ovs-vsctl add-br " + bridge, true},
+		{"ovs-vsctl add-port " + bridge + " " + intf1 + " -- set interface " + intf1 + " type=internal", true},
+		{"ovs-vsctl add-port " + bridge + " " + intf2 + " -- set interface " + intf2 + " type=internal", true},
 	}
 
 	for _, ruleCmd := range rules {
 		var cmd string
 		if ruleCmd.add {
-			cmd = fmt.Sprintf("ovs-ofctl add-flow br-testof1 %s", ruleCmd.rule)
+			cmd = fmt.Sprintf("ovs-ofctl add-flow %s %s", bridge, ruleCmd.rule)
 		} else {
-			cmd = fmt.Sprintf("ovs-ofctl del-flows --strict br-testof1 %s", ruleCmd.rule)
+			cmd = fmt.Sprintf("ovs-ofctl del-flows --strict %s %s", bridge, ruleCmd.rule)
 		}
 		setupCmds = append(setupCmds, Cmd{Cmd: cmd, Check: true})
 	}
@@ -54,13 +62,13 @@ func makeTest(t *testing.T, rules []ruleCmd, expected []int) {
 		setupCmds: setupCmds,
 
 		tearDownCmds: []Cmd{
-			{"ovs-vsctl del-br br-testof1", true},
+			{"ovs-vsctl del-br " + bridge, true},
 		},
 
 		mode: Replay,
 
 		checks: []CheckFunction{func(c *CheckContext) error {
-			return verify(c, expected)
+			return verify(c, bridge, expected)
 		}},
 	}
 
@@ -70,6 +78,7 @@ func makeTest(t *testing.T, rules []ruleCmd, expected []int) {
 func TestAddOFRule(t *testing.T) {
 	makeTest(
 		t,
+		"1",
 		[]ruleCmd{{"table=0,priority=0,in_port=1,actions=resubmit(,1)", true}},
 		[]int{1})
 }
@@ -77,6 +86,7 @@ func TestAddOFRule(t *testing.T) {
 func TestDelOFRule(t *testing.T) {
 	makeTest(
 		t,
+		"2",
 		[]ruleCmd{
 			{"table=0,priority=0,in_port=1,actions=resubmit(,1)", true},
 			{"table=0,priority=0,in_port=1", false},
@@ -87,6 +97,7 @@ func TestDelOFRule(t *testing.T) {
 func TestSuperimposedOFRule(t *testing.T) {
 	makeTest(
 		t,
+		"3",
 		[]ruleCmd{
 			{"table=0,priority=1,actions=resubmit(,1)", true},
 			{"table=0,priority=2,actions=resubmit(,2)", true},
@@ -100,13 +111,14 @@ func TestSuperimposedOFRule(t *testing.T) {
 func TestDelRuleWithBridgeOFRule(t *testing.T) {
 	checkTest(t)
 	setupCmds := []Cmd{
-		{"ovs-vsctl add-br br-testof1", true},
-		{"ovs-vsctl add-port br-testof1 intf1 -- set interface intf1 type=internal", true},
-		{"ovs-vsctl add-port br-testof1 intf2 -- set interface intf2 type=internal", true},
+		{"ovs-vsctl --if-exists del-br br-of4", true},
+		{"ovs-vsctl add-br br-of4", true},
+		{"ovs-vsctl add-port br-of4 intf1-4 -- set interface intf1-4 type=internal", true},
+		{"ovs-vsctl add-port br-of4 intf2-4 -- set interface intf2-4 type=internal", true},
 		{"sleep 1", true},
-		{"ovs-ofctl add-flow br-testof1 table=0,priority=1,actions=resubmit(,1)", true},
+		{"ovs-ofctl add-flow br-of4 table=0,priority=1,actions=resubmit(,1)", true},
 		{"sleep 1", true},
-		{"ovs-vsctl del-br br-testof1", true},
+		{"ovs-vsctl del-br br-of4", true},
 	}
 
 	test := &Test{
@@ -116,7 +128,118 @@ func TestDelRuleWithBridgeOFRule(t *testing.T) {
 
 		mode: Replay,
 
-		checks: []CheckFunction{func(c *CheckContext) error { return verify(c, []int{0}) }},
+		checks: []CheckFunction{func(c *CheckContext) error { return verify(c, "br-4", []int{0}) }},
+	}
+
+	RunTest(t, test)
+}
+
+func TestModOFRule(t *testing.T) {
+	makeTest(
+		t,
+		"5",
+		[]ruleCmd{{"table=0,priority=0,in_port=1,actions=resubmit(,1)", true},
+			{"table=0,priority=0,in_port=1,actions=resubmit(,2)", true}},
+		[]int{0, 1})
+}
+
+func verifyGroup(c *CheckContext, bridge string, expected int) error {
+	retry := func() error {
+		gremlin := c.gremlin.V().Has("Type", "ovsbridge", "Name", bridge).Out("Type", "ofgroup")
+		nodes, err := c.gh.GetNodes(gremlin)
+		if err != nil {
+			return err
+		}
+		l := len(nodes)
+		if l != expected {
+			return fmt.Errorf("expected %d groups - %v", expected)
+		}
+		for _, node := range nodes {
+			m := node.Metadata()
+			if m["group_id"].(int64) != 123 {
+				return fmt.Errorf("Group_id set to %d", m["group_id"])
+			}
+			if m["group_type"].(string) != "all" {
+				return fmt.Errorf("Group type set to %s", m["group_type"])
+			}
+			if !strings.Contains(m["contents"].(string), "resubmit(,1)") {
+				return fmt.Errorf("Problem with contents: %s", m["contents"])
+			}
+		}
+		return nil
+	}
+	return common.Retry(retry, 10, time.Second)
+}
+
+func TestAddOFGroup(t *testing.T) {
+	checkTest(t)
+	setupCmds := []Cmd{
+		{"ovs-vsctl --if-exists del-br br-of6", true},
+		{"ovs-vsctl add-br br-of6", true},
+		{"ovs-vsctl set bridge br-of6 protocols=OpenFlow10,OpenFlow15", true},
+		{"ovs-vsctl add-port br-of6 intf1-6 -- set interface intf1-6 type=internal", true},
+		{"ovs-vsctl add-port br-of6 intf2-6 -- set interface intf2-6 type=internal", true},
+		{"sleep 1", true},
+		{"ovs-ofctl -O OpenFlow15 add-group br-of6 group_id=123,type=all,bucket=actions=1,bucket=actions=resubmit(,1)", true},
+		{"sleep 3", true},
+	}
+	test := &Test{
+		setupCmds: setupCmds,
+		tearDownCmds: []Cmd{
+			{"ovs-vsctl del-br br-of6", true},
+		},
+		mode:   Replay,
+		checks: []CheckFunction{func(c *CheckContext) error { return verifyGroup(c, "br-of6", 1) }},
+	}
+
+	RunTest(t, test)
+}
+
+func TestModOFGroup(t *testing.T) {
+	checkTest(t)
+	setupCmds := []Cmd{
+		{"ovs-vsctl --if-exists del-br br-of7", true},
+		{"ovs-vsctl add-br br-of7", true},
+		{"ovs-vsctl set bridge br-of7 protocols=OpenFlow10,OpenFlow15", true},
+		{"ovs-vsctl add-port br-of7 intf1-7 -- set interface intf1-7 type=internal", true},
+		{"ovs-vsctl add-port br-of7 intf2-7 -- set interface intf2-7 type=internal", true},
+		{"ovs-ofctl -O OpenFlow15 add-group br-of7 group_id=123,type=all,bucket=actions=1", true},
+		{"sleep 1", true},
+		{"ovs-ofctl -O OpenFlow15 insert-buckets br-of7 group_id=123,command_bucket_id=last,bucket=bucket_id=2,actions=resubmit(,1)", true},
+		{"sleep 3", true},
+	}
+	test := &Test{
+		setupCmds: setupCmds,
+		tearDownCmds: []Cmd{
+			{"ovs-vsctl del-br br-of7", true},
+		},
+		mode:   Replay,
+		checks: []CheckFunction{func(c *CheckContext) error { return verifyGroup(c, "br-of7", 1) }},
+	}
+
+	RunTest(t, test)
+}
+
+func TestDelOFGroup(t *testing.T) {
+	checkTest(t)
+	setupCmds := []Cmd{
+		{"ovs-vsctl --if-exists del-br br-of4", true},
+		{"ovs-vsctl add-br br-of8", true},
+		{"ovs-vsctl set bridge br-of8 protocols=OpenFlow10,OpenFlow15", true},
+		{"ovs-vsctl add-port br-of8 intf1-8 -- set interface intf1-8 type=internal", true},
+		{"ovs-vsctl add-port br-of8 intf2-8 -- set interface intf2-8 type=internal", true},
+		{"sleep 1", true},
+		{"ovs-ofctl -O OpenFlow15 add-group br-of8 group_id=123,type=all,bucket=actions=1", true},
+		{"ovs-ofctl -O OpenFlow15 del-groups br-of8", true},
+		{"sleep 3", true},
+	}
+	test := &Test{
+		setupCmds: setupCmds,
+		tearDownCmds: []Cmd{
+			{"ovs-vsctl del-br br-of8", true},
+		},
+		mode:   Replay,
+		checks: []CheckFunction{func(c *CheckContext) error { return verifyGroup(c, "br-of8", 0) }},
 	}
 
 	RunTest(t, test)

--- a/topology/probes/ovsdb/ovs_of.go
+++ b/topology/probes/ovsdb/ovs_of.go
@@ -25,10 +25,15 @@ package ovsdb
 import (
 	"bufio"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -63,14 +68,17 @@ type OvsOfProbe struct {
 // highest priority hides the other rules. It is important to handle rules with the same rawUUID as a group
 // because ovs-ofctl monitor does not report priorities.
 type BridgeOfProbe struct {
-	Host       string             // The global host
-	Bridge     string             // The bridge monitored
-	UUID       string             // The UUID of the bridge node
-	Address    string             // The address of the bridge if different from name
-	BridgeNode *graph.Node        // the bridge node on which the rule nodes are attached.
-	OvsOfProbe *OvsOfProbe        // Back pointer to the probe
-	Rules      map[string][]*Rule // The set of rules found so far grouped by rawUUID
-	cancel     context.CancelFunc
+	Host           string               // The global host
+	Bridge         string               // The bridge monitored
+	UUID           string               // The UUID of the bridge node
+	Address        string               // The address of the bridge if different from name
+	BridgeNode     *graph.Node          // the bridge node on which the rule nodes are attached.
+	OvsOfProbe     *OvsOfProbe          // Back pointer to the probe
+	Rules          map[string][]*Rule   // The set of rules found so far grouped by rawUUID
+	Groups         map[uint]*graph.Node // The set of groups found so far
+	groupMonitored bool
+	ctx            context.Context
+	cancel         context.CancelFunc
 }
 
 // Rule is an OpenFlow rule in a switch
@@ -84,6 +92,14 @@ type Rule struct {
 	UUID     string // Unique id
 }
 
+// Group is an OpenFlow group in a switch
+type Group struct {
+	ID        uint   // Group id
+	GroupType string // Group type
+	Contents  string // Anything else (buckets + selection)
+	UUID      string // Unique id
+}
+
 // Event is an event as monitored by ovs-ofctl monitor <br> watch:
 type Event struct {
 	RawRule *Rule   // The rule from the event
@@ -92,6 +108,19 @@ type Event struct {
 	Action  string  // the action taken
 	Bridge  string  // The bridge whtere it ocured
 }
+
+const (
+	// Set the monitor in slave mode
+	openflowSetSlave = "061800180000000300000003000000008000000000000002"
+	// activate forward to the monitor of group related requests
+	// OVS tests use the following value "061c00280000000200000008000000050002000800000002000400080000001a000a000800000001"
+	// But the added asynchronous messages should not be needed for our use case
+	openflowActivateForwardRequest = "061c001000000002000a000800000001"
+)
+
+// A regular expression to parse group events
+var groupEventRegexp = regexp.MustCompile("[ ]*(ADD|DEL|MOD|INSERT_BUCKET|REMOVE_BUCKET)[ ].*group_id=([0-9]*)(.*)\n$")
+var groupRegexp = regexp.MustCompile("[ ]*group_id=([0-9]*),type=([^,]*),(.*)$")
 
 // ProtectCommas substitute commas with semicolon
 // when inside parenthesis
@@ -145,7 +174,6 @@ func fillIn(components []string, rule *Rule, event *Event) {
 			}
 		}
 	}
-
 }
 
 // extractPriority parses the filter of a rule and extracts the priority if it exists.
@@ -218,6 +246,15 @@ func fillUUID(rule *Rule, prefix string) {
 	}
 }
 
+// Generate a unique UUID for the group
+func fillGroupUUID(group *Group, prefix string) {
+	id := prefix + "-" + string(group.ID)
+	u, err := uuid.NewV5(uuid.NamespaceOID, []byte(id))
+	if err == nil {
+		group.UUID = u.String()
+	}
+}
+
 // parseRule transforms a single line of ofctl dump-flow in a rule.
 // The line DOES NOT include the terminating newline. Protected commas will be replaced.
 func parseRule(line string) (*Rule, error) {
@@ -243,6 +280,24 @@ func parseRule(line string) (*Rule, error) {
 		return nil, errors.New("Rule syntax split filter and actions")
 	}
 	return &rule, nil
+}
+
+// parseGroup transform a single line of ofctl dump-groups in a group
+func parseGroup(line string) *Group {
+	submatch := groupRegexp.FindStringSubmatch(line)
+	if submatch == nil {
+		return nil
+	}
+	groupID, err := strconv.ParseInt(submatch[1], 10, 32)
+	if err != nil {
+		logging.GetLogger().Warningf("Bad group id in %s", line)
+		return nil
+	}
+	return &Group{
+		ID:        uint(groupID),
+		GroupType: submatch[2],
+		Contents:  submatch[3],
+	}
 }
 
 func makeFilter(rule *Rule) string {
@@ -280,7 +335,7 @@ func (r RealExecute) ExecCommandPipe(ctx context.Context, com string, args ...st
 	}
 
 	command.Stderr = command.Stdout
-	if err := command.Start(); err != nil {
+	if err = command.Start(); err != nil {
 		return nil, err
 	}
 
@@ -293,6 +348,7 @@ func launchOnSwitch(cmd []string) (string, error) {
 	if err == nil {
 		return string(bytes), nil
 	}
+	logging.GetLogger().Debugf("Command %v failed: %s", cmd, string(bytes))
 	return "", err
 }
 
@@ -302,11 +358,12 @@ func launchContinuousOnSwitch(ctx context.Context, cmd []string) (<-chan string,
 	var cout = make(chan string, 10)
 
 	go func() {
+		logging.GetLogger().Debugf("Launching continusously %v", cmd)
 		for ctx.Err() == nil {
 			retry := func() error {
 				out, err := executor.ExecCommandPipe(ctx, cmd[0], cmd[1:]...)
 				if err != nil {
-					logging.GetLogger().Errorf("Can't execute command %v", cmd)
+					logging.GetLogger().Errorf("Can't execute command %v: %s", cmd, err)
 					return nil
 				}
 
@@ -329,7 +386,7 @@ func launchContinuousOnSwitch(ctx context.Context, cmd []string) (<-chan string,
 
 				return nil
 			}
-			if err := common.Retry(retry, 100, 10*time.Millisecond); err != nil {
+			if err := common.Retry(retry, 100, 50*time.Millisecond); err != nil {
 				logging.GetLogger().Error(err)
 				break
 			}
@@ -353,6 +410,56 @@ func countElements(filter string) int {
 		}
 	}
 	return l
+}
+
+func (probe *BridgeOfProbe) prefix() string {
+	return probe.OvsOfProbe.Host + "-" + probe.Bridge + "-"
+}
+
+func (probe *BridgeOfProbe) dumpGroups() error {
+	ofp := probe.OvsOfProbe
+	prefix := probe.prefix()
+	command, err := ofp.makeCommand(
+		[]string{"ovs-ofctl", "-O", "OpenFlow15", "dump-groups"},
+		probe.Bridge)
+	if err != nil {
+		return err
+	}
+	lines, err := launchOnSwitch(command)
+	if err != nil {
+		return err
+	}
+	for _, line := range strings.Split(lines, "\n") {
+		group := parseGroup(line)
+		if group != nil {
+			fillGroupUUID(group, prefix)
+			probe.addGroup(group)
+		}
+	}
+	return nil
+}
+
+func (probe *BridgeOfProbe) getGroup(groupID uint) *Group {
+	ofp := probe.OvsOfProbe
+	prefix := probe.prefix()
+	command, err := ofp.makeCommand(
+		[]string{"ovs-ofctl", "-O", "OpenFlow15", "dump-groups"},
+		probe.Bridge, string(groupID))
+	if err != nil {
+		return nil
+	}
+	lines, err := launchOnSwitch(command)
+	if err != nil {
+		return nil
+	}
+	for _, line := range strings.Split(lines, "\n") {
+		group := parseGroup(line)
+		if group != nil && group.ID == groupID {
+			fillGroupUUID(group, prefix)
+			return group
+		}
+	}
+	return nil
 }
 
 // completeEvent completes the event by looking at it again but with dump-flows and a filter including table. This gives back more elements such as priority.
@@ -405,6 +512,7 @@ func (probe *BridgeOfProbe) addRule(rule *Rule) {
 	g.Link(bridgeNode, ruleNode, graph.Metadata{"RelationType": "ownership"})
 }
 
+// modRule modifies the node of an existing rule.
 func (probe *BridgeOfProbe) modRule(rule *Rule) {
 	logging.GetLogger().Infof("Rule %v modified", rule.UUID)
 	g := probe.OvsOfProbe.Graph
@@ -420,6 +528,25 @@ func (probe *BridgeOfProbe) modRule(rule *Rule) {
 	}
 }
 
+// addGroup adds a group to the graph and links it to the bridge
+func (probe *BridgeOfProbe) addGroup(group *Group) {
+	logging.GetLogger().Infof("New group %v added", group.UUID)
+	g := probe.OvsOfProbe.Graph
+	g.Lock()
+	defer g.Unlock()
+	bridgeNode := probe.BridgeNode
+	metadata := graph.Metadata{
+		"Type":       "ofgroup",
+		"group_id":   group.ID,
+		"group_type": group.GroupType,
+		"contents":   group.Contents,
+		"UUID":       group.UUID,
+	}
+	groupNode := g.NewNode(graph.GenID(), metadata)
+	probe.Groups[group.ID] = groupNode
+	g.Link(bridgeNode, groupNode, graph.Metadata{"RelationType": "ownership"})
+}
+
 // delRule deletes a rule from the the graph.
 func (probe *BridgeOfProbe) delRule(rule *Rule) {
 	logging.GetLogger().Infof("Rule %v deleted", rule.UUID)
@@ -433,6 +560,49 @@ func (probe *BridgeOfProbe) delRule(rule *Rule) {
 	}
 }
 
+// delGroup deletes a rule from the the graph.
+func (probe *BridgeOfProbe) delGroup(groupID uint) {
+	g := probe.OvsOfProbe.Graph
+	g.Lock()
+	defer g.Unlock()
+	if groupID == 0xfffffffc {
+		logging.GetLogger().Infof("All groups deleted on %s", probe.Bridge)
+		for _, groupNode := range probe.Groups {
+			g.DelNode(groupNode)
+		}
+		probe.Groups = make(map[uint]*graph.Node)
+	} else {
+		logging.GetLogger().Infof("Group %d deleted on %s", groupID, probe.Bridge)
+		groupNode := probe.Groups[groupID]
+		delete(probe.Groups, groupID)
+		if groupNode != nil {
+			g.DelNode(groupNode)
+		}
+	}
+}
+
+// modGroup modifies a group from the graph
+func (probe *BridgeOfProbe) modGroup(groupID uint) {
+	logging.GetLogger().Infof("Group %d modified", groupID)
+	g := probe.OvsOfProbe.Graph
+	g.Lock()
+	defer g.Unlock()
+	group := probe.getGroup(groupID)
+	node := probe.Groups[groupID]
+	if group == nil || node == nil {
+		logging.GetLogger().Errorf("Cannot modify node of OF group %d", groupID)
+		return
+	}
+	tr := g.StartMetadataTransaction(node)
+	defer tr.Commit()
+	tr.AddMetadata("group_id", group.ID)
+	tr.AddMetadata("group_type", group.GroupType)
+	tr.AddMetadata("contents", group.Contents)
+	tr.AddMetadata("UUID", group.UUID)
+}
+
+// containsRule checks if the searched rule may replace an existing rule in
+// rules and gives back the coresponding rule if found.
 func containsRule(rules []*Rule, searched *Rule) *Rule {
 	for _, rule := range rules {
 		if rule.UUID == searched.UUID {
@@ -440,6 +610,14 @@ func containsRule(rules []*Rule, searched *Rule) *Rule {
 		}
 	}
 	return nil
+}
+
+// sendOpenflow sends an Openflow command in hexadecimal through the control
+// channel of an existing ovs-ofctl monitor command.
+func sendOpenflow(control string, hex string) error {
+	command := []string{"ovs-appctl", "-t", control, "ofctl/send", hex}
+	_, err := launchOnSwitch(command)
+	return err
 }
 
 // monitor monitors the openflow rules of a bridge by launching a goroutine. The context is used to control the execution of the routine.
@@ -454,6 +632,7 @@ func (probe *BridgeOfProbe) monitor(ctx context.Context) error {
 		return err
 	}
 	go func() {
+		logging.GetLogger().Debugf("Launching goroutine for monitor %s", probe.Bridge)
 		prefix := probe.Host + "-" + probe.Bridge + "-"
 		for line := range lines {
 			if ctx.Err() != nil {
@@ -463,7 +642,8 @@ func (probe *BridgeOfProbe) monitor(ctx context.Context) error {
 			if err == nil {
 				err = completeEvent(ctx, ofp, &event, prefix)
 				if err != nil {
-					logging.GetLogger().Error(err.Error())
+					logging.GetLogger().Errorf("Error while monitoring %s@%s: %s", probe.Bridge, probe.Host, err)
+					continue
 				}
 				rawUUID := event.RawRule.UUID
 				oldRules := probe.Rules[rawUUID]
@@ -506,6 +686,104 @@ func (probe *BridgeOfProbe) monitor(ctx context.Context) error {
 	return nil
 }
 
+// Check if a file is created in time
+func waitForFile(path string) error {
+	retry := func() error {
+		_, err := os.Stat(path)
+		return err
+	}
+	return common.Retry(retry, 10, 500*time.Millisecond)
+}
+
+// monitorGroup monitors the openflow groups of a bridge by
+// launching a goroutine. It uses OpenFlow 1.4 ForwardRequest
+// command that is not directly available in ovs-ofctl
+//
+// Note: Openflow15 is really needed. Receiving an insert_bucket on an OF14
+// monitor crashes the switch (yes, the switch itself) on OVS 2.9
+func (probe *BridgeOfProbe) monitorGroup() error {
+	if probe.groupMonitored {
+		return nil
+	}
+	// We check that OF1.5 is supported
+	ofp := probe.OvsOfProbe
+	command, err := ofp.makeCommand(
+		[]string{"ovs-ofctl", "-O", "Openflow15", "show"},
+		probe.Bridge)
+	if err != nil {
+		return err
+	}
+	if _, err = launchOnSwitch(command); err != nil {
+		logging.GetLogger().Warningf("OpenFlow 1.5 not supported on %s", probe.Bridge)
+		return err
+	}
+	randBytes := make([]byte, 16)
+	rand.Read(randBytes)
+	controlChannel := filepath.Join(os.TempDir(), "skyof-"+hex.EncodeToString(randBytes))
+	command, err = ofp.makeCommand(
+		[]string{"ovs-ofctl", "-O", "Openflow15", "monitor", "--unixctl", controlChannel},
+		probe.Bridge)
+	if err != nil {
+		return err
+	}
+	probe.groupMonitored = true
+	lines, err := launchContinuousOnSwitch(probe.ctx, command)
+	if err != nil {
+		logging.GetLogger().Errorf("Group monitor failed %s: %s", probe.Bridge, err)
+		return err
+	}
+	if err = waitForFile(controlChannel); err != nil {
+		logging.GetLogger().Errorf("No control channel for group monitor failed %s: %s", probe.Bridge, err)
+		return err
+	}
+	if err = sendOpenflow(controlChannel, openflowSetSlave); err != nil {
+		logging.GetLogger().Errorf("Openflow command 'set slave' for group monitor failed %s: %s", probe.Bridge, err)
+		return err
+	}
+	if err = sendOpenflow(controlChannel, openflowActivateForwardRequest); err != nil {
+		logging.GetLogger().Errorf("Openflow command 'activate forward request' for group monitor failed %s: %s", probe.Bridge, err)
+		return err
+	}
+	go func() {
+		logging.GetLogger().Debugf("Launching goroutine for monitor groups %s", probe.Bridge)
+		err := probe.dumpGroups()
+		if err != nil {
+			logging.GetLogger().Warningf("Cannot dump groups for %s: %s", probe.Bridge, err)
+			return
+		}
+		logging.GetLogger().Debugf("Treating events for groups on %s", probe.Bridge)
+		for line := range lines {
+			if probe.ctx.Err() != nil {
+				break
+			}
+			submatch := groupEventRegexp.FindStringSubmatch(line)
+			if submatch == nil {
+				continue
+			}
+			gid, err := strconv.ParseUint(submatch[2], 10, 32)
+			if err != nil {
+				logging.GetLogger().Errorf("Cannot parse group id %s on %s: %s", submatch[2], probe.Bridge, err)
+				continue
+			}
+			groupID := uint(gid)
+			switch submatch[1] {
+			case "ADD":
+				group := probe.getGroup(groupID)
+				if group != nil {
+					probe.addGroup(group)
+				}
+			case "DEL":
+				probe.delGroup(groupID)
+			case "MOD", "INSERT_BUCKET", "REMOVE_BUCKET":
+				probe.modGroup(groupID)
+			default:
+				logging.GetLogger().Errorf("unknown group action %s", submatch[1])
+			}
+		}
+	}()
+	return nil
+}
+
 // NewBridgeProbe creates a probe and launch the active process
 func (o *OvsOfProbe) NewBridgeProbe(host string, bridge string, uuid string, bridgeNode *graph.Node) (*BridgeOfProbe, error) {
 	ctx, cancel := context.WithCancel(o.ctx)
@@ -514,16 +792,28 @@ func (o *OvsOfProbe) NewBridgeProbe(host string, bridge string, uuid string, bri
 		address = bridge
 	}
 	probe := &BridgeOfProbe{
-		Host:       host,
-		Bridge:     bridge,
-		UUID:       uuid,
-		Address:    address,
-		BridgeNode: bridgeNode,
-		OvsOfProbe: o,
-		Rules:      make(map[string][]*Rule),
-		cancel:     cancel}
+		Host:           host,
+		Bridge:         bridge,
+		UUID:           uuid,
+		Address:        address,
+		BridgeNode:     bridgeNode,
+		OvsOfProbe:     o,
+		Rules:          make(map[string][]*Rule),
+		Groups:         make(map[uint]*graph.Node),
+		groupMonitored: false,
+		ctx:            ctx,
+		cancel:         cancel}
 
-	return probe, probe.monitor(ctx)
+	err := probe.monitor(ctx)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	err = probe.monitorGroup()
+	if err != nil {
+		logging.GetLogger().Errorf("Cannot add group probe on %s - %s", bridge, err)
+	}
+	return probe, nil
 }
 
 func (o *OvsOfProbe) makeCommand(commands []string, bridge string, args ...string) ([]string, error) {
@@ -548,7 +838,10 @@ func (o *OvsOfProbe) OnOvsBridgeAdd(bridgeNode *graph.Node) {
 	defer o.Unlock()
 
 	uuid, _ := bridgeNode.GetFieldString("UUID")
-	if _, ok := o.BridgeProbes[uuid]; ok {
+	if probe, ok := o.BridgeProbes[uuid]; ok {
+		if !probe.groupMonitored {
+			probe.monitorGroup()
+		}
 		return
 	}
 
@@ -556,15 +849,15 @@ func (o *OvsOfProbe) OnOvsBridgeAdd(bridgeNode *graph.Node) {
 	bridgeName, _ := bridgeNode.GetFieldString("Name")
 	bridgeProbe, err := o.NewBridgeProbe(hostName, bridgeName, uuid, bridgeNode)
 	if err == nil {
-		logging.GetLogger().Infof("Probe added for %s on %s (%s)", bridgeName, hostName, uuid)
+		logging.GetLogger().Debugf("Probe added for %s on %s (%s)", bridgeName, hostName, uuid)
 		o.BridgeProbes[uuid] = bridgeProbe
 	} else {
-		logging.GetLogger().Errorf("Cannot add probe for bridge %s on %s (%s)", bridgeName, hostName, uuid)
+		logging.GetLogger().Errorf("Cannot add probe for bridge %s on %s (%s): %s", bridgeName, hostName, uuid, err)
 	}
 }
 
 // OnOvsBridgeDel is called when a bridge is deleted
-func (o *OvsOfProbe) OnOvsBridgeDel(uuid string, bridgeNode *graph.Node) {
+func (o *OvsOfProbe) OnOvsBridgeDel(uuid string) {
 	o.Lock()
 	defer o.Unlock()
 
@@ -573,11 +866,20 @@ func (o *OvsOfProbe) OnOvsBridgeDel(uuid string, bridgeNode *graph.Node) {
 		delete(o.BridgeProbes, uuid)
 	}
 	// Clean all the rules attached to the bridge.
+	g := o.Graph
+	g.Lock()
+	defer g.Unlock()
+	bridgeNode := o.Graph.LookupFirstNode(graph.Metadata{"UUID": uuid})
 	if bridgeNode != nil {
-		rules := o.Graph.LookupChildren(bridgeNode, graph.Metadata{"Type": "ofrule"}, nil)
+		rules := g.LookupChildren(bridgeNode, graph.Metadata{"Type": "ofrule"}, nil)
 		for _, ruleNode := range rules {
 			logging.GetLogger().Infof("Rule %v deleted (Bridge deleted)", ruleNode.Metadata()["UUID"])
-			o.Graph.DelNode(ruleNode)
+			g.DelNode(ruleNode)
+		}
+		groups := g.LookupChildren(bridgeNode, graph.Metadata{"Type": "ofgroup"}, nil)
+		for _, groupNode := range groups {
+			logging.GetLogger().Infof("Group %v deleted (Bridge deleted)", groupNode.Metadata()["UUID"])
+			g.DelNode(groupNode)
 		}
 	}
 }

--- a/topology/probes/ovsdb/ovsdb.go
+++ b/topology/probes/ovsdb/ovsdb.go
@@ -90,8 +90,6 @@ func (o *OvsdbProbe) OnOvsBridgeAdd(monitor *ovsdb.OvsMonitor, uuid string, row 
 	name := row.New.Fields["name"].(string)
 
 	o.Graph.Lock()
-	defer o.Graph.Unlock()
-
 	bridge := o.Graph.LookupFirstNode(graph.Metadata{"UUID": uuid})
 	if bridge == nil {
 		bridge = o.Graph.NewNode(graph.GenID(), graph.Metadata{"Name": name, "UUID": uuid, "Type": "ovsbridge"})
@@ -129,6 +127,7 @@ func (o *OvsdbProbe) OnOvsBridgeAdd(monitor *ovsdb.OvsMonitor, uuid string, row 
 			}
 		}
 	}
+	o.Graph.Unlock()
 	if o.OvsOfProbe != nil {
 		o.OvsOfProbe.OnOvsBridgeAdd(bridge)
 	}
@@ -136,13 +135,13 @@ func (o *OvsdbProbe) OnOvsBridgeAdd(monitor *ovsdb.OvsMonitor, uuid string, row 
 
 // OnOvsBridgeDel event
 func (o *OvsdbProbe) OnOvsBridgeDel(monitor *ovsdb.OvsMonitor, uuid string, row *libovsdb.RowUpdate) {
+
+	if o.OvsOfProbe != nil {
+		o.OvsOfProbe.OnOvsBridgeDel(uuid)
+	}
 	o.Graph.Lock()
 	defer o.Graph.Unlock()
-
 	bridge := o.Graph.LookupFirstNode(graph.Metadata{"UUID": uuid})
-	if o.OvsOfProbe != nil {
-		o.OvsOfProbe.OnOvsBridgeDel(uuid, bridge)
-	}
 	if bridge != nil {
 		o.Graph.DelNode(bridge)
 	}


### PR DESCRIPTION
The Openflow probe did not display group tables because there was no obvious way to monitor them. Those two commits add support for groups. The hard part is in the probe where we use a mostly hidden functionality of OpenFlow 1.4. As one can expect group support will only work for OF1.5 enabled switch (we cannot safely enable it for 1.4 due to a bug in openvswitch corrected last week).