### PR TITLE
packaging: bump rpm version to 0.21.0

### DIFF
--- a/contrib/packaging/rpm/skydive.spec
+++ b/contrib/packaging/rpm/skydive.spec
@@ -31,7 +31,7 @@
 %endif
 %endif
 
-%{!?fullver:%global fullver 0.20.0}
+%{!?fullver:%global fullver 0.21.0}
 %define version %{extractversion %{fullver}}
 %{!?tag:%global tag 1}
 


### PR DESCRIPTION
skip skydive-go-fmt
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-scale-tests
skip skydive-cdd-overview-tests
skip skydive-unit-tests
skip skydive-compile-tests
skip skydive-k8s-tests
skip skydive-ppc64le-tests