### PR TITLE
istio: now run-istio-tests executes both k8s and istio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ endif
 
 ifeq ($(WITH_ISTIO), true)
   BUILD_TAGS+=k8s istio
-  EXTRA_ARGS+=-analyzer.topology.probes=istio
+  EXTRA_ARGS+=-analyzer.topology.probes=k8s,istio
 endif
 
 ifeq ($(WITH_HELM), true)

--- a/scripts/ci/install-istio.sh
+++ b/scripts/ci/install-istio.sh
@@ -3,20 +3,22 @@
 DIR=$(dirname $0)
 
 OS=linux
-TARGET_DIR=/usr/bin
+TARGET_DIR=/opt
 
 ISTIO_VERSION="1.0.1"
 ISTIO_URL="https://github.com/istio/istio/releases/download/$ISTIO_VERSION/istio-$ISTIO_VERSION-$OS.tar.gz"
 ISTIO_PKG="istio-$ISTIO_VERSION"
-ISTIO_OBJECTS="$TARGET_DIR/$ISTIO_PKG/install/kubernetes/istio-demo.yaml"
+ISTIO_OBJECTS="$TARGET_DIR/$ISTIO_PKG/install/kubernetes/helm/istio/templates/crds.yaml"
+ISTIO_DEMO="$TARGET_DIR/$ISTIO_PKG/install/kubernetes/istio-demo.yaml"
 ISTIO_NS=istio-system
+ISTIOCTL=$TARGET_DIR/$ISTIO_PKG/bin/istioctl
 
 uninstall_istio() {
         sudo rm -rf $TARGET_DIR/$ISTIO_PKG
-        sudo rm -rf $TARGET_DIR/istioctl
 }
 
 install_istio() {
+        echo "Installing Istio"
         local tmpdir=$(mktemp -d)
         cd $tmpdir
         curl -L "$ISTIO_URL" | tar xz
@@ -26,14 +28,15 @@ install_istio() {
                 exit 1
         fi
 
-        chmod a+x $ISTIO_PKG
-        sudo cp $ISTIO_PKG/bin/istioctl $TARGET_DIR/.
-        sudo mv $ISTIO_PKG $TARGET_DIR/.
+        sudo cp -R $ISTIO_PKG $TARGET_DIR
+        sudo cp $ISTIOCTL /usr/bin/
+        cd -
         rm -rf $tmpdir
+        echo "Istio installed"
 }
 
 check_istio() {
-        which istioctl 2>/dev/null
+        which $ISTIOCTL 2>/dev/null
         if [ $? != 0 ]; then
                 echo "istioctl is not installed. Please run install-istio.sh install"
                 exit 1
@@ -49,19 +52,25 @@ uninstall() {
 }
 
 stop() {
+        echo "Stopping Istio"
         check_istio
         kubectl delete -f $ISTIO_OBJECTS
+        echo "Istio stopped"
 }
 
 start() {
+        echo "Starting Istio"
         check_istio
         kubectl apply -f $ISTIO_OBJECTS
+        kubectl apply -f $ISTIO_DEMO
         status
         kubectl -n $ISTIO_NS get services
+        echo "Istio started"
 }
 
 status() {
-        istioctl version
+        echo "Checking Istio status"
+        $ISTIOCTL version
         # TODO: istio status - should be filled
 }
 

--- a/scripts/ci/install-minikube.sh
+++ b/scripts/ci/install-minikube.sh
@@ -116,13 +116,15 @@ start() {
 
 	# FIXME: using '|| true' to overcome following:
         # FIXME: Error cluster status: getting status: running command: sudo systemctl is-active kubelet
+        echo "Starting minikube with minikube start $args"
         minikube start $args || true
 
-	# give minikube time to come up
-	sleep 5
+        echo "Give minikube time to come up"
+        sleep 5
 
+        echo "Get minikube status"
         minikube status
-        export no_proxy=$no_proxy,$(minikube ip)
+
         kubectl config use-context minikube
 
         for i in .kube .minikube; do

--- a/scripts/ci/install-minikube.sh
+++ b/scripts/ci/install-minikube.sh
@@ -101,7 +101,7 @@ stop() {
 start() {
         check_minikube
 
-        local args="--kubernetes-version $K8S_VERSION"
+        local args="--kubernetes-version $K8S_VERSION --memory 4096"
         if [ "$MINIKUBE_DRIVER" == "none" ]; then
                 args="$args --vm-driver=none --bootstrapper=localkube"
                 local driver=$(sudo docker info --format '{{print .CgroupDriver}}')

--- a/scripts/ci/jobs/jobs.yml
+++ b/scripts/ci/jobs/jobs.yml
@@ -269,7 +269,7 @@
           cancel-builds-on-update: true
     builders:
       - skydive-test:
-          test: scripts/ci/run-k8s-tests.sh
+          test: scripts/ci/run-istio-tests.sh
     publishers:
       - junit:
           results: tests.xml

--- a/scripts/ci/jobs/jobs.yml
+++ b/scripts/ci/jobs/jobs.yml
@@ -269,7 +269,7 @@
           cancel-builds-on-update: true
     builders:
       - skydive-test:
-          test: scripts/ci/run-istio-tests.sh
+          test: BACKEND=memory scripts/ci/run-istio-tests.sh
     publishers:
       - junit:
           results: tests.xml

--- a/scripts/ci/jobs/jobs.yml
+++ b/scripts/ci/jobs/jobs.yml
@@ -265,7 +265,7 @@
       - skydive-pull-request:
           name: k8s-tests
           trigger-prefix: "(all )?"
-          only-trigger-phrase: false
+          only-trigger-phrase: true
           cancel-builds-on-update: true
     builders:
       - skydive-test:

--- a/scripts/ci/run-functional-tests.sh
+++ b/scripts/ci/run-functional-tests.sh
@@ -1,39 +1,11 @@
 #!/bin/bash
 
 set -v
+set -e
 
-dir="$(dirname "$0")"
+DIR="$(dirname "$0")"
 
-go get -f -u github.com/tebeka/go2xunit
-
-sudo iptables -F
-sudo iptables -P FORWARD ACCEPT
-for i in $(find /proc/sys/net/bridge/ -type f) ; do echo 0 | sudo tee $i ; done
-
-cd ${GOPATH}/src/github.com/skydive-project/skydive
-
-BACKEND=${BACKEND:-elasticsearch}
-case "$BACKEND" in
-  "orientdb")
-    export ORIENTDB_ROOT_PASSWORD=root
-    ARGS="-analyzer.topology.backend orientdb -analyzer.flow.backend orientdb"
-    ;;
-  "elasticsearch")
-    ARGS="-analyzer.topology.backend elasticsearch -analyzer.flow.backend elasticsearch"
-    ;;
-esac
-
-if [ "$COVERAGE" != "true" -a "$(uname -m)" != "ppc64le" ]; then
-    GOFLAGS="-race"
-fi
-
-make test.functionals.batch GOFLAGS="$GOFLAGS" TAGS="$TAGS" GORACE="history_size=7" WITH_EBPF=true WITH_K8S=false VERBOSE=true TIMEOUT=20m COVERAGE=$COVERAGE ARGS="$ARGS -graph.output ascii -standalone" TEST_PATTERN=$TEST_PATTERN 2>&1 | tee $WORKSPACE/output.log
-retcode=$?
-go2xunit -fail -fail-on-race -suite-name-prefix tests -input $WORKSPACE/output.log -output $WORKSPACE/tests.xml
-sed -i 's/\x1b\[[0-9;]*m//g' $WORKSPACE/tests.xml
-
-if [ -e functionals.cover ]; then
-    mv functionals.cover functionals-${BACKEND}.cover
-fi
-
-exit $retcode
+. "$DIR/run-tests-utils.sh"
+network_setup
+tests_run
+exit $RETCODE

--- a/scripts/ci/run-istio-tests.sh
+++ b/scripts/ci/run-istio-tests.sh
@@ -7,24 +7,28 @@ DIR="$(dirname "$0")"
 
 istio_setup() {
         . "$DIR/install-minikube.sh" install
-        . "$DIR/install-minikube.sh" stop
+        . "$DIR/install-minikube.sh" stop || true
         . "$DIR/install-minikube.sh" start
 
         . "$DIR/install-istio.sh" install
-        . "$DIR/install-istio.sh" stop
+        . "$DIR/install-istio.sh" stop || true
         . "$DIR/install-istio.sh" start
 }
 
 istio_teardown() {
-        [ "$KEEP_RESOURCES" = "true" ] || . "$DIR/install-istio.sh" stop
-        [ "$KEEP_RESOURCES" = "true" ] || . "$DIR/install-minikube.sh" stop
+        . "$DIR/install-istio.sh" stop || true
+        . "$DIR/install-minikube.sh" stop || true
 }
+
+[ "$KEEP_RESOURCES" = "true" ] || trap istio_teardown EXIT
+
+export no_proxy=$no_proxy,192.168.99.100
 
 . "$DIR/run-tests-utils.sh"
 network_setup
 istio_setup
+WITH_K8S=true
 WITH_ISTIO=true
 TEST_PATTERN='\(Istio\|K8s\)'
 tests_run
-istio_teardown
 exit $RETCODE

--- a/scripts/ci/run-istio-tests.sh
+++ b/scripts/ci/run-istio-tests.sh
@@ -24,7 +24,7 @@ istio_teardown() {
 network_setup
 istio_setup
 WITH_ISTIO=true
-TEST_PATTERN=Istio
+TEST_PATTERN='\(Istio\|K8s\)'
 tests_run
 istio_teardown
 exit $RETCODE

--- a/scripts/ci/run-k8s-tests.sh
+++ b/scripts/ci/run-k8s-tests.sh
@@ -19,7 +19,7 @@ k8s_setup
 network_setup
 WITH_EBPF=true
 WITH_K8S=true
-TEST_PATTERN=K8s
+TEST_PATTERN="K8s"
 tests_run
 k8s_teardown
 exit $RETCODE

--- a/scripts/ci/run-tests-utils.sh
+++ b/scripts/ci/run-tests-utils.sh
@@ -16,12 +16,13 @@ tests_run() {
         LOGFILE=$WORKSPACE/output.log
         TESTFILE=$WORKSPACE/tests.xml
 
-        BACKEND="memory"
-        ARGS=" -analyzer.topology.backend $BACKEND -analyzer.flow.backend $BACKEND -graph.output ascii -standalone"
+        BACKEND=${BACKEND:-memory}
+        ARGS="-graph.output ascii -standalone -analyzer.topology.backend $BACKEND -analyzer.flow.backend $BACKEND"
+        export ORIENTDB_ROOT_PASSWORD=root
 
         if [ "$COVERAGE" != "true" -a "$(uname -m)" != "ppc64le" ]; then
-            GOFLAGS="-race"
-              export TEST_COVERPROFILE=../functionals-$BACKEND.cover
+                GOFLAGS="-race"
+                export TEST_COVERPROFILE=../functionals-$BACKEND.cover
         fi
 
         make test.functionals.batch \
@@ -34,4 +35,8 @@ tests_run() {
         go2xunit -fail -fail-on-race -suite-name-prefix tests \
                 -input $LOGFILE -output $TESTFILE
         sed -i 's/\x1b\[[0-9;]*m//g' $TESTFILE
+
+        if [ -e functionals.cover ]; then
+                mv functionals.cover $TEST_COVERPROFILE
+        fi
 }

--- a/scripts/ci/run-tests-utils.sh
+++ b/scripts/ci/run-tests-utils.sh
@@ -27,7 +27,7 @@ tests_run() {
         make test.functionals.batch \
                 GOFLAGS="$GOFLAGS" VERBOSE=true TAGS="$TAGS" GORACE="history_size=5" TIMEOUT=20m \
                 WITH_HELM="$WITH_HELM" WITH_EBPF="$WITH_EBPF" WITH_K8S="$WITH_K8S" WITH_ISTIO="$WITH_ISTIO" \
-                ARGS="$ARGS" TEST_PATTERN=$TEST_PATTERN 2>&1 | tee $LOGFILE
+                ARGS="$ARGS" TEST_PATTERN="$TEST_PATTERN" 2>&1 | tee $LOGFILE
         RETCODE=$?
 
         go get -f -u github.com/tebeka/go2xunit


### PR DESCRIPTION
the new istio test includes both k8s (ran on a system with istio) and istio tests. to check this fix you must add a CI hook enabling to write `run skydive-istio-tests` if successful it should replace the `run skydive-k8s-tests`

skip skydive-go-fmt
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-scale-tests
skip skydive-cdd-overview-tests
skip skydive-unit-tests
skip skydive-compile-tests
skip skydive-ppc64le-tests