### PR TITLE
libvirt: initial version of libvirt probe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ BOOTSTRAP_ARGS?=
 BUILD_TAGS?=$(TAGS)
 WITH_LXD?=true
 WITH_OPENCONTRAIL?=true
+WITH_LIBVIRT?=true
 
 export PATH:=$(BUILD_TOOLS):$(PATH)
 
@@ -170,6 +171,10 @@ endif
 
 ifeq ($(WITH_LXD), true)
   BUILD_TAGS+=lxd
+endif
+
+ifeq ($(WITH_LIBVIRT), true)
+  BUILD_TAGS+=libvirt
 endif
 
 STATIC_LIBS_ABS := $(addprefix $(STATIC_DIR)/,$(STATIC_LIBS))

--- a/agent/probes.go
+++ b/agent/probes.go
@@ -31,6 +31,7 @@ import (
 	"github.com/skydive-project/skydive/probe"
 	"github.com/skydive-project/skydive/topology/graph"
 	"github.com/skydive-project/skydive/topology/probes/docker"
+	"github.com/skydive-project/skydive/topology/probes/libvirt"
 	"github.com/skydive-project/skydive/topology/probes/lldp"
 	"github.com/skydive-project/skydive/topology/probes/lxd"
 	"github.com/skydive-project/skydive/topology/probes/netlink"
@@ -107,6 +108,12 @@ func NewTopologyProbeBundleFromConfig(g *graph.Graph, hostNode *graph.Node) (*pr
 			probes[t] = opencontrail
 		case "socketinfo":
 			probes[t] = socketinfo.NewSocketInfoProbe(g, hostNode)
+		case "libvirt":
+			libvirt, err := libvirt.NewProbeFromConfig(g, hostNode)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to initialize Libvirt probe: %s", err)
+			}
+			probes[t] = libvirt
 		default:
 			logging.GetLogger().Errorf("unknown probe type %s", t)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -80,6 +80,7 @@ func init() {
 	cfg.SetDefault("agent.flow.pcapsocket.max_port", 8132)
 	cfg.SetDefault("agent.listen", "127.0.0.1:8081")
 	cfg.SetDefault("agent.topology.probes", []string{"ovsdb"})
+	cfg.SetDefault("agent.topology.libvirt.url", "qemu:///system")
 	cfg.SetDefault("agent.topology.netlink.metrics_update", 30)
 	cfg.SetDefault("agent.topology.neutron.domain_name", "Default")
 	cfg.SetDefault("agent.topology.neutron.endpoint_type", "public")

--- a/contrib/ansible/roles/skydive_dev/tasks/main.yml
+++ b/contrib/ansible/roles/skydive_dev/tasks/main.yml
@@ -27,6 +27,7 @@
      - rpm-build
      - rpmlint
      - libvirt
+     - libvirt-devel
      - libvirt-client
      - vagrant-libvirt
      - ansible

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -2,7 +2,7 @@ ARG  BASE=ubuntu:18.04
 FROM $BASE
 ARG  ARCH=x86_64
 RUN apt-get -y update \
-    && apt-get -y install openvswitch-common libpcap0.8 libxml2 \
+    && apt-get -y install openvswitch-common libpcap0.8 libxml2 libvirt0 \
     && rm -rf /var/lib/apt/lists/*
 COPY skydive.$ARCH /usr/bin/skydive
 COPY skydive.yml /etc/skydive.yml

--- a/contrib/docker/Dockerfile.compile
+++ b/contrib/docker/Dockerfile.compile
@@ -12,7 +12,7 @@ RUN apt-get -y update \
     && add-apt-repository -y ppa:ubuntu-toolchain-r/ppa \
     && apt-get -y update \
     && apt-get -y install git make flex bison wget unzip golang libpcap0.8-dev npm \
-         clang llvm zlib1g-dev liblzma-dev libc++-dev libc-dev linux-libc-dev libxml2-dev \
+         clang llvm zlib1g-dev liblzma-dev libc++-dev libc-dev linux-libc-dev libxml2-dev libvirt-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # EBPF requires llvm-6.0 clang-6.0 however the cross compulation docker image can't install them

--- a/contrib/docker/Dockerfile.crosscompile
+++ b/contrib/docker/Dockerfile.crosscompile
@@ -55,4 +55,4 @@ CMD chown -R $UID /root/go/.cache/govendor \
     CC=${TARGET_ARCH}-linux-gnu-gcc \
     GOOS=linux \
     GOARCH=$TARGET_GOARCH \
-    make govendor compile.static WITH_OPENCONTRAIL=false WITH_EBPF=true
+    make govendor compile.static WITH_OPENCONTRAIL=false WITH_LIBVIRT=false WITH_EBPF=true

--- a/contrib/packaging/rpm/skydive.spec
+++ b/contrib/packaging/rpm/skydive.spec
@@ -43,12 +43,13 @@ License:        ASL 2.0
 URL:            https://%{import_path}
 Source0:        https://%{import_path}/releases/download/v%{version}/skydive-%{fullver}.tar.gz
 BuildRequires:  systemd
-BuildRequires:  libpcap-devel libxml2-devel
+BuildRequires:  libpcap-devel libxml2-devel libvirt-devel
 %if 0%{?fedora} >= 27
 BuildRequires:  llvm clang kernel-headers
 %endif
 BuildRequires:  selinux-policy-devel, policycoreutils-devel
 Requires:       %{name}-selinux = %{version}-%{release}
+Requires:       libpcap libxml2 libvirt-libs
 
 # This is used by the specfile-update-bundles script to automatically
 # generate the list of the Go libraries bundled into the Skydive binaries

--- a/devstack/plugin.sh
+++ b/devstack/plugin.sh
@@ -127,9 +127,9 @@ function pre_install_skydive {
 function install_skydive {
     if [ ! -f $GOPATH/bin/skydive ]; then
         if is_fedora ; then
-            install_package libpcap-devel npm
+            install_package libpcap-devel npm libvirt-devel
         else
-            install_package libpcap-dev npm
+            install_package libpcap-dev npm libvirt-dev
         fi
         SKYDIVE_SRC=$GOPATH/src/github.com/skydive-project
         mkdir -p $SKYDIVE_SRC

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -216,6 +216,9 @@ agent:
       interfaces:
         # - eth0
 
+    libvirt:
+      # url: qemu:///system
+
   capture:
     # Period in second to get capture stats from the probe. Note this
     # stats_update: 1

--- a/scripts/ci/create-binaries.sh
+++ b/scripts/ci/create-binaries.sh
@@ -21,7 +21,7 @@ dir="$(dirname "$0")"
 cd ${GOPATH}/src/github.com/skydive-project/skydive
 
 echo "--- BINARIES ---"
-make static WITH_EBPF=true
+make static WITH_EBPF=true WITH_LIBVIRT=false
 git reset --hard
 git remote add binaries ${BINARIES_REPO}
 git fetch binaries

--- a/scripts/ci/create-release.sh
+++ b/scripts/ci/create-release.sh
@@ -34,7 +34,7 @@ fi
 set -v
 
 changelog=$(scripts/ci/extract-changelog.py CHANGELOG.md $CHANGELOG_VERSION)
-make static WITH_EBPF=true
+make static WITH_EBPF=true WITH_LIBVIRT=false
 ${dir}/../../contrib/packaging/rpm/generate-skydive-bootstrap.sh -s -r ${TAG}
 
 github-release release ${FLAGS} --user skydive-project --repo skydive --tag ${TAG} --description "$changelog"

--- a/scripts/ci/run-compile-tests.sh
+++ b/scripts/ci/run-compile-tests.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -v
+set -e
 
 dir="$(dirname "$0")"
 
@@ -23,4 +24,4 @@ make WITH_PROF=true VERBOSE=true
 make test.functionals.compile TAGS=${TAGS} WITH_NEUTRON=true WITH_SELENIUM=true WITH_CDD=true WITH_SCALE=true
 
 # Compile static
-make static
+make static WITH_LIBVIRT=false

--- a/scripts/ci/run-tripleo-tests.sh
+++ b/scripts/ci/run-tripleo-tests.sh
@@ -5,7 +5,7 @@ set -e
 SKYDIVE_PATH=$PWD
 
 pushd ${GOPATH}/src/github.com/skydive-project/skydive
-make static
+make static WITH_LIBVIRT=false
 popd
 
 QUICKSTART=${QUICKSTART:-/tmp/tripleo-quickstart}

--- a/topology/graph/processor.go
+++ b/topology/graph/processor.go
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2018 Orange
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package graph
+
+import (
+	"github.com/skydive-project/skydive/common"
+)
+
+// NodeAction is a callback to perform on a node. The action is kept
+// active as long as it returns true.
+type NodeAction interface {
+	ProcessNode(g *Graph, n *Node) bool
+}
+
+// deferred represents a node action with additional info if needed
+// for cancellation.
+type deferred struct {
+	action NodeAction
+}
+
+// Processor encapsulates an indexer that will process NodeActions
+// on the nodes that filter
+type Processor struct {
+	common.RWMutex
+	DefaultGraphListener
+	MetadataIndexer *MetadataIndexer
+	actions         map[string][]deferred
+}
+
+// NewProcessor creates a Processor on the graph g, a stream of
+// events controlled by listenerHandler, that match a first set
+// of metadata m. Actions will be associated to a given set
+// of values for indexes.
+func NewProcessor(g *Graph, listenerHandler ListenerHandler, m ElementMatcher, indexes ...string) (processor *Processor) {
+	processor = &Processor{
+		MetadataIndexer: NewMetadataIndexer(g, listenerHandler, m, indexes...),
+		actions:         make(map[string][]deferred),
+	}
+	processor.MetadataIndexer.AddEventListener(processor)
+	return
+}
+
+// DoAction will perform the action for nodes matching values.
+func (processor *Processor) DoAction(action NodeAction, values ...interface{}) {
+	processor.Lock()
+	defer processor.Unlock()
+	nodes, _ := processor.MetadataIndexer.Get(values...)
+	kont := true
+	for _, node := range nodes {
+		kont = action.ProcessNode(processor.MetadataIndexer.graph, node)
+		if !kont {
+			break
+		}
+	}
+	if kont {
+		act := deferred{action: action}
+		hash := processor.MetadataIndexer.Hash(values...)
+		if actions, ok := processor.actions[hash]; ok {
+			actions = append(actions, act)
+		} else {
+			actions := []deferred{act}
+			processor.actions[hash] = actions
+		}
+	}
+}
+
+// Start starts the processor
+func (processor *Processor) Start() {
+	processor.MetadataIndexer.Start()
+}
+
+// Stop stops the processor
+func (processor *Processor) Stop() {
+	processor.MetadataIndexer.Stop()
+}
+
+// Cancel the actions attached to a given set of values.
+func (processor *Processor) Cancel(values ...interface{}) {
+	processor.Lock()
+	defer processor.Unlock()
+	hash := processor.MetadataIndexer.Hash(values...)
+	delete(processor.actions, hash)
+}
+
+// OnNodeAdded event
+func (processor *Processor) OnNodeAdded(n *Node) {
+	if values, err := getFieldsAsArray(n, processor.MetadataIndexer.indexes); err == nil {
+		hash := processor.MetadataIndexer.Hash(values...)
+		processor.Lock()
+		defer processor.Unlock()
+		if actions, ok := processor.actions[hash]; ok {
+			var keep []deferred
+			for _, action := range actions {
+				if action.action.ProcessNode(processor.MetadataIndexer.graph, n) {
+					keep = append(keep, action)
+				}
+			}
+			if len(keep) == 0 {
+				delete(processor.actions, hash)
+			} else {
+				processor.actions[hash] = keep
+			}
+		}
+	}
+}

--- a/topology/graph/processor_test.go
+++ b/topology/graph/processor_test.go
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2018 Orange
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package graph
+
+import (
+	"sort"
+	"testing"
+)
+
+// A simple action that we may repeat. More common actions will likely
+// check a property of nodes and return false when a matching node has been
+// processed.
+type action struct {
+	count int
+}
+
+// ProcessNode for action marks the node (set Mark to true)
+func (action *action) ProcessNode(g *Graph, n *Node) bool {
+	tr := g.StartMetadataTransaction(n)
+	tr.AddMetadata("Mark", true)
+	tr.Commit()
+	if action.count > 0 {
+		action.count = action.count - 1
+		return true
+	}
+	return false
+}
+
+// testNode create basic nodes with Num Type and Attr
+func testNode(g *Graph, n int, filtered bool, attr string) {
+	typ := "Test"
+	if !filtered {
+		typ = "Other"
+	}
+	m := Metadata{
+		"Num":  n,
+		"Type": typ,
+		"Attr": attr,
+		"Mark": false,
+	}
+	g.NewNode(GenID(), m, "host")
+}
+
+// TestProcessor checks that processor will perform the right number of actions
+// on the expected nodes
+func TestProcessor(t *testing.T) {
+	g := newGraph(t)
+	processor := NewProcessor(g, g, Metadata{"Type": "Test"}, "Attr")
+	processor.Start()
+
+	testNode(g, 0, true, "A")                  // marked by action 1
+	testNode(g, 1, true, "B")                  // not marked wrong attr
+	testNode(g, 2, false, "A")                 // not marked wrong type
+	processor.DoAction(&action{count: 0}, "A") // action 1
+	testNode(g, 3, true, "A")                  // not marked found immediately
+	processor.DoAction(&action{count: 0}, "C") // action 2
+	testNode(g, 4, true, "B")                  // not marked wrong attr
+	testNode(g, 5, false, "C")                 // not marked wrong type
+	testNode(g, 6, true, "C")                  // marked action 2
+	testNode(g, 7, true, "D")                  // marked action 3
+	processor.DoAction(&action{count: 2}, "D") // action 3
+	testNode(g, 8, true, "D")                  // marked action 3
+	testNode(g, 9, true, "D")                  // marked action 3
+	testNode(g, 10, true, "D")                 // not marked exhausted
+	nodes := g.GetNodes(Metadata{"Mark": true})
+	result := make([]int, len(nodes))
+	for i, node := range nodes {
+		result[i], _ = node.Metadata()["Num"].(int)
+	}
+	sort.Ints(result)
+	expected := []int{0, 6, 7, 8, 9}
+	if len(result) != len(expected) {
+		t.Errorf("Got %d instead of %d elements", len(result), len(expected))
+	}
+	for i, v := range result {
+		e := -1
+		if i < len(expected) {
+			e = expected[i]
+		}
+		if v != e {
+			t.Errorf("Expected %d at position %d, got %d", e, i, v)
+		}
+	}
+}

--- a/topology/probes/libvirt/libvirt.go
+++ b/topology/probes/libvirt/libvirt.go
@@ -1,0 +1,302 @@
+// +build libvirt,linux
+
+/*
+ * Copyright (C) 2018 Orange.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package libvirt
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"sync"
+
+	"github.com/skydive-project/skydive/config"
+
+	libvirtgo "github.com/libvirt/libvirt-go"
+	"github.com/skydive-project/skydive/logging"
+	"github.com/skydive-project/skydive/topology/graph"
+)
+
+// Probe is the libvirt probe
+type Probe struct {
+	sync.Mutex
+	graph        *graph.Graph          // the graph
+	conn         *libvirtgo.Connect    // libvirt conection
+	interfaceMap map[string]*Interface // Found interfaces not yet connected.
+	cidLifecycle int                   // libvirt callback id of monitor to unregister
+	cidDevAdded  int                   // second monitor on devices added to domains
+	uri          string                // uri of the libvirt connection
+	cancel       context.CancelFunc    // cancel function
+	root         *graph.Node           // root node for ownership
+	tunProcessor *graph.Processor      // metadata indexer
+}
+
+// Address describes the XML coding of the pci addres of an interface in libvirt
+type Address struct {
+	Type     string `xml:"type,attr"`
+	Domain   string `xml:"domain,attr"`
+	Bus      string `xml:"bus,attr"`
+	Slot     string `xml:"slot,attr"`
+	Function string `xml:"function,attr"`
+}
+
+// DomainStateMap stringifies the state of a domain
+var DomainStateMap map[libvirtgo.DomainState]string = map[libvirtgo.DomainState]string{
+	libvirtgo.DOMAIN_NOSTATE:     "UNDEFINED",
+	libvirtgo.DOMAIN_RUNNING:     "UP",
+	libvirtgo.DOMAIN_BLOCKED:     "BLOCKED",
+	libvirtgo.DOMAIN_PAUSED:      "PAUSED",
+	libvirtgo.DOMAIN_SHUTDOWN:    "DOWN",
+	libvirtgo.DOMAIN_CRASHED:     "CRASHED",
+	libvirtgo.DOMAIN_PMSUSPENDED: "PMSUSPENDED",
+	libvirtgo.DOMAIN_SHUTOFF:     "DOWN",
+}
+
+// Interface is XML coding of an interface in libvirt
+type Interface struct {
+	Mac struct {
+		Address string `xml:"address,attr"`
+	} `xml:"mac"`
+	Target struct {
+		Device string `xml:"dev,attr"`
+	} `xml:"target"`
+	Address Address `xml:"address"`
+	Alias   struct {
+		Name string `xml:"name,attr"`
+	} `xml:"alias"`
+	Host *graph.Node `xml:"-"`
+}
+
+// Domain is the subset of XML coding of a domain in libvirt
+type Domain struct {
+	Interfaces []Interface `xml:"devices>interface"`
+}
+
+// getDomainInterfaces uses libvirt to get information on the interfaces of a
+// domain.
+func (probe *Probe) getDomainInterfaces(
+	domain *libvirtgo.Domain, // domain to query
+	domainNode *graph.Node, // Node representing the domain
+	constraint string, // to restrict the search to a single interface (by alias)
+) (interfaces []*Interface) {
+	rawXML, err := domain.GetXMLDesc(0)
+	if err != nil {
+		logging.GetLogger().Errorf("Cannot get XMLDesc: %s", err)
+		return
+	}
+	d := Domain{}
+	if err = xml.Unmarshal([]byte(rawXML), &d); err != nil {
+		logging.GetLogger().Errorf("XML parsing error: %s", err)
+		return
+	}
+	for _, itf := range d.Interfaces {
+		if constraint == "" || constraint == itf.Alias.Name {
+			itf.Host = domainNode
+			interfaces = append(interfaces, &itf)
+		}
+	}
+	return
+}
+
+// registerInterfaces puts the information collected in the graph
+// interfaces is an array of collected information.
+func (probe *Probe) registerInterfaces(interfaces []*Interface) {
+	probe.graph.Lock()
+	defer probe.graph.Unlock()
+	for _, itf := range interfaces {
+		name := itf.Target.Device
+		if name == "" {
+			continue
+		}
+		logging.GetLogger().Debugf(
+			"Libvirt interface %s on %s", name, itf.Host)
+		probe.tunProcessor.DoAction(itf, name)
+	}
+}
+
+// ProcessNode adds the libvirt interface information to a node of the graph
+func (itf *Interface) ProcessNode(g *graph.Graph, node *graph.Node) bool {
+	logging.GetLogger().Debugf("enrich %s", itf.Alias.Name)
+	tr := g.StartMetadataTransaction(node)
+	tr.AddMetadata("Libvirt.MAC", itf.Mac.Address)
+	tr.AddMetadata("Libvirt.Domain", itf.Host)
+	address := itf.Address
+	formatted := fmt.Sprintf(
+		"%s:%s.%s.%s.%s", address.Type, address.Domain, address.Bus,
+		address.Slot, address.Function)
+	tr.AddMetadata("Libvirt.Address", formatted)
+	tr.AddMetadata("Libvirt.Alias", itf.Alias.Name)
+	tr.AddMetadata("PeerIntfMAC", itf.Mac.Address)
+	tr.Commit()
+	if !g.AreLinked(node, itf.Host, graph.Metadata{"RelationType": "vlayer2"}) {
+		g.Link(node, itf.Host, graph.Metadata{"RelationType": "vlayer2"})
+	}
+	return false
+}
+
+// getDomain access the graph node representing a libvirt domain
+func (probe *Probe) getDomain(d *libvirtgo.Domain) *graph.Node {
+	domainName, _ := d.GetName()
+	probe.graph.RLock()
+	defer probe.graph.RUnlock()
+	return probe.graph.LookupFirstNode(graph.Metadata{"Name": domainName, "Type": "libvirt"})
+}
+
+// createOrUpdateDomain creates a new graph node representing a libvirt domain
+// if necessary and updates its state.
+func (probe *Probe) createOrUpdateDomain(d *libvirtgo.Domain) *graph.Node {
+	g := probe.graph
+	g.Lock()
+	defer g.Unlock()
+	domainName, _ := d.GetName()
+	metadata := graph.Metadata{
+		"Name": domainName,
+		"Type": "libvirt",
+	}
+	domainNode := g.LookupFirstNode(metadata)
+	if domainNode == nil {
+		domainNode = g.NewNode(graph.GenID(), metadata)
+		g.Link(probe.root, domainNode, graph.Metadata{"RelationType": "ownership"})
+	}
+	state, _, err := d.GetState()
+	if err != nil {
+		logging.GetLogger().Errorf("Cannot update domain state for %s", domainName)
+	} else {
+		tr := g.StartMetadataTransaction(domainNode)
+		defer tr.Commit()
+		tr.AddMetadata("State", DomainStateMap[state])
+	}
+	return domainNode
+}
+
+// deleteDomain deletes the graph node representing a libvirt domain
+func (probe *Probe) deleteDomain(d *libvirtgo.Domain) {
+	domainNode := probe.getDomain(d)
+	if domainNode != nil {
+		probe.graph.Lock()
+		defer probe.graph.Unlock()
+		probe.graph.DelNode(domainNode)
+	}
+}
+
+// Start get all domains attached to a libvirt connection
+func (probe *Probe) Start() {
+	// The event loop must be registered WITH its poll loop active BEFORE the
+	// connection is opened. Otherwise it just does not work.
+	if err := libvirtgo.EventRegisterDefaultImpl(); err != nil {
+		logging.GetLogger().Errorf("libvirt event handler:  %s", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	probe.cancel = cancel
+	go func() {
+		for ctx.Err() == nil {
+			if err := libvirtgo.EventRunDefaultImpl(); err != nil {
+				logging.GetLogger().Errorf("libvirt poll loop problem: %s", err)
+			}
+		}
+	}()
+	conn, err := libvirtgo.NewConnectReadOnly(probe.uri)
+	if err != nil {
+		logging.GetLogger().Errorf("Failed to create libvirt connect")
+		return
+	}
+	probe.conn = conn
+	callback := func(
+		c *libvirtgo.Connect, d *libvirtgo.Domain,
+		event *libvirtgo.DomainEventLifecycle,
+	) {
+		switch event.Event {
+		case libvirtgo.DOMAIN_EVENT_UNDEFINED:
+			probe.deleteDomain(d)
+		case libvirtgo.DOMAIN_EVENT_STARTED:
+			domainNode := probe.createOrUpdateDomain(d)
+			interfaces := probe.getDomainInterfaces(d, domainNode, "")
+			probe.registerInterfaces(interfaces)
+		case libvirtgo.DOMAIN_EVENT_DEFINED, libvirtgo.DOMAIN_EVENT_SUSPENDED,
+			libvirtgo.DOMAIN_EVENT_RESUMED, libvirtgo.DOMAIN_EVENT_STOPPED,
+			libvirtgo.DOMAIN_EVENT_SHUTDOWN, libvirtgo.DOMAIN_EVENT_PMSUSPENDED,
+			libvirtgo.DOMAIN_EVENT_CRASHED:
+			probe.createOrUpdateDomain(d)
+		}
+	}
+	probe.cidLifecycle, err = conn.DomainEventLifecycleRegister(nil, callback)
+	if err != nil {
+		logging.GetLogger().Errorf(
+			"Could not register the lifecycle event handler %s", err)
+	}
+	callbackDeviceAdded := func(
+		c *libvirtgo.Connect, d *libvirtgo.Domain,
+		event *libvirtgo.DomainEventDeviceAdded,
+	) {
+		domainNode := probe.getDomain(d)
+		interfaces := probe.getDomainInterfaces(d, domainNode, event.DevAlias)
+		probe.registerInterfaces(interfaces) // 0 or 1 device changed.
+	}
+	probe.cidDevAdded, err = conn.DomainEventDeviceAddedRegister(nil, callbackDeviceAdded)
+	if err != nil {
+		logging.GetLogger().Errorf(
+			"Could not register the device added event handler %s", err)
+	}
+	domains, err := probe.conn.ListAllDomains(0)
+	if err != nil {
+		logging.GetLogger().Error(err)
+		return
+	}
+	for _, domain := range domains {
+		domainNode := probe.createOrUpdateDomain(&domain)
+		interfaces := probe.getDomainInterfaces(&domain, domainNode, "")
+		probe.registerInterfaces(interfaces)
+	}
+}
+
+// Stop stops the probe
+func (probe *Probe) Stop() {
+	probe.cancel()
+	probe.tunProcessor.Stop()
+	if probe.cidLifecycle != -1 {
+		probe.conn.DomainEventDeregister(probe.cidLifecycle)
+		probe.conn.DomainEventDeregister(probe.cidDevAdded)
+	}
+	probe.conn.Close()
+}
+
+// NewProbe creates a libvirt topology probe
+func NewProbe(g *graph.Graph, uri string, root *graph.Node) *Probe {
+	tunProcessor := graph.NewProcessor(g, g, graph.Metadata{"Type": "tun"}, "Name")
+	probe := &Probe{
+		graph:        g,
+		interfaceMap: make(map[string]*Interface),
+		cidLifecycle: -1,
+		uri:          uri,
+		root:         root,
+		tunProcessor: tunProcessor,
+	}
+	tunProcessor.Start()
+	return probe
+}
+
+// NewProbeFromConfig initializes the probe
+func NewProbeFromConfig(g *graph.Graph, root *graph.Node) (*Probe, error) {
+	uri := config.GetString("agent.topology.libvirt.url")
+	return NewProbe(g, uri, root), nil
+}

--- a/topology/probes/libvirt/no_libvirt.go
+++ b/topology/probes/libvirt/no_libvirt.go
@@ -1,0 +1,47 @@
+// +build !linux !libvirt
+
+/*
+ * Copyright (C) 2018 Orange
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package libvirt
+
+import (
+	"github.com/skydive-project/skydive/common"
+	"github.com/skydive-project/skydive/topology/graph"
+)
+
+// Probe describes a Libvirt probe that does nothing
+type Probe struct {
+}
+
+// Start of the probe interface
+func (p *Probe) Start() {
+}
+
+// Stop of the probe interface
+func (p *Probe) Stop() {
+}
+
+// NewProbeFromConfig Refuses to create a probe.
+func NewProbeFromConfig(g *graph.Graph, root *graph.Node) (*Probe, error) {
+	return nil, common.ErrNotImplemented
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1595,6 +1595,12 @@
 			"revisionTime": "2017-10-06T17:48:01Z"
 		},
 		{
+			"checksumSHA1": "Yu3IvAsGn8hW418tnDYqUs6YC3o=",
+			"path": "github.com/libvirt/libvirt-go",
+			"revision": "9c5bdce3c18faad94cb383e7ec42f5122a8c7fa1",
+			"revisionTime": "2018-10-05T09:27:46Z"
+		},
+		{
 			"checksumSHA1": "E6lbuGqlBGB0dnklAzqfNZ8wd6s=",
 			"path": "github.com/lxc/lxd/client",
 			"revision": "9907f3a64b6b8ec9144e8be02d633b951439c0f6",


### PR DESCRIPTION
Libvirt probe dynamically polls the status of libvirt domains and their network
interfaces. For each new interface, it tries to enrich the coresponding tun
device with the name of the domain, the guest mac and the complete address of the
device on the guest pci bus.

The probe relies on libvirt-go the official go binding for libvirt that requires
the c libvirt library.

closes #1410