### PR TITLE
test: remove bench test as the result is not used

### DIFF
--- a/scripts/ci/run-unit-tests.sh
+++ b/scripts/ci/run-unit-tests.sh
@@ -16,6 +16,3 @@ cd ${GOPATH}/src/github.com/skydive-project/skydive
 make test GOFLAGS="${GOFLAGS}" TAGS="${TAGS}" VERBOSE=true TIMEOUT=5m COVERAGE=${COVERAGE} | tee $WORKSPACE/unit-tests.log
 go2xunit -input $WORKSPACE/unit-tests.log -output $WORKSPACE/tests.xml
 sed -i 's/\x1b\[[0-9;]*m//g' $WORKSPACE/tests.xml
-
-# Run Benchmark
-make bench.flow


### PR DESCRIPTION
Bench test results are not used and rely on external
resource which is currenlty unavailable. Moreover
It would be better to pass the pcap file as an
argument and should be cached.