### PR TITLE
Expand icon alignment issue

### DIFF
--- a/statics/css/skydive.css
+++ b/statics/css/skydive.css
@@ -628,6 +628,10 @@ ul.dropdown-menu .fa.pull-right {
   color: #47AAFF;
 }
 
+.object-key-value {
+ line-height:21px;
+}
+
 .object-sub-detail {
   margin-top: 5px;
   margin-bottom: 5px;


### PR DESCRIPTION
Expand icon is not right aligned correctly when two consecutive
rows having expand icons.