### PR TITLE
neutron: peering with ovs firewall

### DIFF
--- a/topology/probes/neutron/neutron.go
+++ b/topology/probes/neutron/neutron.go
@@ -275,6 +275,14 @@ func (mapper *Probe) updateNode(node *graph.Node, attrs *attributes) {
 		return
 	}
 
+	if strings.HasPrefix(name, "tap") {
+		if attachedMac, _ := node.GetFieldString("ExtID.attached-mac"); attachedMac != "" {
+			tr := mapper.graph.StartMetadataTransaction(node)
+			tr.AddMetadata("PeerIntfMAC", attachedMac)
+			tr.Commit()
+		}
+	}
+
 	if !strings.HasPrefix(name, "qvo") {
 		return
 	}


### PR DESCRIPTION
Adds meta-information for peering in the case where the firwall
is provided directly by openvswitch with conntrack and not by the
hybrid iptable firewall.

Both the legacy and the new implementations are supported.

This is the bugfix part of #1410.