### PR TITLE
K8s: use stucts in-place of maps for node meta

### DIFF
--- a/analyzer/server.go
+++ b/analyzer/server.go
@@ -388,10 +388,10 @@ func init() {
 	// add decoders for specific metadata keys, this aims to keep the same
 	// object type between the agent and the analyzer
 	// Decoder will be used while unmarshal the metadata
-	graph.NodeMetadataDecoders["RoutingTables"] = netlink.RoutingTablesMetadataDecoder
-	graph.NodeMetadataDecoders["FDB"] = netlink.NeighborMetadataDecoder
-	graph.NodeMetadataDecoders["Neighbors"] = netlink.NeighborMetadataDecoder
-	graph.NodeMetadataDecoders["Metric"] = topology.InterfaceMetricMetadataDecoder
-	graph.NodeMetadataDecoders["LastUpdateMetric"] = topology.InterfaceMetricMetadataDecoder
-	graph.NodeMetadataDecoders["SFlow"] = sflow.SFMetadataDecoder
+	graph.RegisterNodeDecoder("RoutingTables", netlink.RoutingTablesMetadataDecoder)
+	graph.RegisterNodeDecoder("FDB", netlink.NeighborMetadataDecoder)
+	graph.RegisterNodeDecoder("Neighbors", netlink.NeighborMetadataDecoder)
+	graph.RegisterNodeDecoder("Metric", topology.InterfaceMetricMetadataDecoder)
+	graph.RegisterNodeDecoder("LastUpdateMetric", topology.InterfaceMetricMetadataDecoder)
+	graph.RegisterNodeDecoder("SFlow", sflow.SFMetadataDecoder)
 }

--- a/topology/probes/istio/destinationrule.go
+++ b/topology/probes/istio/destinationrule.go
@@ -33,8 +33,8 @@ type destinationRuleHandler struct {
 // Map graph node to k8s resource
 func (h *destinationRuleHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	dr := obj.(*kiali.DestinationRule)
-	m := k8s.NewMetadataFields(&dr.ObjectMeta)
-	return graph.Identifier(dr.GetUID()), k8s.NewMetadata(Manager, "destinationrule", m, dr, dr.Name)
+	inner := new(k8s.MetadataInner).Setup(&dr.ObjectMeta, dr)
+	return graph.Identifier(dr.GetUID()), k8s.NewMetadata(Manager, "destinationrule", inner.Name, inner)
 }
 
 // Dump k8s resource
@@ -44,6 +44,7 @@ func (h *destinationRuleHandler) Dump(obj interface{}) string {
 }
 
 func newDestinationRuleProbe(client interface{}, g *graph.Graph) k8s.Subprobe {
+	k8s.RegisterNodeDecoder(k8s.MetadataInnerDecoder, "destinationrule")
 	return k8s.NewResourceCache(client.(*kiali.IstioClient).GetIstioNetworkingApi(), &kiali.DestinationRule{}, "destinationrules", g, &destinationRuleHandler{})
 }
 

--- a/topology/probes/istio/gateway.go
+++ b/topology/probes/istio/gateway.go
@@ -32,8 +32,8 @@ type gatewayHandler struct {
 // Map graph node to k8s resource
 func (h *gatewayHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	gw := obj.(*kiali.Gateway)
-	m := k8s.NewMetadataFields(&gw.ObjectMeta)
-	return graph.Identifier(gw.GetUID()), k8s.NewMetadata(Manager, "gateway", m, gw, gw.Name)
+	inner := new(k8s.MetadataInner).Setup(&gw.ObjectMeta, gw)
+	return graph.Identifier(gw.GetUID()), k8s.NewMetadata(Manager, "gateway", inner.Name, inner)
 }
 
 // Dump k8s resource
@@ -43,6 +43,7 @@ func (h *gatewayHandler) Dump(obj interface{}) string {
 }
 
 func newGatewayProbe(client interface{}, g *graph.Graph) k8s.Subprobe {
+	k8s.RegisterNodeDecoder(k8s.MetadataInnerDecoder, "gateway")
 	return k8s.NewResourceCache(client.(*kiali.IstioClient).GetIstioNetworkingApi(), &kiali.Gateway{}, "gateways", g, &gatewayHandler{})
 }
 

--- a/topology/probes/istio/quotaspec.go
+++ b/topology/probes/istio/quotaspec.go
@@ -31,8 +31,8 @@ type quotaSpecHandler struct {
 // Map graph node to k8s resource
 func (h *quotaSpecHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	qs := obj.(*kiali.QuotaSpec)
-	m := k8s.NewMetadataFields(&qs.ObjectMeta)
-	return graph.Identifier(qs.GetUID()), k8s.NewMetadata(Manager, "quotaspec", m, qs, qs.Name)
+	inner := new(k8s.MetadataInner).Setup(&qs.ObjectMeta, qs)
+	return graph.Identifier(qs.GetUID()), k8s.NewMetadata(Manager, "quotaspec", inner.Name, inner)
 }
 
 // Dump k8s resource
@@ -42,5 +42,6 @@ func (h *quotaSpecHandler) Dump(obj interface{}) string {
 }
 
 func newQuotaSpecProbe(client interface{}, g *graph.Graph) k8s.Subprobe {
+	k8s.RegisterNodeDecoder(k8s.MetadataInnerDecoder, "quotaspec")
 	return k8s.NewResourceCache(client.(*kiali.IstioClient).GetIstioConfigApi(), &kiali.QuotaSpec{}, "quotaspecs", g, &quotaSpecHandler{})
 }

--- a/topology/probes/istio/quotaspecbinding.go
+++ b/topology/probes/istio/quotaspecbinding.go
@@ -31,8 +31,8 @@ type quotaSpecBindingHandler struct {
 // Map graph node to k8s resource
 func (h *quotaSpecBindingHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	qsb := obj.(*kiali.QuotaSpecBinding)
-	m := k8s.NewMetadataFields(&qsb.ObjectMeta)
-	return graph.Identifier(qsb.GetUID()), k8s.NewMetadata(Manager, "quotaspecbinding", m, qsb, qsb.Name)
+	inner := new(k8s.MetadataInner).Setup(&qsb.ObjectMeta, qsb)
+	return graph.Identifier(qsb.GetUID()), k8s.NewMetadata(Manager, "quotaspecbinding", inner.Name, inner)
 }
 
 // Dump k8s resource
@@ -42,5 +42,6 @@ func (h *quotaSpecBindingHandler) Dump(obj interface{}) string {
 }
 
 func newQuotaSpecBindingProbe(client interface{}, g *graph.Graph) k8s.Subprobe {
+	k8s.RegisterNodeDecoder(k8s.MetadataInnerDecoder, "quotaspecbinding")
 	return k8s.NewResourceCache(client.(*kiali.IstioClient).GetIstioConfigApi(), &kiali.QuotaSpecBinding{}, "quotaspecbindings", g, &quotaSpecBindingHandler{})
 }

--- a/topology/probes/istio/serviceentry.go
+++ b/topology/probes/istio/serviceentry.go
@@ -31,8 +31,8 @@ type serviceEntryHandler struct {
 // Map graph node to k8s resource
 func (h *serviceEntryHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	se := obj.(*kiali.ServiceEntry)
-	m := k8s.NewMetadataFields(&se.ObjectMeta)
-	return graph.Identifier(se.GetUID()), k8s.NewMetadata(Manager, "serviceentry", m, se, se.Name)
+	inner := new(k8s.MetadataInner).Setup(&se.ObjectMeta, se)
+	return graph.Identifier(se.GetUID()), k8s.NewMetadata(Manager, "serviceentry", inner.Name, inner)
 }
 
 // Dump k8s resource
@@ -42,5 +42,6 @@ func (h *serviceEntryHandler) Dump(obj interface{}) string {
 }
 
 func newServiceEntryProbe(client interface{}, g *graph.Graph) k8s.Subprobe {
+	k8s.RegisterNodeDecoder(k8s.MetadataInnerDecoder, "serviceentry")
 	return k8s.NewResourceCache(client.(*kiali.IstioClient).GetIstioNetworkingApi(), &kiali.ServiceEntry{}, "serviceentries", g, &serviceEntryHandler{})
 }

--- a/topology/probes/istio/virtualservice.go
+++ b/topology/probes/istio/virtualservice.go
@@ -34,8 +34,8 @@ type virtualServiceHandler struct {
 // Map graph node to k8s resource
 func (h *virtualServiceHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	vs := obj.(*kiali.VirtualService)
-	m := k8s.NewMetadataFields(&vs.ObjectMeta)
-	return graph.Identifier(vs.GetUID()), k8s.NewMetadata(Manager, "virtualservice", m, vs, vs.Name)
+	inner := new(k8s.MetadataInner).Setup(&vs.ObjectMeta, vs)
+	return graph.Identifier(vs.GetUID()), k8s.NewMetadata(Manager, "virtualservice", inner.Name, inner)
 }
 
 // Dump k8s resource
@@ -45,6 +45,7 @@ func (h *virtualServiceHandler) Dump(obj interface{}) string {
 }
 
 func newVirtualServiceProbe(client interface{}, g *graph.Graph) k8s.Subprobe {
+	k8s.RegisterNodeDecoder(k8s.MetadataInnerDecoder, "virtualservice")
 	return k8s.NewResourceCache(client.(*kiali.IstioClient).GetIstioNetworkingApi(), &kiali.VirtualService{}, "virtualservices", g, &virtualServiceHandler{})
 }
 

--- a/topology/probes/k8s/cluster.go
+++ b/topology/probes/k8s/cluster.go
@@ -38,10 +38,11 @@ func (c *clusterCache) addClusterNode() {
 	c.graph.Lock()
 	defer c.graph.Unlock()
 
-	m := graph.Metadata{"Name": ClusterName}
+	inner := new(MetadataInner)
+	inner.Name = ClusterName
 
 	var err error
-	clusterNode, err = c.graph.NewNode(graph.GenID(), NewMetadata(Manager, "cluster", m, nil, ClusterName), "")
+	clusterNode, err = c.graph.NewNode(graph.GenID(), NewMetadata(Manager, "cluster", inner.Name, inner), "")
 	if err != nil {
 		logging.GetLogger().Error(err)
 		return
@@ -57,6 +58,7 @@ func (c *clusterCache) Stop() {
 }
 
 func newClusterProbe(clientset interface{}, g *graph.Graph) Subprobe {
+	RegisterNodeDecoder(MetadataInnerDecoder, "cluster")
 	c := &clusterCache{
 		EventHandler: graph.NewEventHandler(100),
 		graph:        g,
@@ -68,8 +70,7 @@ func newClusterProbe(clientset interface{}, g *graph.Graph) Subprobe {
 type clusterLinker struct {
 	graph.DefaultLinker
 	*graph.ResourceLinker
-	g             *graph.Graph
-	objectIndexer *graph.MetadataIndexer
+	g *graph.Graph
 }
 
 func (linker *clusterLinker) createEdge(cluster, object *graph.Node) *graph.Edge {

--- a/topology/probes/k8s/configmap.go
+++ b/topology/probes/k8s/configmap.go
@@ -36,10 +36,11 @@ func (h *configMapHandler) Dump(obj interface{}) string {
 
 func (h *configMapHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	cm := obj.(*v1.ConfigMap)
-	m := NewMetadataFields(&cm.ObjectMeta)
-	return graph.Identifier(cm.GetUID()), NewMetadata(Manager, "configmap", m, cm, cm.Name)
+	inner := new(MetadataInner).Setup(&cm.ObjectMeta, cm)
+	return graph.Identifier(cm.GetUID()), NewMetadata(Manager, "configmap", inner.Name, inner)
 }
 
 func newConfigMapProbe(client interface{}, g *graph.Graph) Subprobe {
+	RegisterNodeDecoder(MetadataInnerDecoder, "configmap")
 	return NewResourceCache(client.(*kubernetes.Clientset).CoreV1().RESTClient(), &v1.ConfigMap{}, "configmaps", g, &configMapHandler{})
 }

--- a/topology/probes/k8s/endpoints.go
+++ b/topology/probes/k8s/endpoints.go
@@ -36,10 +36,11 @@ func (h *endpointsHandler) Dump(obj interface{}) string {
 
 func (h *endpointsHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	endpoints := obj.(*v1.Endpoints)
-	m := NewMetadataFields(&endpoints.ObjectMeta)
-	return graph.Identifier(endpoints.GetUID()), NewMetadata(Manager, "endpoints", m, endpoints, endpoints.Name)
+	inner := new(MetadataInner).Setup(&endpoints.ObjectMeta, endpoints)
+	return graph.Identifier(endpoints.GetUID()), NewMetadata(Manager, "endpoints", inner.Name, inner)
 }
 
 func newEndpointsProbe(client interface{}, g *graph.Graph) Subprobe {
+	RegisterNodeDecoder(MetadataInnerDecoder, "endpoints")
 	return NewResourceCache(client.(*kubernetes.Clientset).Core().RESTClient(), &v1.Endpoints{}, "endpoints", g, &endpointsHandler{})
 }

--- a/topology/probes/k8s/graph.go
+++ b/topology/probes/k8s/graph.go
@@ -18,6 +18,12 @@
 package k8s
 
 import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/skydive-project/skydive/common"
 	"github.com/skydive-project/skydive/filters"
 	"github.com/skydive-project/skydive/graffiti/graph"
 	"github.com/skydive-project/skydive/probe"
@@ -33,6 +39,140 @@ const (
 	// ExtraKey is the metadata area for k8s extra fields
 	ExtraKey = "K8s.Extra"
 )
+
+// DereferenceValue dereference pointers returning the real value
+func DereferenceValue(val reflect.Value) reflect.Value {
+	for val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+	return val
+}
+
+// GenericGetFieldKeys underlaying implementation of Getter.GetFieldKeys method
+func GenericGetFieldKeys(i interface{}) (keys []string) {
+	parent := DereferenceValue(reflect.ValueOf(i))
+	for i := 0; i < parent.NumField(); i++ {
+		child := DereferenceValue(parent.Field(i))
+		typeOfChild := parent.Type().Field(i)
+		switch typeOfChild.Name {
+		case "MetadataInner":
+			keys = append(keys, GenericGetFieldKeys(child.Interface())...)
+		default:
+			if _, ok := typeOfChild.Tag.Lookup("skydive"); ok {
+				keys = append(keys, typeOfChild.Name)
+			}
+		}
+	}
+	return
+}
+
+// GenericGetFieldTyped underlaying implementation of Getter.GetField<XXX> methods
+func GenericGetFieldTyped(i interface{}, key string, ty ...string) (reflect.Value, error) {
+	parent := DereferenceValue(reflect.ValueOf(i))
+	for i := 0; i < parent.NumField(); i++ {
+		child := DereferenceValue(parent.Field(i))
+		typeOfChild := parent.Type().Field(i)
+		switch typeOfChild.Name {
+		case "MetadataInner":
+			if grandchild, err := GenericGetFieldTyped(child.Interface(), key, ty...); err != common.ErrFieldNotFound {
+				return grandchild, err
+			}
+		case key:
+			if tag, ok := typeOfChild.Tag.Lookup("skydive"); ok {
+				for _, v := range strings.Split(tag, ",") {
+					if len(ty) == 0 || v == ty[0] {
+						return child, nil
+					}
+				}
+				return reflect.Value{}, common.ErrFieldWrongType
+			}
+		}
+	}
+	return reflect.Value{}, common.ErrFieldNotFound
+}
+
+// GenericGetField underlaying implementation of Getter.GetField method
+func GenericGetField(i interface{}, key string) (interface{}, error) {
+	val, err := GenericGetFieldTyped(i, key)
+	if err != nil {
+		return 0, err
+	}
+	return val.Interface(), nil
+}
+
+// GenericGetFieldInt64 underlaying implementation of Getter.GetFieldInt64 method
+func GenericGetFieldInt64(i interface{}, key string) (int64, error) {
+	val, err := GenericGetFieldTyped(i, key, "int")
+	if err != nil {
+		return 0, err
+	}
+	return val.Int(), nil
+}
+
+// GenericGetFieldString underlaying implementation of Getter.GetFieldString method
+func GenericGetFieldString(i interface{}, key string) (string, error) {
+	val, err := GenericGetFieldTyped(i, key, "string")
+	if err != nil {
+		return "", err
+	}
+	return val.String(), nil
+}
+
+// GenericMetadataDecoder implements a generic json message raw decoder
+func GenericMetadataDecoder(inner common.Getter, raw json.RawMessage) (common.Getter, error) {
+	if err := json.Unmarshal(raw, inner); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal routing table %s: %s", string(raw), err)
+	}
+
+	return inner, nil
+}
+
+// RegisterNodeDecoder register graph decoder
+func RegisterNodeDecoder(decoder graph.MetadataDecoder, ty string) {
+	graph.RegisterNodeDecoder(Manager, decoder, ty)
+}
+
+// Setup standard type specific fields
+func (inner *MetadataInner) Setup(meta *metav1.ObjectMeta, extra interface{}) *MetadataInner {
+	inner.Namespace = meta.Namespace
+	inner.Name = meta.Name
+	inner.Extra = extra
+	return inner
+}
+
+// MetadataInner contains type specific fields
+// easyjson:json
+type MetadataInner struct {
+	Namespace string `skydive:"string"`
+	Name      string `skydive:"string"`
+	Extra     interface{}
+}
+
+// GetField implements Getter interface
+func (inner *MetadataInner) GetField(key string) (interface{}, error) {
+	return GenericGetField(inner, key)
+}
+
+// GetFieldInt64 implements Getter interface
+func (inner *MetadataInner) GetFieldInt64(key string) (int64, error) {
+	return GenericGetFieldInt64(inner, key)
+}
+
+// GetFieldString implements Getter interface
+func (inner *MetadataInner) GetFieldString(key string) (string, error) {
+	return GenericGetFieldString(inner, key)
+}
+
+// GetFieldKeys implements Getter interface
+func (inner *MetadataInner) GetFieldKeys() []string {
+	return GenericGetFieldKeys(inner)
+}
+
+// MetadataInnerDecoder implements a json message raw decoder
+func MetadataInnerDecoder(raw json.RawMessage) (common.Getter, error) {
+	var inner MetadataInner
+	return GenericMetadataDecoder(&inner, raw)
+}
 
 // MetadataField is generates full path of a k8s specific field
 func MetadataField(field string) string {
@@ -58,16 +198,13 @@ func NewMetadataFields(o metav1.Object) graph.Metadata {
 }
 
 // NewMetadata creates a k8s node base metadata struct
-func NewMetadata(manager, ty string, kubeMeta graph.Metadata, extra interface{}, name string) graph.Metadata {
-	m := graph.Metadata{}
-	m["Manager"] = manager
-	m["Type"] = ty
-	m["Name"] = name
-	m.SetFieldAndNormalize(KubeKey, map[string]interface{}(kubeMeta))
-	if extra != nil {
-		m.SetFieldAndNormalize(ExtraKey, extra)
+func NewMetadata(manager, ty, name string, inner interface{}) graph.Metadata {
+	return graph.Metadata{
+		"Manager": manager,
+		"Type":    ty,
+		"Name":    name,
+		KubeKey:   inner,
 	}
-	return m
 }
 
 // SetState field of node metadata

--- a/topology/probes/k8s/job.go
+++ b/topology/probes/k8s/job.go
@@ -18,13 +18,52 @@
 package k8s
 
 import (
+	"encoding/json"
 	"fmt"
 
+	"github.com/skydive-project/skydive/common"
 	"github.com/skydive-project/skydive/graffiti/graph"
 
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/client-go/kubernetes"
 )
+
+// MetadataInnerJob contains the type specific fields
+// easyjson:json
+type MetadataInnerJob struct {
+	MetadataInner
+	Parallelism int32 `skydive:"int"`
+	Completions int32 `skydive:"int"`
+	Active      int32 `skydive:"int"`
+	Succeeded   int32 `skydive:"int"`
+	Failed      int32 `skydive:"int"`
+}
+
+// GetField implements Getter interface
+func (inner *MetadataInnerJob) GetField(key string) (interface{}, error) {
+	return GenericGetField(inner, key)
+}
+
+// GetFieldInt64 implements Getter interface
+func (inner *MetadataInnerJob) GetFieldInt64(key string) (int64, error) {
+	return GenericGetFieldInt64(inner, key)
+}
+
+// GetFieldString implements Getter interface
+func (inner *MetadataInnerJob) GetFieldString(key string) (string, error) {
+	return GenericGetFieldString(inner, key)
+}
+
+// GetFieldKeys implements Getter interface
+func (inner *MetadataInnerJob) GetFieldKeys() []string {
+	return GenericGetFieldKeys(inner)
+}
+
+// MetadataInnerJobDecoder implements a json message raw decoder
+func MetadataInnerJobDecoder(raw json.RawMessage) (common.Getter, error) {
+	var inner MetadataInnerJob
+	return GenericMetadataDecoder(&inner, raw)
+}
 
 type jobHandler struct {
 }
@@ -37,16 +76,18 @@ func (h *jobHandler) Dump(obj interface{}) string {
 func (h *jobHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	job := obj.(*batchv1.Job)
 
-	m := NewMetadataFields(&job.ObjectMeta)
-	m.SetField("Parallelism", job.Spec.Parallelism)
-	m.SetField("Completions", job.Spec.Completions)
-	m.SetField("Active", job.Status.Active)
-	m.SetField("Succeeded", job.Status.Succeeded)
-	m.SetField("Failed", job.Status.Failed)
+	inner := new(MetadataInnerJob)
+	inner.MetadataInner.Setup(&job.ObjectMeta, job)
+	inner.Parallelism = *job.Spec.Parallelism
+	inner.Completions = *job.Spec.Completions
+	inner.Active = job.Status.Active
+	inner.Succeeded = job.Status.Succeeded
+	inner.Failed = job.Status.Failed
 
-	return graph.Identifier(job.GetUID()), NewMetadata(Manager, "job", m, job, job.Name)
+	return graph.Identifier(job.GetUID()), NewMetadata(Manager, "job", inner.Name, inner)
 }
 
 func newJobProbe(client interface{}, g *graph.Graph) Subprobe {
+	RegisterNodeDecoder(MetadataInnerJobDecoder, "job")
 	return NewResourceCache(client.(*kubernetes.Clientset).BatchV1().RESTClient(), &batchv1.Job{}, "jobs", g, &jobHandler{})
 }

--- a/topology/probes/k8s/networkpolicy.go
+++ b/topology/probes/k8s/networkpolicy.go
@@ -41,11 +41,12 @@ func (h *networkPolicyHandler) Dump(obj interface{}) string {
 
 func (h *networkPolicyHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	np := obj.(*v1beta1.NetworkPolicy)
-	m := NewMetadataFields(&np.ObjectMeta)
-	return graph.Identifier(np.GetUID()), NewMetadata(Manager, "networkpolicy", m, np, np.Name)
+	inner := new(MetadataInner).Setup(&np.ObjectMeta, np)
+	return graph.Identifier(np.GetUID()), NewMetadata(Manager, "networkpolicy", inner.Name, inner)
 }
 
 func newNetworkPolicyProbe(client interface{}, g *graph.Graph) Subprobe {
+	RegisterNodeDecoder(MetadataInnerDecoder, "networkpolicy")
 	return NewResourceCache(client.(*kubernetes.Clientset).ExtensionsV1beta1().RESTClient(), &v1beta1.NetworkPolicy{}, "networkpolicies", g, &networkPolicyHandler{})
 }
 

--- a/topology/probes/k8s/node.go
+++ b/topology/probes/k8s/node.go
@@ -18,14 +18,54 @@
 package k8s
 
 import (
+	"encoding/json"
 	"fmt"
 
+	"github.com/skydive-project/skydive/common"
 	"github.com/skydive-project/skydive/graffiti/graph"
 	"github.com/skydive-project/skydive/probe"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
+
+// MetadataInnerNode contains the type specific fields
+// easyjson:json
+type MetadataInnerNode struct {
+	MetadataInner
+	Hostname   string `skydive:"string" json:"Hostname,omitempty"`
+	InternalIP string `skydive:"string" json:"InternalIP,omitempty"`
+	ExternalIP string `skydive:"string" json:"ExternalIP,omitempty"`
+	Arch       string `skydive:"string"`
+	Kernel     string `skydive:"string"`
+	OS         string `skydive:"string"`
+}
+
+// GetField implements Getter interface
+func (inner *MetadataInnerNode) GetField(key string) (interface{}, error) {
+	return GenericGetField(inner, key)
+}
+
+// GetFieldInt64 implements Getter interface
+func (inner *MetadataInnerNode) GetFieldInt64(key string) (int64, error) {
+	return GenericGetFieldInt64(inner, key)
+}
+
+// GetFieldString implements Getter interface
+func (inner *MetadataInnerNode) GetFieldString(key string) (string, error) {
+	return GenericGetFieldString(inner, key)
+}
+
+// GetFieldKeys implements Getter interface
+func (inner *MetadataInnerNode) GetFieldKeys() []string {
+	return GenericGetFieldKeys(inner)
+}
+
+// MetadataInnerNodeDecoder implements a json message raw decoder
+func MetadataInnerNodeDecoder(raw json.RawMessage) (common.Getter, error) {
+	var inner MetadataInnerNode
+	return GenericMetadataDecoder(&inner, raw)
+}
 
 type nodeHandler struct {
 }
@@ -38,20 +78,27 @@ func (h *nodeHandler) Dump(obj interface{}) string {
 func (h *nodeHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	node := obj.(*v1.Node)
 
-	m := NewMetadataFields(&node.ObjectMeta)
+	inner := new(MetadataInnerNode)
+	inner.MetadataInner.Setup(&node.ObjectMeta, node)
 	for _, a := range node.Status.Addresses {
-		if a.Type == "Hostname" || a.Type == "InternalIP" || a.Type == "ExternalIP" {
-			m.SetField(string(a.Type), a.Address)
+		switch a.Type {
+		case "Hostname":
+			inner.Hostname = a.Address
+		case "InternalIP":
+			inner.InternalIP = a.Address
+		case "ExternalIP":
+			inner.ExternalIP = a.Address
 		}
 	}
-	m.SetField("Arch", node.Status.NodeInfo.Architecture)
-	m.SetField("Kernel", node.Status.NodeInfo.KernelVersion)
-	m.SetField("OS", node.Status.NodeInfo.OperatingSystem)
+	inner.Arch = node.Status.NodeInfo.Architecture
+	inner.Kernel = node.Status.NodeInfo.KernelVersion
+	inner.OS = node.Status.NodeInfo.OperatingSystem
 
-	return graph.Identifier(node.GetUID()), NewMetadata(Manager, "node", m, node, node.Name)
+	return graph.Identifier(node.GetUID()), NewMetadata(Manager, "node", inner.Name, inner)
 }
 
 func newNodeProbe(client interface{}, g *graph.Graph) Subprobe {
+	RegisterNodeDecoder(MetadataInnerNodeDecoder, "node")
 	return NewResourceCache(client.(*kubernetes.Clientset).Core().RESTClient(), &v1.Node{}, "nodes", g, &nodeHandler{})
 }
 

--- a/topology/probes/k8s/persistentvolume.go
+++ b/topology/probes/k8s/persistentvolume.go
@@ -18,13 +18,53 @@
 package k8s
 
 import (
+	"encoding/json"
 	"fmt"
 
+	"github.com/skydive-project/skydive/common"
 	"github.com/skydive-project/skydive/graffiti/graph"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
+
+// MetadataInnerPersistentVolume contains the type specific fields
+// easyjson:json
+type MetadataInnerPersistentVolume struct {
+	MetadataInner
+	Capacity         v1.ResourceList
+	VolumeMode       *v1.PersistentVolumeMode `skydive:"string"`
+	StorageClassName string                   `skydive:"string"`
+	Status           string                   `skydive:"string"`
+	AccessModes      []v1.PersistentVolumeAccessMode
+	ClaimRef         string
+}
+
+// GetField implements Getter interface
+func (inner *MetadataInnerPersistentVolume) GetField(key string) (interface{}, error) {
+	return GenericGetField(inner, key)
+}
+
+// GetFieldInt64 implements Getter interface
+func (inner *MetadataInnerPersistentVolume) GetFieldInt64(key string) (int64, error) {
+	return GenericGetFieldInt64(inner, key)
+}
+
+// GetFieldString implements Getter interface
+func (inner *MetadataInnerPersistentVolume) GetFieldString(key string) (string, error) {
+	return GenericGetFieldString(inner, key)
+}
+
+// GetFieldKeys implements Getter interface
+func (inner *MetadataInnerPersistentVolume) GetFieldKeys() []string {
+	return GenericGetFieldKeys(inner)
+}
+
+// MetadataInnerPersistentVolumeDecoder implements a json message raw decoder
+func MetadataInnerPersistentVolumeDecoder(raw json.RawMessage) (common.Getter, error) {
+	var inner MetadataInnerPersistentVolume
+	return GenericMetadataDecoder(&inner, raw)
+}
 
 type persistentVolumeHandler struct {
 }
@@ -37,22 +77,24 @@ func (h *persistentVolumeHandler) Dump(obj interface{}) string {
 func (h *persistentVolumeHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	pv := obj.(*v1.PersistentVolume)
 
-	m := NewMetadataFields(&pv.ObjectMeta)
-	m.SetFieldAndNormalize("Capacity", pv.Spec.Capacity)
-	m.SetFieldAndNormalize("VolumeMode", pv.Spec.VolumeMode)
-	m.SetFieldAndNormalize("StorageClassName", pv.Spec.StorageClassName)
-	m.SetFieldAndNormalize("Status", pv.Status.Phase)
-	m.SetFieldAndNormalize("AccessModes", pv.Spec.AccessModes)
+	inner := new(MetadataInnerPersistentVolume)
+	inner.MetadataInner.Setup(&pv.ObjectMeta, pv)
+	inner.Capacity = pv.Spec.Capacity
+	inner.VolumeMode = pv.Spec.VolumeMode
+	inner.StorageClassName = pv.Spec.StorageClassName
+	inner.Status = string(pv.Status.Phase)
+	inner.AccessModes = pv.Spec.AccessModes
 	if pv.Spec.ClaimRef != nil {
-		m.SetFieldAndNormalize("ClaimRef", pv.Spec.ClaimRef.Name)
+		inner.ClaimRef = pv.Spec.ClaimRef.Name
 	}
 
-	metadata := NewMetadata(Manager, "persistentvolume", m, pv, pv.Name)
+	metadata := NewMetadata(Manager, "persistentvolume", inner.Name, inner)
 	SetState(&metadata, pv.Status.Phase != "Failed")
 
 	return graph.Identifier(pv.GetUID()), metadata
 }
 
 func newPersistentVolumeProbe(client interface{}, g *graph.Graph) Subprobe {
+	RegisterNodeDecoder(MetadataInnerPersistentVolumeDecoder, "persistentvolume")
 	return NewResourceCache(client.(*kubernetes.Clientset).CoreV1().RESTClient(), &v1.PersistentVolume{}, "persistentvolumes", g, &persistentVolumeHandler{})
 }

--- a/topology/probes/k8s/replicaset.go
+++ b/topology/probes/k8s/replicaset.go
@@ -36,10 +36,11 @@ func (h *replicaSetHandler) Dump(obj interface{}) string {
 
 func (h *replicaSetHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	rs := obj.(*v1beta1.ReplicaSet)
-	m := NewMetadataFields(&rs.ObjectMeta)
-	return graph.Identifier(rs.GetUID()), NewMetadata(Manager, "replicaset", m, rs, rs.Name)
+	inner := new(MetadataInner).Setup(&rs.ObjectMeta, rs)
+	return graph.Identifier(rs.GetUID()), NewMetadata(Manager, "replicaset", inner.Name, inner)
 }
 
 func newReplicaSetProbe(client interface{}, g *graph.Graph) Subprobe {
+	RegisterNodeDecoder(MetadataInnerDecoder, "replicaset")
 	return NewResourceCache(client.(*kubernetes.Clientset).ExtensionsV1beta1().RESTClient(), &v1beta1.ReplicaSet{}, "replicasets", g, &replicaSetHandler{})
 }

--- a/topology/probes/k8s/replicationcontroller.go
+++ b/topology/probes/k8s/replicationcontroller.go
@@ -36,10 +36,11 @@ func (h *replicationControllerHandler) Dump(obj interface{}) string {
 
 func (h *replicationControllerHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	rc := obj.(*v1.ReplicationController)
-	m := NewMetadataFields(&rc.ObjectMeta)
-	return graph.Identifier(rc.GetUID()), NewMetadata(Manager, "replicationcontroller", m, rc, rc.Name)
+	inner := new(MetadataInner).Setup(&rc.ObjectMeta, rc)
+	return graph.Identifier(rc.GetUID()), NewMetadata(Manager, "replicationcontroller", inner.Name, inner)
 }
 
 func newReplicationControllerProbe(client interface{}, g *graph.Graph) Subprobe {
+	RegisterNodeDecoder(MetadataInnerDecoder, "replicationcontroller")
 	return NewResourceCache(client.(*kubernetes.Clientset).CoreV1().RESTClient(), &v1.ReplicationController{}, "replicationcontrollers", g, &replicationControllerHandler{})
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2400,7 +2400,7 @@
 			"revision": "604eaf189ee867d8c147fafc28def2394e878d25"
 		},
 		{
-			"checksumSHA1": "rFSw9cpg4vxtZD7dlOtKx25h4kI=",
+			"checksumSHA1": "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
 			"path": "github.com/weaveworks/tcptracer-bpf",
 			"revision": "e080bd747dc6b62d4ed3ed2b7f0be4801bef8faf",
 			"revisionTime": "2017-08-17T15:53:01Z",


### PR DESCRIPTION
NOTE: WIP as there is still a bug in k8s.Extra object serialization - @safchain / @lebauce  - can you check why this is happening? 

This PR replaced the K8s field which was a `map[string]interface{}` with a real structure. So as to support filters/gremlin I use a set of generic methods which traverse the structure and according to content of the `skydive` tag ("string", "int" or empty) implement the common.Getter interface.

Using this technique maybe more elegant that implementing specific `GetFieldString()` `GetFieldInt64()` etc. methods as for example is the case in `netlink/neighbor.go` so going forward methods I implemented in `k8s/graph.go` can be moved to `common`.

I assume we could consider later on relaying directly on the `skydive` tags thus enabling to cancel all-together the need to implement the `common.Getter` interface, but this can only be done once all searchable struct fields are tagged (using `skydive` tag) or if we agree to some convention as to which fields are exposed as `string` or `int64`.

In any case - code is ready for review. 