### PR TITLE
K8s container operations based on k8s runtime events

### DIFF
--- a/topology/probes/k8s/container.go
+++ b/topology/probes/k8s/container.go
@@ -121,7 +121,7 @@ func newContainerProbe(clientset *kubernetes.Clientset, g *graph.Graph) Subprobe
 		graph:        g,
 	}
 	c.containerIndexer = newObjectIndexer(g, c.EventHandler, "container", "Namespace", "Pod")
-	c.KubeCache = NewKubeCache(clientset.CoreV1().RESTClient(), &v1.Pod{}, "pods", c)
+	c.KubeCache = RegisterKubeCache(clientset.CoreV1().RESTClient(), &v1.Pod{}, "pods", c)
 	return c
 }
 

--- a/topology/probes/k8s/k8s.go
+++ b/topology/probes/k8s/k8s.go
@@ -108,7 +108,8 @@ func NewK8sProbe(g *graph.Graph) (*Probe, error) {
 	}
 
 	linkerHandlers := []linkHandler{
-		newContainerLinker,
+		newContainerDockerLinker,
+		newPodContainerLinker,
 		newHostNodeLinker,
 		newNodePodLinker,
 		newIngressServiceLinker,

--- a/topology/probes/k8s/pod.go
+++ b/topology/probes/k8s/pod.go
@@ -45,6 +45,7 @@ func (h *podHandler) Dump(obj interface{}) string {
 func (h *podHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	pod := obj.(*v1.Pod)
 
+	pod.Spec.Containers = nil
 	m := NewMetadata(Manager, "pod", pod, pod.Name, pod.Namespace)
 	m.SetField("Node", pod.Spec.NodeName)
 


### PR DESCRIPTION
Fixed the bugs in containers implementation: 
- the container listened to graph events and used pod.K8s.Spec.Containers field to add/update/delete containers (rather than using the k8s runtime v1.Pod objects)
- the pod objects had the entire container metadata within them - making them needlessly large