### PR TITLE
k8s: fix indexer needed for cluster linker

### DIFF
--- a/topology/graph/indexer.go
+++ b/topology/graph/indexer.go
@@ -204,7 +204,7 @@ func NewMetadataIndexer(g *Graph, listenerHandler ListenerHandler, m ElementMatc
 		Indexer: NewIndexer(g, listenerHandler, func(n *Node) (kv map[string]interface{}) {
 			if match := n.MatchMetadata(m); match {
 				kv = make(map[string]interface{})
-				if values, err := getFieldsAsArray(n, indexes); err == nil && len(values) > 0 {
+				if values, err := getFieldsAsArray(n, indexes); err == nil && len(indexes) == len(values) {
 					kv[Hash(values...)] = values
 				}
 			}

--- a/topology/probes/k8s/cluster.go
+++ b/topology/probes/k8s/cluster.go
@@ -70,7 +70,6 @@ type clusterLinker struct {
 	graph.DefaultLinker
 	*graph.ResourceLinker
 	g             *graph.Graph
-	objectIndexer *graph.MetadataIndexer
 }
 
 func (linker *clusterLinker) createEdge(cluster, object *graph.Node) *graph.Edge {


### PR DESCRIPTION
@lebauce - apparently the commit replacing `len(values) > 0` with `len(indexes) == len(values)` was needed - I did not retest after removing the commit as a result the cluster linker is now still broken even after merging: https://github.com/skydive-project/skydive/pull/1432 

please advise - I need an MetadataIndexer for cluster to object links which would capture   all graph Nodes from one of several types ("namespace", "node", etc.) - as currently len(values) > 0 - such a MetadataIndexer is not allowed -  I an reluctant to implement yest another variant of MetadataIndexer for handling the `len(indexes) == 0` case.