### PR TITLE
security: Improve TLS

### DIFF
--- a/common/tls.go
+++ b/common/tls.go
@@ -29,8 +29,8 @@ import (
 	"io/ioutil"
 )
 
-// SetupTLSLoadCertificate creates a X509 certificate from file
-func SetupTLSLoadCertificate(certPEM string) (*x509.CertPool, error) {
+// SetupTLSLoadCA creates an X509 certificate from file
+func SetupTLSLoadCA(certPEM string) (*x509.CertPool, error) {
 	rootPEM, err := ioutil.ReadFile(certPEM)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to open root certificate '%s' : %s", certPEM, err)

--- a/config/config.go
+++ b/config/config.go
@@ -335,13 +335,22 @@ func GetEtcdServerAddrs() []string {
 	return []string{fmt.Sprintf("http://localhost:%d", port)}
 }
 
-// IsTLSEnabled returns true is the analyzer certificates are set
+// IsTLSEnabled returns true is the client / server certificates are set
 func IsTLSEnabled() bool {
-	certPEM := GetString("analyzer.X509_cert")
-	keyPEM := GetString("analyzer.X509_key")
-	if len(certPEM) > 0 && len(keyPEM) > 0 {
+	client := GetString("tls.client_cert")
+	clientKey := GetString("tls.client_key")
+	server := GetString("tls.server_cert")
+	serverKey := GetString("tls.server_key")
+	ca := GetString("tls.ca_cert")
+
+	if len(client) > 0 &&
+		len(clientKey) > 0 &&
+		len(server) > 0 &&
+		len(serverKey) > 0 &&
+		len(ca) > 0 {
 		return true
 	}
+
 	return false
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -88,7 +88,6 @@ func init() {
 	cfg.SetDefault("agent.topology.neutron.tenant_name", "service")
 	cfg.SetDefault("agent.topology.neutron.username", "neutron")
 	cfg.SetDefault("agent.topology.socketinfo.host_update", 10)
-	cfg.SetDefault("agent.X509_servername", "")
 
 	cfg.SetDefault("analyzer.auth.cluster.backend", "noauth")
 	cfg.SetDefault("analyzer.auth.api.backend", "noauth")

--- a/config/tls.go
+++ b/config/tls.go
@@ -28,10 +28,10 @@ import (
 	"github.com/skydive-project/skydive/common"
 )
 
-// GetTLSClientConfig returns TLS config to be used by a server
+// GetTLSClientConfig returns TLS config to be used by client
 func GetTLSClientConfig(setupRootCA bool) (*tls.Config, error) {
-	certPEM := GetString("agent.X509_cert")
-	keyPEM := GetString("agent.X509_key")
+	certPEM := GetString("tls.client_cert")
+	keyPEM := GetString("tls.client_key")
 	var tlsConfig *tls.Config
 	if certPEM != "" && keyPEM != "" {
 		var err error
@@ -40,8 +40,8 @@ func GetTLSClientConfig(setupRootCA bool) (*tls.Config, error) {
 			return nil, err
 		}
 		if setupRootCA {
-			analyzerCertPEM := GetString("analyzer.X509_cert")
-			tlsConfig.RootCAs, err = common.SetupTLSLoadCertificate(analyzerCertPEM)
+			rootCaPEM := GetString("tls.ca_cert")
+			tlsConfig.RootCAs, err = common.SetupTLSLoadCA(rootCaPEM)
 			if err != nil {
 				return nil, err
 			}
@@ -50,18 +50,21 @@ func GetTLSClientConfig(setupRootCA bool) (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
-// GetTLSServerConfig returns TLS config to be used by a server
+// GetTLSServerConfig returns TLS config to be used by server
 func GetTLSServerConfig(setupRootCA bool) (*tls.Config, error) {
-	certPEM := GetString("analyzer.X509_cert")
-	keyPEM := GetString("analyzer.X509_key")
-	agentCertPEM := GetString("agent.X509_cert")
+	certPEM := GetString("tls.server_cert")
+	keyPEM := GetString("tls.server_key")
+
 	tlsConfig, err := common.SetupTLSServerConfig(certPEM, keyPEM)
 	if err != nil {
 		return nil, err
 	}
-	tlsConfig.ClientCAs, err = common.SetupTLSLoadCertificate(agentCertPEM)
-	if err != nil {
-		return nil, err
+	if setupRootCA {
+		rootCaPEM := GetString("tls.ca_cert")
+		tlsConfig.ClientCAs, err = common.SetupTLSLoadCA(rootCaPEM)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return tlsConfig, nil
 }

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -3,6 +3,17 @@
 # host_id is used to reference the agent, by default set to hostname
 # host_id:
 
+tls:
+  # File path to X509 Certificate and Private Key to enable TLS communication
+  # Unique certificate per agent is recommended
+  # client_cert: /etc/ssl/certs/agent.domain.com.crt
+  # client_key:  /etc/ssl/certs/agent.domain.com.key
+
+  # server_cert: /etc/ssl/certs/analyzer.domain.com.crt
+  # server_key:  /etc/ssl/certs/analyzer.domain.com.key
+
+  # ca_cert: /etc/ssl/certs/ca.domain.com.crt
+
 http:
   # define the Cookie HTTP Request Header
   cookie:
@@ -36,11 +47,6 @@ analyzer:
   # address and port for the analyzer API, Format: addr:port.
   # Default addr is 127.0.0.1
   # listen: :8082
-
-  # File path to X509 Certificate and Private Key to enable TLS communication
-  # Must be different than the agent
-  # X509_cert: /etc/ssl/certs/analyzer.domain.com.crt
-  # X509_key:  /etc/ssl/certs/analyzer.domain.com.key
 
   auth:
     # auth section for API request
@@ -161,17 +167,6 @@ agent:
   # Default addr is 127.0.0.1
   # listen: :8081
 
-  # File path to X509 Certificate and Private Key to enable TLS communication
-  # Must be different than the analyzer and unique per agent (recommended)
-  # X509_cert: /etc/ssl/certs/agent.domain.com.crt
-  # X509_key:  /etc/ssl/certs/agent.domain.com.key
-
-  # Allow to use auto-signed Certificate
-  # X509_insecure: false
-
-  # Server name field specified in TLS communications.
-  # Not required, but can be used to allow virtual hosting
-  # X509_servername: domain.com
 
   auth:
     # auth section for API request


### PR DESCRIPTION
The implementation of TLS in Skydive is severely lacking and a little bit unorthodox. 

Here is an attempt at making the implementation a little more standard and easier to understand.

**Agent Does not use TLS unless CA Certificate and Keys are specified**
Previously, the logic for checking if the admin wanted TLS was to check whether the `analyzer:cert` was specified. This is counter-intuitive and bad security practice.

This MR changes this so that the logic is changed. 

**Concepts regarding certificates and services confusing**
Previously, the code used `analyzer:cert` for server certificates, and `agent:cert` for client certificates. This gets confusing, since when Skydive runs in "agent" mode, a server is set up. Why would it use the certificates from the Analyzer configuration for that.

This MR proposes to move the specification of certificates to a separate node, like so:

```
tls:
 client_cert: /pki/client.crt.pem
 client_key: /pki/client.key.pem
 server_cert: /pki/server.crt.pem
 server_key: /pki/server.key.pem
 ca_cert: /pki/ca.crt.pem
```
When Skydive is started in Analyzer mode, it uses the Server certificates for the service, and uses Client certificates when connecting out to other Agents.

When Skydive is started in Agent mode, it also uses the Server certificates for the Agent service, and uses Client certificates when connecting to the Analyzers.

**Inappropriate use of certificate trust**
Previously, the examples and implementation did not allow for an administrator to dictate what certificates to trust in a secure way. 

This MR proposes to allow the admin to specify `tls:ca_cert` that is used to verify peers (either from client to server or from server to client). 

This way, the admin does not have to "give away the keys to the kingdom" by giving all Agents the certifcate AND key for the issuing CA.

It also matches better with the standard way of implementing PKI, where a Root CA issues a Subordinate CA that issues Certificates. The Root and Subordinate CAs private keys must be kept secret.