### PR TITLE
[WIP] topology: support exclusion of metadata fields

### DIFF
--- a/common/types_test.go
+++ b/common/types_test.go
@@ -137,6 +137,31 @@ func TestNormalizeMapKeys(t *testing.T) {
 	}
 }
 
+func TestExcludePaths(t *testing.T) {
+	before := map[string]interface{}{
+		"a": map[string]interface{}{
+			"aa": "11",
+			"ab": 12,
+			"ac": []string{"131", "132"},
+		},
+		"b": "2",
+		"c": "3",
+	}
+	expected := map[string]interface{}{
+		"a": map[string]interface{}{
+			"aa": "11",
+			"ac": []string{"131", "132"},
+		},
+		"b": "2",
+	}
+
+	actual := ExcludeFields(before, "a.ab", "c")
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %+v actual %+v", expected, actual)
+	}
+}
+
 func TestSetField(t *testing.T) {
 	actual := map[string]interface{}{
 		"a": map[string]interface{}{

--- a/config/config.go
+++ b/config/config.go
@@ -96,6 +96,7 @@ func init() {
 	cfg.SetDefault("analyzer.flow.max_buffer_size", 100000)
 	cfg.SetDefault("analyzer.listen", "127.0.0.1:8082")
 	cfg.SetDefault("analyzer.replication.debug", false)
+	cfg.SetDefault("analyzer.topology.exclude_fields", []string{})
 	cfg.SetDefault("analyzer.topology.backend", "memory")
 	cfg.SetDefault("analyzer.topology.probes", []string{})
 	cfg.SetDefault("analyzer.topology.k8s.config_file", "/etc/skydive/kubeconfig")

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -75,6 +75,10 @@ analyzer:
     # Storage backend name: mymemory, myelasticsearch, myorientdb
     # backend: mymemory
 
+    # Define paths to feilds be exluded from backend
+    # exclude_fields:
+    # - a.b.c
+
     # Define static interfaces and links updating Skydive topology
     # Can be useful to define external resources like : TOR, Router, etc.
     #

--- a/topology/graph/graph.go
+++ b/topology/graph/graph.go
@@ -755,6 +755,14 @@ func dedupEdges(edges []*Edge) []*Edge {
 	return uniq
 }
 
+func (g *Graph) preNodeNotify(n *Node) {
+	excludeFields := config.GetStringSlice("analyzer.topology.exclude_fields")
+	m := common.ExcludeFields(map[string]interface{}(n.metadata), excludeFields...)
+	if m, ok := m.(map[string]interface{}); ok {
+		n.metadata = Metadata(m)
+	}
+}
+
 // NodeUpdated updates a node
 func (g *Graph) NodeUpdated(n *Node) bool {
 	if node := g.GetNode(n.ID); node != nil {
@@ -766,6 +774,7 @@ func (g *Graph) NodeUpdated(n *Node) bool {
 			return false
 		}
 
+		g.preNodeNotify(node)
 		g.eventHandler.NotifyEvent(NodeUpdated, node)
 		return true
 	}
@@ -1200,6 +1209,7 @@ func (g *Graph) AddNode(n *Node) bool {
 	if !g.backend.NodeAdded(n) {
 		return false
 	}
+	g.preNodeNotify(n)
 	g.eventHandler.NotifyEvent(NodeAdded, n)
 
 	return true
@@ -1333,6 +1343,7 @@ func (g *Graph) DelEdge(e *Edge) bool {
 // NodeDeleted event
 func (g *Graph) NodeDeleted(n *Node) {
 	if g.backend.NodeDeleted(n) {
+		g.preNodeNotify(n)
 		g.eventHandler.NotifyEvent(NodeDeleted, n)
 	}
 }


### PR DESCRIPTION
This issue related to:
- removing some of the K8s fields (to save storage space; and reduce UI contention)
- issue discussing removing flow fields https://github.com/skydive-project/skydive/issues/1439

One can filter out fields from `graph.Node.metadata` using the following:

```
analyzer:
  topology:
    exclude_fields:
    - a.b.c
    - x.y.z
```

