### PR TITLE
ui: fix collapse/expand node by levels

### DIFF
--- a/statics/js/components/graph-layout.js
+++ b/statics/js/components/graph-layout.js
@@ -602,7 +602,7 @@ TopologyGraphLayout.prototype = {
   },
 
   setGroupLevel: function(group) {
-    var level = 1, g = group;
+    var level = 0, g = group;
     while (g) {
       if (level > g.depth) g.depth = level;
       level++;
@@ -1349,7 +1349,7 @@ TopologyGraphLayout.prototype = {
       if (maxLevel === 0) {
         return false;
       }
-      if ((this.collapseLevel + 1) >= maxLevel) {
+      if ((this.collapseLevel) >= maxLevel) {
         return false;
       }
 


### PR DESCRIPTION
when we have a group with level one we are not able to expand that. this patch fixes that