### PR TITLE
devstack: bump the go version as required

### DIFF
--- a/devstack/plugin.sh
+++ b/devstack/plugin.sh
@@ -15,8 +15,8 @@
 # The path where go binaries have to be installed
 GOROOT=${GOROOT:-/opt/go}
 
-# golang version. Skydive needs at least version 1.7
-GO_VERSION=${GO_VERSION:-1.8}
+# golang version. Skydive needs at least version 1.9
+GO_VERSION=${GO_VERSION:-1.9}
 
 # GOPATH where the go src, pkgs are installed
 GOPATH=/opt/stack/go


### PR DESCRIPTION
skip skydive-go-fmt
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-scale-tests
skip skydive-cdd-overview-tests
skip skydive-unit-tests
skip skydive-compile-tests
skip skydive-ppc64le-tests
skip skydive-k8s-tests