### PR TITLE
istio: add edges to virtualservice and destinationrule probes

### DIFF
--- a/tests/istio/vs-dr-pod-service.yaml
+++ b/tests/istio/vs-dr-pod-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: skydive-test-virtualservice-pod
+  name: skydive-test-vs-dr-pod-service
 spec:
   hosts:
   - reviews.prod.svc.cluster.local
@@ -14,7 +14,7 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: skydive-test-virtualservice-pod
+  name: skydive-test-vs-dr-pod-service
   labels:
     app: reviews.prod.svc.cluster.local
     version: v1
@@ -25,10 +25,23 @@ spec:
     ports:
     - containerPort: 80
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: skydive-test-vs-dr-pod-service
+  labels:
+    app: reviews.prod.svc.cluster.local
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: reviews.prod.svc.cluster.local
+---
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
-  name: skydive-test-virtualservice-pod
+  name: skydive-test-vs-dr-pod-service
 spec:
   host: reviews.prod.svc.cluster.local
   subsets:

--- a/tests/istio_test.go
+++ b/tests/istio_test.go
@@ -27,7 +27,6 @@ package tests
 import (
 	"testing"
 
-	"github.com/skydive-project/skydive/graffiti/graph"
 	g "github.com/skydive-project/skydive/gremlin"
 	"github.com/skydive-project/skydive/topology/probes/istio"
 	"github.com/skydive-project/skydive/topology/probes/k8s"
@@ -58,12 +57,8 @@ func TestIstioVirtualServiceNode(t *testing.T) {
 	testNodeCreationFromConfig(t, istio.Manager, "virtualservice", objName+"-virtualservice")
 }
 
-func checkEdgeVirtualService(t *testing.T, c *CheckContext, from, to *graph.Node, edgeArgs ...interface{}) error {
-	return checkEdge(t, c, from, to, "virtualservice", edgeArgs...)
-}
-
-func TestIstioVirtualServicePodScenario(t *testing.T) {
-	file := "virtualservice-pod"
+func TestIstioVirtualServiceDestinationRuleServicePodScenario(t *testing.T) {
+	file := "vs-dr-pod-service"
 	name := objName + "-" + file
 	testRunner(
 		t,
@@ -75,17 +70,38 @@ func TestIstioVirtualServicePodScenario(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				_, err = checkNodeCreation(t, c, istio.Manager, "destinationrule", name)
+
+				destinationrule, err := checkNodeCreation(t, c, istio.Manager, "destinationrule", name)
 				if err != nil {
 					return err
 				}
+
 				pod, err := checkNodeCreation(t, c, k8s.Manager, "pod", name)
 				if err != nil {
 					return err
 				}
-				if err = checkEdgeVirtualService(t, c, virtualservice, pod); err != nil {
+
+				service, err := checkNodeCreation(t, c, k8s.Manager, "service", name)
+				if err != nil {
 					return err
 				}
+
+				if err = checkEdge(t, c, virtualservice, pod, "virtualservice"); err != nil {
+					return err
+				}
+
+				if err = checkEdge(t, c, virtualservice, service, "virtualservice"); err != nil {
+					return err
+				}
+
+				if err = checkEdge(t, c, virtualservice, destinationrule, "virtualservice"); err != nil {
+					return err
+				}
+
+				if err = checkEdge(t, c, destinationrule, service, "destinationrule"); err != nil {
+					return err
+				}
+
 				return nil
 			},
 		},
@@ -105,42 +121,83 @@ func TestBookInfoScenario(t *testing.T) {
 		[]CheckFunction{
 			func(c *CheckContext) error {
 				// check nodes exist
-				_, err := checkNodeCreation(t, c, istio.Manager, "destinationrule", "details")
+				drDetails, err := checkNodeCreation(t, c, istio.Manager, "destinationrule", "details")
 				if err != nil {
 					return err
 				}
 
-				_, err = checkNodeCreation(t, c, istio.Manager, "destinationrule", "productpage")
+				drProductpage, err := checkNodeCreation(t, c, istio.Manager, "destinationrule", "productpage")
 				if err != nil {
 					return err
 				}
 
-				_, err = checkNodeCreation(t, c, istio.Manager, "destinationrule", "ratings")
+				drRatings, err := checkNodeCreation(t, c, istio.Manager, "destinationrule", "ratings")
 				if err != nil {
 					return err
 				}
 
-				_, err = checkNodeCreation(t, c, istio.Manager, "destinationrule", "reviews")
+				drReviews, err := checkNodeCreation(t, c, istio.Manager, "destinationrule", "reviews")
 				if err != nil {
 					return err
 				}
 
-				_, err = checkNodeCreation(t, c, istio.Manager, "gateway", "bookinfo-gateway")
+				vs, err := checkNodeCreation(t, c, istio.Manager, "virtualservice", "bookinfo")
 				if err != nil {
 					return err
 				}
 
-				virtualservice, err := checkNodeCreation(t, c, istio.Manager, "virtualservice", "bookinfo")
+				podProductpage, err := checkNodeCreation(t, c, k8s.Manager, "pod", g.Regex("%s-.*", "productpage"))
 				if err != nil {
 					return err
 				}
 
-				pod, err := checkNodeCreation(t, c, k8s.Manager, "pod", g.Regex("%s-.*", "productpage"))
+				serviceDetails, err := checkNodeCreation(t, c, k8s.Manager, "service", "details")
 				if err != nil {
 					return err
 				}
 
-				if err = checkEdgeVirtualService(t, c, virtualservice, pod); err != nil {
+				serviceProductpage, err := checkNodeCreation(t, c, k8s.Manager, "service", "productpage")
+				if err != nil {
+					return err
+				}
+
+				serviceRatings, err := checkNodeCreation(t, c, k8s.Manager, "service", "ratings")
+				if err != nil {
+					return err
+				}
+
+				serviceReviews, err := checkNodeCreation(t, c, k8s.Manager, "service", "reviews")
+				if err != nil {
+					return err
+				}
+
+				// check edges exist
+
+				if err = checkEdge(t, c, vs, podProductpage, "virtualservice"); err != nil {
+					return err
+				}
+
+				if err = checkEdge(t, c, vs, serviceProductpage, "virtualservice"); err != nil {
+					return err
+				}
+
+				if err = checkEdge(t, c, vs, drProductpage, "virtualservice"); err != nil {
+					return err
+				}
+
+				if err = checkEdge(t, c, drDetails, serviceDetails, "destinationrule"); err != nil {
+					return err
+				}
+
+				if err = checkEdge(t, c, drProductpage, serviceProductpage, "destinationrule"); err != nil {
+					return err
+				}
+
+				if err = checkEdge(t, c, drRatings, serviceRatings, "destinationrule"); err != nil {
+					return err
+				}
+
+				if err = checkEdge(t, c, drReviews, serviceReviews, "destinationrule"); err != nil {
 					return err
 				}
 

--- a/topology/probes/istio/istio.go
+++ b/topology/probes/istio/istio.go
@@ -65,6 +65,9 @@ func NewIstioProbe(g *graph.Graph) (*k8s.Probe, error) {
 
 	linkerHandlers := []k8s.LinkHandler{
 		newVirtualServicePodLinker,
+		newVirtualServiceServiceLinker,
+		newVirtualServiceDestinationRuleLinker,
+		newDestinationRuleServiceLinker,
 	}
 
 	linkers := k8s.InitLinkers(linkerHandlers, g)

--- a/topology/probes/istio/virtualservice.go
+++ b/topology/probes/istio/virtualservice.go
@@ -28,10 +28,9 @@ import (
 	kiali "github.com/kiali/kiali/kubernetes"
 	"github.com/mitchellh/mapstructure"
 	"github.com/skydive-project/skydive/graffiti/graph"
-	"github.com/skydive-project/skydive/logging"
 	"github.com/skydive-project/skydive/probe"
 	"github.com/skydive-project/skydive/topology/probes/k8s"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 )
 
 type virtualServiceHandler struct {
@@ -54,148 +53,93 @@ func newVirtualServiceProbe(client interface{}, g *graph.Graph) k8s.Subprobe {
 	return k8s.NewResourceCache(client.(*kiali.IstioClient).GetIstioNetworkingApi(), &kiali.VirtualService{}, "virtualservices", g, &virtualServiceHandler{})
 }
 
-type virtualServicePodLinker struct {
-	graph      *graph.Graph
-	vsCache    *k8s.ResourceCache
-	podCache   *k8s.ResourceCache
-	vsIndexer  *graph.Indexer
-	podIndexer *graph.Indexer
-}
-
-type virtualServiceInfo struct {
-	App     string `mapstructure:"host"`
-	Version string `mapstructure:"subset"`
-}
-
-func (i *virtualServiceInfo) getIndexerValues() []interface{} {
-	values := []interface{}{i.App}
-	if i.Version != "" {
-		values = append(values, i.Version)
-	}
-	return values
-}
-
 type virtualServiceSpec struct {
 	HTTP []struct {
 		Route []struct {
-			Destination virtualServiceInfo `mapstructure:"destination"`
+			Destination struct {
+				App     string `mapstructure:"host"`
+				Version string `mapstructure:"subset"`
+			} `mapstructure:"destination"`
 		} `mapstructure:"route"`
 	} `mapstructure:"http"`
 }
 
-func getVirtualServiceInfos(vs *kiali.VirtualService) ([]virtualServiceInfo, error) {
-	vsSpec := &virtualServiceSpec{}
-	if err := mapstructure.Decode(vs.Spec, vsSpec); err != nil {
-		return nil, err
-	}
-	var infos []virtualServiceInfo
+func (vsSpec virtualServiceSpec) getAppsVersions() map[string][]string {
+	appsVersions := make(map[string][]string)
 	for _, http := range vsSpec.HTTP {
 		for _, route := range http.Route {
-			infos = append(infos, route.Destination)
+			app := route.Destination.App
+			version := route.Destination.Version
+			appsVersions[app] = append(appsVersions[app], version)
 		}
 	}
-	return infos, nil
+	return appsVersions
 }
 
-func (vspl *virtualServicePodLinker) GetABLinks(vsNode *graph.Node) (edges []*graph.Edge) {
-	vs := vspl.vsCache.GetByNode(vsNode)
-	if vs, ok := vs.(*kiali.VirtualService); ok {
-		infos, _ := getVirtualServiceInfos(vs)
-		for _, info := range infos {
-			podNodes, _ := vspl.podIndexer.Get(info.getIndexerValues()...)
-			for _, podNode := range podNodes {
-				id := graph.GenID(string(vsNode.ID), string(podNode.ID), "RelationType", "virtualservice")
-
-				edge, err := vspl.graph.NewEdge(id, vsNode, podNode, nil, "")
-				if err != nil {
-					logging.GetLogger().Error(err)
-					continue
+func virtualServicePodAreLinked(a, b interface{}) bool {
+	vs := a.(*kiali.VirtualService)
+	pod := b.(*v1.Pod)
+	vsSpec := &virtualServiceSpec{}
+	if err := mapstructure.Decode(vs.Spec, vsSpec); err != nil {
+		return false
+	}
+	vsAppsVersions := vsSpec.getAppsVersions()
+	for app, versions := range vsAppsVersions {
+		if app == pod.Labels["app"] {
+			for _, version := range versions {
+				if version == "" || version == pod.Labels["version"] {
+					return true
 				}
-
-				edges = append(edges, edge)
 			}
 		}
 	}
-	return
+	return false
 }
 
-func (vspl *virtualServicePodLinker) GetBALinks(podNode *graph.Node) (edges []*graph.Edge) {
-	pod := vspl.podCache.GetByNode(podNode)
-	if pod, ok := pod.(*v1.Pod); ok {
-		infoWithVersion := virtualServiceInfo{App: pod.Labels["app"], Version: pod.Labels["version"]}
-		infoWithoutVersion := virtualServiceInfo{App: pod.Labels["app"], Version: ""}
-		vsWithVersionNodes, _ := vspl.vsIndexer.Get(infoWithVersion.getIndexerValues()...)
-		vsWithoutVersionNodes, _ := vspl.vsIndexer.Get(infoWithoutVersion.getIndexerValues()...)
-		vsNodes := append(vsWithVersionNodes, vsWithoutVersionNodes...)
-		for _, vsNode := range vsNodes {
-			id := graph.GenID(string(vsNode.ID), string(podNode.ID), "RelationType", "virtualservice")
-
-			edge, err := vspl.graph.NewEdge(id, vsNode, podNode, nil, "")
-			if err != nil {
-				logging.GetLogger().Error(err)
-				continue
-			}
-
-			edges = append(edges, edge)
+func virtualServiceServiceAreLinked(a, b interface{}) bool {
+	vs := a.(*kiali.VirtualService)
+	service := b.(*v1.Service)
+	vsSpec := &virtualServiceSpec{}
+	if err := mapstructure.Decode(vs.Spec, vsSpec); err != nil {
+		return false
+	}
+	vsAppsVersions := vsSpec.getAppsVersions()
+	for app := range vsAppsVersions {
+		if app == service.Labels["app"] {
+			return true
 		}
 	}
-	return
+	return false
+}
+
+func virtualServiceDestinationRuleAreLinked(a, b interface{}) bool {
+	vs := a.(*kiali.VirtualService)
+	dr := b.(*kiali.DestinationRule)
+	vsSpec := &virtualServiceSpec{}
+	drSpec := &destinationRuleSpec{}
+	if err := mapstructure.Decode(vs.Spec, vsSpec); err != nil {
+		return false
+	}
+	if err := mapstructure.Decode(dr.Spec, drSpec); err != nil {
+		return false
+	}
+	vsAppsVersions := vsSpec.getAppsVersions()
+	for app := range vsAppsVersions {
+		if app == drSpec.App {
+			return true
+		}
+	}
+	return false
 }
 
 func newVirtualServicePodLinker(g *graph.Graph) probe.Probe {
-	vsProbe := k8s.GetSubprobe(Manager, "virtualservice")
-	podProbe := k8s.GetSubprobe("k8s", "pod")
-	if vsProbe == nil || podProbe == nil {
-		return nil
-	}
-	podCache := podProbe.(*k8s.ResourceCache)
-	vsCache := vsProbe.(*k8s.ResourceCache)
+	return k8s.NewABLinker(g, Manager, "virtualservice", k8s.Manager, "pod", virtualServicePodAreLinked)
+}
 
-	podIndexer := graph.NewIndexer(g, podCache, func(n *graph.Node) (kv map[string]interface{}) {
-		if pod := podCache.GetByNode(n); pod != nil {
-			pod := pod.(*v1.Pod)
-			app, version := pod.Labels["app"], pod.Labels["version"]
-			return map[string]interface{}{
-				graph.Hash(app, version): pod,
-				graph.Hash(app):          pod,
-			}
-		}
-		return
-	}, false)
-	podIndexer.Start()
+func newVirtualServiceServiceLinker(g *graph.Graph) probe.Probe {
+	return k8s.NewABLinker(g, Manager, "virtualservice", k8s.Manager, "service", virtualServiceServiceAreLinked)
+}
 
-	vsIndexer := graph.NewIndexer(g, vsCache, func(n *graph.Node) (kv map[string]interface{}) {
-		if vs := vsCache.GetByNode(n); vs != nil {
-			vs := vs.(*kiali.VirtualService)
-			infos, _ := getVirtualServiceInfos(vs)
-			kv = make(map[string]interface{}, len(infos)*2)
-			for _, info := range infos {
-				kv[graph.Hash(info.App, info.Version)] = vs
-				kv[graph.Hash(info.App)] = vs
-			}
-		}
-		return kv
-	}, false)
-	vsIndexer.Start()
-
-	nvspl := graph.NewResourceLinker(
-		g,
-		[]graph.ListenerHandler{vsProbe},
-		[]graph.ListenerHandler{podProbe},
-		&virtualServicePodLinker{
-			graph:      g,
-			vsCache:    vsCache,
-			podCache:   podCache,
-			vsIndexer:  vsIndexer,
-			podIndexer: podIndexer,
-		},
-		k8s.NewEdgeMetadata("istio", "virtualservice"),
-	)
-
-	linker := &k8s.Linker{
-		ResourceLinker: nvspl,
-	}
-	nvspl.AddEventListener(linker)
-
-	return linker
+func newVirtualServiceDestinationRuleLinker(g *graph.Graph) probe.Probe {
+	return k8s.NewABLinker(g, Manager, "virtualservice", Manager, "destinationrule", virtualServiceDestinationRuleAreLinked)
 }


### PR DESCRIPTION
This PR constructs the connections between virtualservice-service, virtualservice-destinationrule and destinationrule-service objects.
The above connections can be tested using the two tests provided.
Based on: #1543 