### PR TITLE
K8s netpol ui minor

### DIFF
--- a/statics/css/graph-layout.css
+++ b/statics/css/graph-layout.css
@@ -116,11 +116,9 @@ circle.emphasized  {
 }
 
 .links path.networkpolicy {
-  stroke-dasharray: 5;
-  stroke-dashoffset: 80;
   stroke: rgb(102, 102, 51);
   stroke-width: 2;
-  opacity: 0.5;
+  opacity: 0.2;
 }
 
 .group {

--- a/statics/js/components/graph-layout.js
+++ b/statics/js/components/graph-layout.js
@@ -286,9 +286,9 @@ var TopologyGraphLayout = function(vm, selector) {
       pathD = a + " " + b
     }
 
-    let color = "rgb(159, 218, 64, 0.4)"
+    let color = "rgb(0, 128, 0, 0.8)"
     if (target === "deny") {
-      color = "rgba(255, 99, 71, 0.4)"
+      color = "rgba(255, 0, 0, 0.8)"
     }
 
     self.svg.append("defs").append("marker")
@@ -1538,9 +1538,20 @@ TopologyGraphLayout.prototype = {
   },
 
   arrowhead: function(link) {
-    if (link.metadata.RelationType !== "networkpolicy") {
-      return "url(#arrowhead-none)";
+    let none = "url(#arrowhead-none)";
+
+    if (link.source.metadata.Type !== "networkpolicy") {
+      return none
     }
+
+    if (link.target.metadata.Type !== "pod") {
+      return none
+    }
+
+    if (link.metadata.RelationType !== "networkpolicy") {
+      return none
+    }
+
     return "url(#arrowhead-"+link.metadata.PolicyType+"-"+link.metadata.PolicyTarget+"-"+link.metadata.PolicyPoint+")";
   },
 

--- a/topology/probes/k8s/networkpolicy.go
+++ b/topology/probes/k8s/networkpolicy.go
@@ -55,8 +55,6 @@ func (h *networkPolicyHandler) Dump(obj interface{}) string {
 func (h *networkPolicyHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	np := obj.(*v1beta1.NetworkPolicy)
 	m := NewMetadata(Manager, "networkpolicy", np, np.Name, np.Namespace)
-	m.SetFieldAndNormalize("Egress", np.Spec.Egress)
-	m.SetFieldAndNormalize("Ingress", np.Spec.Ingress)
 	return graph.Identifier(np.GetUID()), m
 }
 


### PR DESCRIPTION
Minor fixes to how k8s netpol is presented, to check:

```
make debug.analyzer
```

```
kubectl create -f tests/k8s/networkpolicy-ingress-allow-namespace.yaml
```