### PR TITLE
docker: fix remaining Id instead repo disgest

### DIFF
--- a/scripts/ci/create-docker-image.sh
+++ b/scripts/ci/create-docker-image.sh
@@ -80,8 +80,8 @@ done
 
 for arch in $ARCHES
 do
-    digest=$( docker inspect --format='{{index .Id}}' ${DOCKER_IMAGE}:${arch}-${DOCKER_TAG} )
-    docker manifest annotate --arch $arch "${DOCKER_IMAGE}:${DOCKER_TAG}" ${DOCKER_IMAGE}@$digest
+    digest=$( docker inspect --format='{{index .RepoDigests 0}}' ${DOCKER_IMAGE}:${arch}-${DOCKER_TAG} )
+    docker manifest annotate --arch $arch "${DOCKER_IMAGE}:${DOCKER_TAG}" $digest
 done
 
 docker manifest inspect "${DOCKER_IMAGE}:${DOCKER_TAG}"


### PR DESCRIPTION
skip skydive-compile-tests
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-go-fmt
skip skydive-k8s-tests
skip skydive-scale-tests
skip skydive-selenium-tests
skip skydive-unit-tests
skip skydive-cdd-overview-tests
skip skydive-ppc64le-tests
skip skydive-opencontrail-tests