### PR TITLE
Build : fix static and docker-image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -343,7 +343,8 @@ bench.flow: bench.flow.traces
 	govendor test -bench=. ${SKYDIVE_GITHUB}/flow
 
 .PHONY: static
-static: skydive.clean govendor genlocalfiles compile.static
+static: skydive.clean govendor genlocalfiles
+	$(MAKE) compile.static WITH_LIBVIRT=false
 
 .PHONY: contribs.clean
 contribs.clean:

--- a/scripts/ci/create-binaries.sh
+++ b/scripts/ci/create-binaries.sh
@@ -21,7 +21,7 @@ dir="$(dirname "$0")"
 cd ${GOPATH}/src/github.com/skydive-project/skydive
 
 echo "--- BINARIES ---"
-make static WITH_EBPF=true WITH_LIBVIRT=false
+make static WITH_EBPF=true
 git reset --hard
 git remote add binaries ${BINARIES_REPO}
 git fetch binaries

--- a/scripts/ci/create-release.sh
+++ b/scripts/ci/create-release.sh
@@ -34,7 +34,7 @@ fi
 set -v
 
 changelog=$(scripts/ci/extract-changelog.py CHANGELOG.md $CHANGELOG_VERSION)
-make static WITH_EBPF=true WITH_LIBVIRT=false
+make static WITH_EBPF=true
 ${dir}/../../contrib/packaging/rpm/generate-skydive-bootstrap.sh -s -r ${TAG}
 
 github-release release ${FLAGS} --user skydive-project --repo skydive --tag ${TAG} --description "$changelog"

--- a/scripts/ci/run-compile-tests.sh
+++ b/scripts/ci/run-compile-tests.sh
@@ -24,4 +24,4 @@ make WITH_PROF=true VERBOSE=true
 make test.functionals.compile TAGS=${TAGS} WITH_NEUTRON=true WITH_SELENIUM=true WITH_CDD=true WITH_SCALE=true
 
 # Compile static
-make static WITH_LIBVIRT=false
+make static

--- a/scripts/ci/run-python-tests.sh
+++ b/scripts/ci/run-python-tests.sh
@@ -13,7 +13,7 @@ make docker-image
 cd contrib/python
 
 echo "Python2 tests"
-virtualenv-2 venv2
+virtualenv -p python2 venv2
 source venv2/bin/activate
 
 pip install -r api/requirements.txt
@@ -27,7 +27,7 @@ deactivate
 
 
 echo "Python3 tests"
-virtualenv-3 venv3
+virtualenv -p python3 venv3
 source venv3/bin/activate
 
 pip install flake8

--- a/scripts/ci/run-tripleo-tests.sh
+++ b/scripts/ci/run-tripleo-tests.sh
@@ -5,7 +5,7 @@ set -e
 SKYDIVE_PATH=$PWD
 
 pushd ${GOPATH}/src/github.com/skydive-project/skydive
-make static WITH_LIBVIRT=false
+make static
 popd
 
 QUICKSTART=${QUICKSTART:-/tmp/tripleo-quickstart}


### PR DESCRIPTION
As libvirt can't be linked in static
User should not pass a special parameter in this case