### PR TITLE
es: don't index topology metadata fields under '*.Extra'

### DIFF
--- a/scripts/ci/jobs/jobs.yml
+++ b/scripts/ci/jobs/jobs.yml
@@ -281,7 +281,7 @@
           slave-name: baremetal
     builders:
       - skydive-test:
-          test: BACKEND=memory scripts/ci/run-istio-tests.sh
+          test: BACKEND=elasticsearch scripts/ci/run-istio-tests.sh
     publishers:
       - junit:
           results: tests.xml

--- a/tests/k8s_test.go
+++ b/tests/k8s_test.go
@@ -65,7 +65,7 @@ func makeHasArgsType(mngr, ty interface{}, args1 ...interface{}) []interface{} {
 }
 
 func makeHasArgsNode(node *graph.Node, args1 ...interface{}) []interface{} {
-	m := node.Metadata()
+	m := node.Metadata
 	args := []interface{}{}
 	for _, key := range []string{"Namespace", "Name"} {
 		if val, ok := m[key]; ok {
@@ -166,7 +166,7 @@ func testNodeCreation(t *testing.T, setupCmds, tearDownCmds []Cmd, mngr, typ, na
 				return err
 			}
 
-			m := obj.Metadata()
+			m := obj.Metadata
 			for _, field := range fields {
 				if _, ok := m[field]; !ok {
 					return fmt.Errorf("Node '%s %s' missing field: %s", typ, name, field)

--- a/tests/k8s_test.go
+++ b/tests/k8s_test.go
@@ -528,7 +528,7 @@ func TestK8sNetworkPolicyAllowIngressNamespaceToNamespaceScenario(t *testing.T) 
 }
 
 func TestK8sNetworkPolicyAllowIngressPodToPodPortsScenario(t *testing.T) {
-	testK8sNetworkPolicyObjectToObjectScenario(t, k8s.PolicyTypeIngress, k8s.PolicyTargetAllow, "ports", "Ports", ":80")
+	testK8sNetworkPolicyObjectToObjectScenario(t, k8s.PolicyTypeIngress, k8s.PolicyTargetAllow, "ports", "PolicyPorts", ":80")
 }
 
 func TestK8sServicePodScenario(t *testing.T) {

--- a/topology/graph/elasticsearch.go
+++ b/topology/graph/elasticsearch.go
@@ -39,11 +39,23 @@ const graphElementMapping = `
 {
 	"dynamic_templates": [
 		{
-			"strings": {
-				"match": "*",
-				"match_mapping_type": "string",
+                        "strings": {
+                                "path_match": "*",
+                                "path_unmatch": "*.Extra.*",
+                                "match_mapping_type": "string",
+                                "mapping": {
+                                        "type": "keyword"
+                                }
+                        }
+                },
+		{
+			"extra": {
+				"path_match": "*.Extra",
 				"mapping": {
-					"type": "keyword"
+					"type": "object",
+					"enabled": false,
+					"store": true,
+					"index": "no"
 				}
 			}
 		},

--- a/topology/probes/k8s/networkpolicy.go
+++ b/topology/probes/k8s/networkpolicy.go
@@ -255,7 +255,7 @@ func (npl *networkPolicyLinker) createLinks(np *v1beta1.NetworkPolicy, npNode, f
 	metadata := npl.newEdgeMetadata(ty, target, point)
 	for _, objNode := range podNodes {
 		if filterNode == nil || filterNode.ID == objNode.ID {
-			metadata.SetFieldAndNormalize("Ports", getFieldPorts(np, ty))
+			metadata.SetFieldAndNormalize("PolicyPorts", getFieldPorts(np, ty))
 			fields := []string{string(npNode.ID), string(objNode.ID)}
 			for k, v := range metadata {
 				fields = append(fields, k, v.(string))


### PR DESCRIPTION
provided two mechanisms for handling large metadata fields (as the k8s metadata section):
- support configuring elasticsearch limit on number of fields (default 1000 fields)
- enable k8s probe to disable or prune size of the k8s metadata section (default is enabled with max 100 fields)

