### PR TITLE
K8s: place large raw metadata under 'k8s.Extra'

### DIFF
--- a/scripts/ci/jobs/jobs.yml
+++ b/scripts/ci/jobs/jobs.yml
@@ -286,6 +286,7 @@
       - skydive-labels:
           slave-name: baremetal
     builders:
+      - skydive-cleanup
       - skydive-test:
           test: BACKEND=elasticsearch scripts/ci/run-istio-tests.sh
     publishers:

--- a/scripts/ci/jobs/jobs.yml
+++ b/scripts/ci/jobs/jobs.yml
@@ -287,7 +287,7 @@
           slave-name: baremetal
     builders:
       - skydive-test:
-          test: BACKEND=memory scripts/ci/run-istio-tests.sh
+          test: BACKEND=elasticsearch scripts/ci/run-istio-tests.sh
     publishers:
       - junit:
           results: tests.xml

--- a/tests/istio_test.go
+++ b/tests/istio_test.go
@@ -75,27 +75,27 @@ func TestBookInfoScenario(t *testing.T) {
 		[]CheckFunction{
 			func(c *CheckContext) error {
 				// check nodes exist
-				_, err := checkNodeCreation(t, c, istio.Manager, "destinationrule", "Name", "details")
+				_, err := checkNodeCreation(t, c, istio.Manager, "destinationrule", "details")
 				if err != nil {
 					return err
 				}
 
-				_, err = checkNodeCreation(t, c, istio.Manager, "destinationrule", "Name", "productpage")
+				_, err = checkNodeCreation(t, c, istio.Manager, "destinationrule", "productpage")
 				if err != nil {
 					return err
 				}
 
-				_, err = checkNodeCreation(t, c, istio.Manager, "destinationrule", "Name", "ratings")
+				_, err = checkNodeCreation(t, c, istio.Manager, "destinationrule", "ratings")
 				if err != nil {
 					return err
 				}
 
-				_, err = checkNodeCreation(t, c, istio.Manager, "destinationrule", "Name", "reviews")
+				_, err = checkNodeCreation(t, c, istio.Manager, "destinationrule", "reviews")
 				if err != nil {
 					return err
 				}
 
-				_, err = checkNodeCreation(t, c, istio.Manager, "gateway", "Name", "bookinfo-gateway")
+				_, err = checkNodeCreation(t, c, istio.Manager, "gateway", "bookinfo-gateway")
 				if err != nil {
 					return err
 				}

--- a/topology/graph/elasticsearch.go
+++ b/topology/graph/elasticsearch.go
@@ -40,10 +40,22 @@ const graphElementMapping = `
 	"dynamic_templates": [
 		{
 			"strings": {
-				"match": "*",
+				"path_match": "*",
+				"path_unmatch": "*.Extra.*",
 				"match_mapping_type": "string",
-				"mapping": {
+                                "mapping": {
 					"type": "keyword"
+				}
+			}
+		},
+		{
+			"extra": {
+				"path_match": "*.Extra",
+				"mapping": {
+					"type": "object",
+					"enabled": false,
+					"store": true,
+					"index": false
 				}
 			}
 		},

--- a/topology/probes/istio/destinationrule.go
+++ b/topology/probes/istio/destinationrule.go
@@ -36,7 +36,8 @@ type destinationRuleHandler struct {
 // Map graph node to k8s resource
 func (h *destinationRuleHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	dr := obj.(*kiali.DestinationRule)
-	return graph.Identifier(dr.GetUID()), k8s.NewMetadata(Manager, "destinationrule", dr, dr.Name, dr.Namespace)
+	m := k8s.NewMetadataFields(&dr.ObjectMeta)
+	return graph.Identifier(dr.GetUID()), k8s.NewMetadata(Manager, "destinationrule", m, dr, dr.Name)
 }
 
 // Dump k8s resource

--- a/topology/probes/istio/gateway.go
+++ b/topology/probes/istio/gateway.go
@@ -36,7 +36,8 @@ type gatewayHandler struct {
 // Map graph node to k8s resource
 func (h *gatewayHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	gw := obj.(*kiali.Gateway)
-	return graph.Identifier(gw.GetUID()), k8s.NewMetadata(Manager, "gateway", gw, gw.Name, gw.Namespace)
+	m := k8s.NewMetadataFields(&gw.ObjectMeta)
+	return graph.Identifier(gw.GetUID()), k8s.NewMetadata(Manager, "gateway", m, gw, gw.Name)
 }
 
 // Dump k8s resource

--- a/topology/probes/istio/quotaspec.go
+++ b/topology/probes/istio/quotaspec.go
@@ -36,7 +36,8 @@ type quotaSpecHandler struct {
 // Map graph node to k8s resource
 func (h *quotaSpecHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	qs := obj.(*kiali.QuotaSpec)
-	return graph.Identifier(qs.GetUID()), k8s.NewMetadata(Manager, "quotaspec", qs, qs.Name, qs.Namespace)
+	m := k8s.NewMetadataFields(&qs.ObjectMeta)
+	return graph.Identifier(qs.GetUID()), k8s.NewMetadata(Manager, "quotaspec", m, qs, qs.Name)
 }
 
 // Dump k8s resource

--- a/topology/probes/istio/quotaspecbinding.go
+++ b/topology/probes/istio/quotaspecbinding.go
@@ -36,7 +36,8 @@ type quotaSpecBindingHandler struct {
 // Map graph node to k8s resource
 func (h *quotaSpecBindingHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	qsb := obj.(*kiali.QuotaSpecBinding)
-	return graph.Identifier(qsb.GetUID()), k8s.NewMetadata(Manager, "quotaspecbinding", qsb, qsb.Name, qsb.Namespace)
+	m := k8s.NewMetadataFields(&qsb.ObjectMeta)
+	return graph.Identifier(qsb.GetUID()), k8s.NewMetadata(Manager, "quotaspecbinding", m, qsb, qsb.Name)
 }
 
 // Dump k8s resource

--- a/topology/probes/istio/serviceentry.go
+++ b/topology/probes/istio/serviceentry.go
@@ -36,7 +36,8 @@ type serviceEntryHandler struct {
 // Map graph node to k8s resource
 func (h *serviceEntryHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	se := obj.(*kiali.ServiceEntry)
-	return graph.Identifier(se.GetUID()), k8s.NewMetadata(Manager, "serviceentry", se, se.Name, se.Namespace)
+	m := k8s.NewMetadataFields(&se.ObjectMeta)
+	return graph.Identifier(se.GetUID()), k8s.NewMetadata(Manager, "serviceentry", m, se, se.Name)
 }
 
 // Dump k8s resource

--- a/topology/probes/istio/virtualservice.go
+++ b/topology/probes/istio/virtualservice.go
@@ -36,7 +36,8 @@ type virtualServiceHandler struct {
 // Map graph node to k8s resource
 func (h *virtualServiceHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	vs := obj.(*kiali.VirtualService)
-	return graph.Identifier(vs.GetUID()), k8s.NewMetadata(Manager, "virtualservice", vs, vs.Name, vs.Namespace)
+	m := k8s.NewMetadataFields(&vs.ObjectMeta)
+	return graph.Identifier(vs.GetUID()), k8s.NewMetadata(Manager, "virtualservice", m, vs, vs.Name)
 }
 
 // Dump k8s resource

--- a/topology/probes/k8s/cache.go
+++ b/topology/probes/k8s/cache.go
@@ -68,7 +68,7 @@ func (c *KubeCache) getByKey(namespace, name string) interface{} {
 }
 
 func (c *KubeCache) getByNode(node *graph.Node) interface{} {
-	namespace, _ := node.GetFieldString("Namespace")
+	namespace, _ := node.GetFieldString(MetadataField("Namespace"))
 	name, _ := node.GetFieldString("Name")
 	if name == "" {
 		return nil

--- a/topology/probes/k8s/cluster.go
+++ b/topology/probes/k8s/cluster.go
@@ -45,8 +45,8 @@ func (c *clusterCache) addClusterNode() {
 	c.graph.Lock()
 	defer c.graph.Unlock()
 
-	m := NewMetadata(Manager, "cluster", nil, ClusterName)
-	clusterNode = c.graph.NewNode(graph.GenID(), m, "")
+	m := graph.Metadata{"Name": ClusterName}
+	clusterNode = c.graph.NewNode(graph.GenID(), NewMetadata(Manager, "cluster", m, nil, ClusterName), "")
 	c.NotifyEvent(graph.NodeAdded, clusterNode)
 	logging.GetLogger().Debugf("Added cluster{Name: %s}", ClusterName)
 }

--- a/topology/probes/k8s/cronjob.go
+++ b/topology/probes/k8s/cronjob.go
@@ -41,10 +41,12 @@ func (h *cronJobHandler) Dump(obj interface{}) string {
 
 func (h *cronJobHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	cj := obj.(*v1beta1.CronJob)
-	m := NewMetadata(Manager, "cronjob", cj, cj.Name, cj.Namespace)
+
+	m := NewMetadataFields(&cj.ObjectMeta)
 	m.SetField("Schedule", cj.Spec.Schedule)
 	m.SetField("Suspended", cj.Spec.Suspend != nil && *cj.Spec.Suspend)
-	return graph.Identifier(cj.GetUID()), m
+
+	return graph.Identifier(cj.GetUID()), NewMetadata(Manager, "cronjob", m, cj, cj.Name)
 }
 
 func newCronJobProbe(client interface{}, g *graph.Graph) Subprobe {

--- a/topology/probes/k8s/daemonset.go
+++ b/topology/probes/k8s/daemonset.go
@@ -42,13 +42,12 @@ func (h *daemonSetHandler) Dump(obj interface{}) string {
 func (h *daemonSetHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	ds := obj.(*v1beta1.DaemonSet)
 
-	m := NewMetadata(Manager, "daemonset", ds, ds.Name, ds.Namespace)
-	m.SetFieldAndNormalize("Labels", ds.Labels)
+	m := NewMetadataFields(&ds.ObjectMeta)
 	m.SetField("DesiredNumberScheduled", ds.Status.DesiredNumberScheduled)
 	m.SetField("CurrentNumberScheduled", ds.Status.CurrentNumberScheduled)
 	m.SetField("NumberMisscheduled", ds.Status.NumberMisscheduled)
 
-	return graph.Identifier(ds.GetUID()), m
+	return graph.Identifier(ds.GetUID()), NewMetadata(Manager, "daemonset", m, ds, ds.Name)
 }
 
 func newDaemonSetProbe(client interface{}, g *graph.Graph) Subprobe {

--- a/topology/probes/k8s/deployment.go
+++ b/topology/probes/k8s/deployment.go
@@ -42,15 +42,14 @@ func (h *deploymentHandler) Dump(obj interface{}) string {
 func (h *deploymentHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	deployment := obj.(*v1beta1.Deployment)
 
-	m := NewMetadata(Manager, "deployment", deployment, deployment.Name, deployment.Namespace)
-	m.SetFieldAndNormalize("Selector", deployment.Spec.Selector)
+	m := NewMetadataFields(&deployment.ObjectMeta)
 	m.SetField("DesiredReplicas", int32ValueOrDefault(deployment.Spec.Replicas, 1))
 	m.SetField("Replicas", deployment.Status.Replicas)
 	m.SetField("ReadyReplicas", deployment.Status.ReadyReplicas)
 	m.SetField("AvailableReplicas", deployment.Status.AvailableReplicas)
 	m.SetField("UnavailableReplicas", deployment.Status.UnavailableReplicas)
 
-	return graph.Identifier(deployment.GetUID()), m
+	return graph.Identifier(deployment.GetUID()), NewMetadata(Manager, "deployment", m, deployment, deployment.Name)
 }
 
 func newDeploymentProbe(client interface{}, g *graph.Graph) Subprobe {

--- a/topology/probes/k8s/endpoints.go
+++ b/topology/probes/k8s/endpoints.go
@@ -41,8 +41,8 @@ func (h *endpointsHandler) Dump(obj interface{}) string {
 
 func (h *endpointsHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	endpoints := obj.(*v1.Endpoints)
-	m := NewMetadata(Manager, "endpoints", endpoints, endpoints.Name, endpoints.Namespace)
-	return graph.Identifier(endpoints.GetUID()), m
+	m := NewMetadataFields(&endpoints.ObjectMeta)
+	return graph.Identifier(endpoints.GetUID()), NewMetadata(Manager, "endpoints", m, endpoints, endpoints.Name)
 }
 
 func newEndpointsProbe(client interface{}, g *graph.Graph) Subprobe {

--- a/topology/probes/k8s/ingress.go
+++ b/topology/probes/k8s/ingress.go
@@ -43,12 +43,12 @@ func (h *ingressHandler) Dump(obj interface{}) string {
 func (h *ingressHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	ingress := obj.(*v1beta1.Ingress)
 
-	m := NewMetadata(Manager, "ingress", ingress, ingress.Name, ingress.Namespace)
+	m := NewMetadataFields(&ingress.ObjectMeta)
 	m.SetFieldAndNormalize("Backend", ingress.Spec.Backend)
 	m.SetFieldAndNormalize("TLS", ingress.Spec.TLS)
 	m.SetFieldAndNormalize("Rules", ingress.Spec.Rules)
 
-	return graph.Identifier(ingress.GetUID()), m
+	return graph.Identifier(ingress.GetUID()), NewMetadata(Manager, "ingress", m, ingress, ingress.Name)
 }
 
 func newIngressProbe(client interface{}, g *graph.Graph) Subprobe {
@@ -56,5 +56,5 @@ func newIngressProbe(client interface{}, g *graph.Graph) Subprobe {
 }
 
 func newIngressServiceLinker(g *graph.Graph, subprobes map[string]Subprobe) probe.Probe {
-	return newResourceLinker(g, subprobes, "ingress", []string{"Namespace", "Backend.ServiceName"}, "service", []string{"Namespace", "Name"}, graph.Metadata{"RelationType": "ingress"})
+	return newResourceLinker(g, subprobes, "ingress", MetadataFields("Namespace", "Backend.ServiceName"), "service", MetadataFields("Namespace", "Name"), graph.Metadata{"RelationType": "ingress"})
 }

--- a/topology/probes/k8s/job.go
+++ b/topology/probes/k8s/job.go
@@ -42,14 +42,14 @@ func (h *jobHandler) Dump(obj interface{}) string {
 func (h *jobHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	job := obj.(*batchv1.Job)
 
-	m := NewMetadata(Manager, "job", job, job.Name, job.Namespace)
+	m := NewMetadataFields(&job.ObjectMeta)
 	m.SetField("Parallelism", job.Spec.Parallelism)
 	m.SetField("Completions", job.Spec.Completions)
 	m.SetField("Active", job.Status.Active)
 	m.SetField("Succeeded", job.Status.Succeeded)
 	m.SetField("Failed", job.Status.Failed)
 
-	return graph.Identifier(job.GetUID()), m
+	return graph.Identifier(job.GetUID()), NewMetadata(Manager, "job", m, job, job.Name)
 }
 
 func newJobProbe(client interface{}, g *graph.Graph) Subprobe {

--- a/topology/probes/k8s/networkpolicy.go
+++ b/topology/probes/k8s/networkpolicy.go
@@ -48,8 +48,8 @@ func (h *networkPolicyHandler) Dump(obj interface{}) string {
 
 func (h *networkPolicyHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	np := obj.(*v1beta1.NetworkPolicy)
-	m := NewMetadata(Manager, "networkpolicy", np, np.Name, np.Namespace)
-	return graph.Identifier(np.GetUID()), m
+	m := NewMetadataFields(&np.ObjectMeta)
+	return graph.Identifier(np.GetUID()), NewMetadata(Manager, "networkpolicy", m, np, np.Name)
 }
 
 func newNetworkPolicyProbe(client interface{}, g *graph.Graph) Subprobe {
@@ -255,7 +255,7 @@ func (npl *networkPolicyLinker) createLinks(np *v1beta1.NetworkPolicy, npNode, f
 	metadata := npl.newEdgeMetadata(ty, target, point)
 	for _, objNode := range podNodes {
 		if filterNode == nil || filterNode.ID == objNode.ID {
-			metadata.SetFieldAndNormalize("Ports", getFieldPorts(np, ty))
+			metadata.SetFieldAndNormalize("PolicyPorts", getFieldPorts(np, ty))
 			fields := []string{string(npNode.ID), string(objNode.ID)}
 			for k, v := range metadata {
 				fields = append(fields, k, v.(string))

--- a/topology/probes/k8s/persistentvolume.go
+++ b/topology/probes/k8s/persistentvolume.go
@@ -41,18 +41,18 @@ func (h *persistentVolumeHandler) Dump(obj interface{}) string {
 
 func (h *persistentVolumeHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	pv := obj.(*v1.PersistentVolume)
-	m := NewMetadata(Manager, "persistentvolume", pv, pv.Name, pv.Namespace)
+
+	m := NewMetadataFields(&pv.ObjectMeta)
 	m.SetFieldAndNormalize("Capacity", pv.Spec.Capacity)
 	m.SetFieldAndNormalize("VolumeMode", pv.Spec.VolumeMode)
 	m.SetFieldAndNormalize("StorageClassName", pv.Spec.StorageClassName) // FIXME: replace by link to StorageClass
 	m.SetFieldAndNormalize("Status", pv.Status.Phase)
 	m.SetFieldAndNormalize("AccessModes", pv.Spec.AccessModes)
-
 	if pv.Spec.ClaimRef != nil {
 		m.SetFieldAndNormalize("ClaimRef", pv.Spec.ClaimRef.Name) // FIXME: replace by link to PersistentVolumeClaim
 	}
 
-	return graph.Identifier(pv.GetUID()), m
+	return graph.Identifier(pv.GetUID()), NewMetadata(Manager, "persistentvolume", m, pv, pv.Name)
 }
 
 func newPersistentVolumeProbe(client interface{}, g *graph.Graph) Subprobe {

--- a/topology/probes/k8s/persistentvolumeclaim.go
+++ b/topology/probes/k8s/persistentvolumeclaim.go
@@ -41,13 +41,15 @@ func (h *persistentVolumeClaimHandler) Dump(obj interface{}) string {
 
 func (h *persistentVolumeClaimHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	pvc := obj.(*v1.PersistentVolumeClaim)
-	m := NewMetadata(Manager, "persistentvolumeclaim", pvc, pvc.Name, pvc.Namespace)
+
+	m := NewMetadataFields(&pvc.ObjectMeta)
 	m.SetFieldAndNormalize("AccessModes", pvc.Spec.AccessModes)
 	m.SetFieldAndNormalize("VolumeName", pvc.Spec.VolumeName)             // FIXME: replace by link to PersistentVolume
 	m.SetFieldAndNormalize("StorageClassName", pvc.Spec.StorageClassName) // FIXME: replace by link to StorageClass
 	m.SetFieldAndNormalize("VolumeMode", pvc.Spec.VolumeMode)
 	m.SetFieldAndNormalize("Status", pvc.Status.Phase)
-	return graph.Identifier(pvc.GetUID()), m
+
+	return graph.Identifier(pvc.GetUID()), NewMetadata(Manager, "persistentvolumeclaim", m, pvc, pvc.Name)
 }
 
 func newPersistentVolumeClaimProbe(client interface{}, g *graph.Graph) Subprobe {

--- a/topology/probes/k8s/pod.go
+++ b/topology/probes/k8s/pod.go
@@ -50,21 +50,20 @@ func (h *podHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	pod := deepcopy.Copy(obj).(*v1.Pod)
 
 	pod.Spec.Containers = nil
-	m := NewMetadata(Manager, "pod", pod, pod.Name, pod.Namespace)
-	m.SetField("Node", pod.Spec.NodeName)
 
+	m := NewMetadataFields(&pod.ObjectMeta)
+	m.SetField("Node", pod.Spec.NodeName)
 	podIP := pod.Status.PodIP
 	if podIP != "" {
 		m.SetField("IP", podIP)
 	}
-
 	reason := string(pod.Status.Phase)
 	if pod.Status.Reason != "" {
 		reason = pod.Status.Reason
 	}
 	m.SetField("Status", reason)
 
-	return graph.Identifier(pod.GetUID()), m
+	return graph.Identifier(pod.GetUID()), NewMetadata(Manager, "pod", m, pod, pod.Name)
 }
 
 func newPodProbe(client interface{}, g *graph.Graph) Subprobe {

--- a/topology/probes/k8s/replicaset.go
+++ b/topology/probes/k8s/replicaset.go
@@ -41,7 +41,8 @@ func (h *replicaSetHandler) Dump(obj interface{}) string {
 
 func (h *replicaSetHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	rs := obj.(*v1beta1.ReplicaSet)
-	return graph.Identifier(rs.GetUID()), NewMetadata(Manager, "replicaset", rs, rs.Name, rs.Namespace)
+	m := NewMetadataFields(&rs.ObjectMeta)
+	return graph.Identifier(rs.GetUID()), NewMetadata(Manager, "replicaset", m, rs, rs.Name)
 }
 
 func newReplicaSetProbe(client interface{}, g *graph.Graph) Subprobe {

--- a/topology/probes/k8s/replicationcontroller.go
+++ b/topology/probes/k8s/replicationcontroller.go
@@ -41,7 +41,8 @@ func (h *replicationControllerHandler) Dump(obj interface{}) string {
 
 func (h *replicationControllerHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	rc := obj.(*v1.ReplicationController)
-	return graph.Identifier(rc.GetUID()), NewMetadata(Manager, "replicationcontroller", rc, rc.Name, rc.Namespace)
+	m := NewMetadataFields(&rc.ObjectMeta)
+	return graph.Identifier(rc.GetUID()), NewMetadata(Manager, "replicationcontroller", m, rc, rc.Name)
 }
 
 func newReplicationControllerProbe(client interface{}, g *graph.Graph) Subprobe {

--- a/topology/probes/k8s/service.go
+++ b/topology/probes/k8s/service.go
@@ -44,7 +44,7 @@ func (h *serviceHandler) Dump(obj interface{}) string {
 func (h *serviceHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	srv := obj.(*v1.Service)
 
-	m := NewMetadata(Manager, "service", srv, srv.Name, srv.Namespace)
+	m := NewMetadataFields(&srv.ObjectMeta)
 	m.SetFieldAndNormalize("Ports", srv.Spec.Ports)
 	m.SetFieldAndNormalize("ClusterIP", srv.Spec.ClusterIP)
 	m.SetFieldAndNormalize("ServiceType", srv.Spec.Type)
@@ -52,7 +52,7 @@ func (h *serviceHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata)
 	m.SetFieldAndNormalize("LoadBalancerIP", srv.Spec.LoadBalancerIP)
 	m.SetFieldAndNormalize("ExternalName", srv.Spec.ExternalName)
 
-	return graph.Identifier(srv.GetUID()), m
+	return graph.Identifier(srv.GetUID()), NewMetadata(Manager, "service", m, srv, srv.Name)
 }
 
 func newServiceProbe(client interface{}, g *graph.Graph) Subprobe {
@@ -86,8 +86,8 @@ func (spl *servicePodLinker) GetABLinks(srvNode *graph.Node) (edges []*graph.Edg
 }
 
 func (spl *servicePodLinker) GetBALinks(podNode *graph.Node) (edges []*graph.Edge) {
-	namespace, _ := podNode.GetFieldString("Namespace")
-	name, _ := podNode.GetFieldString("Name")
+	namespace, _ := podNode.GetFieldString(MetadataField("Namespace"))
+	name, _ := podNode.GetFieldString(MetadataField("Name"))
 	pod := spl.podCache.getByKey(namespace, name)
 	for _, srv := range spl.serviceCache.getByNamespace(namespace) {
 		srv := srv.(*v1.Service)

--- a/topology/probes/k8s/statefulset.go
+++ b/topology/probes/k8s/statefulset.go
@@ -42,7 +42,7 @@ func (h *statefulSetHandler) Dump(obj interface{}) string {
 func (h *statefulSetHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	ss := obj.(*v1beta1.StatefulSet)
 
-	m := NewMetadata(Manager, "statefulset", ss, ss.Name, ss.Namespace)
+	m := NewMetadataFields(&ss.ObjectMeta)
 	m.SetField("DesiredReplicas", int32ValueOrDefault(ss.Spec.Replicas, 1))
 	m.SetField("ServiceName", ss.Spec.ServiceName) // FIXME: replace by link to Service
 	m.SetField("Replicas", ss.Status.Replicas)
@@ -52,7 +52,7 @@ func (h *statefulSetHandler) Map(obj interface{}) (graph.Identifier, graph.Metad
 	m.SetField("CurrentRevision", ss.Status.CurrentRevision)
 	m.SetField("UpdateRevision", ss.Status.UpdateRevision)
 
-	return graph.Identifier(ss.GetUID()), m
+	return graph.Identifier(ss.GetUID()), NewMetadata(Manager, "statefulset", m, ss, ss.Name)
 }
 
 func newStatefulSetProbe(client interface{}, g *graph.Graph) Subprobe {

--- a/topology/probes/k8s/storageclass.go
+++ b/topology/probes/k8s/storageclass.go
@@ -42,10 +42,10 @@ func (h *storageClassHandler) Dump(obj interface{}) string {
 func (h *storageClassHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	sc := obj.(*v1.StorageClass)
 
-	m := NewMetadata(Manager, "storageclass", sc, sc.Name, sc.Namespace)
+	m := NewMetadataFields(&sc.ObjectMeta)
 	m.SetField("Provisioner", sc.Provisioner)
 
-	return graph.Identifier(sc.GetUID()), m
+	return graph.Identifier(sc.GetUID()), NewMetadata(Manager, "storageclass", m, sc, sc.Name)
 }
 
 func newStorageClassProbe(client interface{}, g *graph.Graph) Subprobe {


### PR DESCRIPTION
Layout K8s metadata into three designated areas:
- *toplevel* - fields common across skydive such as "Name", "Manager", "Type"
- *toplevel*.K8s - fields which specific to k8s such as: "Namespace", "Name", "Pod", "IP", etc.
- *toplevel*.Extra.K8s - the raw runtime binary object

This is illustrated here:
```
{
  "Type": "pod",
  "Manager": "k8s",
  "Name": "default/pod1",
  "K8s": {
    "Namespace": "default",
    "Name": "pod1",
    "IP": ...
    "Status": ...
    "Extra": {
      "K8s": {
         .... the entire V1.Pod content ....
      }
   }
}
```

So as to save merge efforts this PR was rebased atop of: https://github.com/skydive-project/skydive/pull/1426