### PR TITLE
ui: add ui.k8s_enabled config parameter

### DIFF
--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -470,6 +470,9 @@ ui:
   # Enable/disable ssh to hosts
   # ssh_enabled: false
 
+  # Enable/disable k8s related elements
+  # k8s_enabled: false
+
   bpf:
     # Pre-defined BPF filters
     favorites:

--- a/statics/js/components/topology.js
+++ b/statics/js/components/topology.js
@@ -484,7 +484,7 @@ var TopologyComponent = {
     },
 
     isK8SEnabled: function() {
-      return (globalVars["probes"].indexOf("k8s") >= 0);
+      return app.getConfigValue('k8s_enabled')
     },
 
     metadataLinks: function(m) {


### PR DESCRIPTION
Added a ui independent parameter for enabling k8s artifacts such as filters (which may interfere with users  not using k8s). When you have the following setup:
- local-analyzer - collecting k8s and reporting upstream
- remote-analyzer - getting k8s info from local-analyzer and serving as webserver

```
local-analyzer (analyzer.topology.probes.k8s) ----> remote-analyzer (ui.k8s_enabled: true)
```

This parameter is disabled by default;  to enable it set:

```
ui.k8s_enabled: true
```

