### PR TITLE
ansible: initial support for podman

### DIFF
--- a/contrib/ansible/roles/skydive_agent/defaults/main.yml
+++ b/contrib/ansible/roles/skydive_agent/defaults/main.yml
@@ -4,3 +4,4 @@ skydive_agent_docker_image: skydive/skydive
 skydive_agent_docker_command: agent
 skydive_agent_docker_image_tag:
 skydive_topology_probes:
+skydive_container_cli: docker

--- a/contrib/ansible/roles/skydive_agent/tasks/container.yml
+++ b/contrib/ansible/roles/skydive_agent/tasks/container.yml
@@ -1,8 +1,8 @@
 ---
-- name: Make the docker image available
+- name: Make the container image available
   include_role:
     name: skydive_common
-    tasks_from: docker
+    tasks_from: container
   vars:
     skydive_docker_image: "{{ skydive_agent_docker_image }}"
     skydive_service_docker_image_tag: "{{ skydive_agent_docker_image_tag }}"
@@ -13,13 +13,15 @@
     tasks_from: systemd
   vars:
     service_name: skydive-agent
-    exec_start_pre: /usr/bin/docker stop skydive-agent-{{ ansible_hostname }}
+    exec_start_pre: /usr/bin/{{ skydive_container_cli }} stop skydive-agent-{{ ansible_hostname }}
     exec_start: |
-      /usr/bin/docker run --rm \
+      /usr/bin/{{ skydive_container_cli }} run --rm \
         --privileged --net=host --pid=host \
         --user 0:0 \
         -v /var/run/openvswitch/db.sock:/var/run/openvswitch/db.sock \
+        {% if skydive_container_cli == 'docker' %}
         -v /var/run/docker.sock:/var/run/docker.sock \
+        {% endif %}
         -v /var/run/netns:/host/run:ro,shared \
         -v /etc/skydive/skydive.yml:/etc/skydive.yml \
         -e SKYDIVE_NETNS_RUN_PATH=/host/run {{ skydive_agent_docker_extra_env }} \
@@ -27,6 +29,6 @@
         --name=skydive-agent-{{ ansible_hostname }} \
         {{ skydive_docker_registry }}/{{ skydive_agent_docker_image }}:{{ skydive_agent_docker_image_tag or skydive_docker_image_tag }} \
         {{ skydive_agent_docker_command }}
-    exec_stop_post: /usr/bin/docker stop skydive-agent-{{ ansible_hostname }}
+    exec_stop_post: /usr/bin/{{ skydive_container_cli }} stop skydive-agent-{{ ansible_hostname }}
     user: root
     group: root

--- a/contrib/ansible/roles/skydive_agent/tasks/main.yml
+++ b/contrib/ansible/roles/skydive_agent/tasks/main.yml
@@ -16,7 +16,7 @@
   tags:
     - config
 
-- include_tasks: docker.yml
+- include_tasks: container.yml
   when: skydive_deployment_mode == "container"
 
 - include_tasks: package.yml

--- a/contrib/ansible/roles/skydive_analyzer/defaults/main.yml
+++ b/contrib/ansible/roles/skydive_analyzer/defaults/main.yml
@@ -34,3 +34,5 @@ skydive_auth_os_domain_id: default
 skydive_auth_os_user_role: admin
 
 skydive_deployment_test: yes
+
+skydive_container_cli: docker

--- a/contrib/ansible/roles/skydive_analyzer/tasks/container.yml
+++ b/contrib/ansible/roles/skydive_analyzer/tasks/container.yml
@@ -1,8 +1,8 @@
 ---
-- name: Make the docker image available
+- name: Make the container image available
   include_role:
     name: skydive_common
-    tasks_from: docker
+    tasks_from: container
   vars:
     skydive_docker_image: "{{ skydive_analyzer_docker_image }}"
     skydive_service_docker_image_tag: "{{ skydive_analyzer_docker_image_tag }}"
@@ -13,9 +13,9 @@
     tasks_from: systemd
   vars:
     service_name: skydive-analyzer
-    exec_start_pre: /usr/bin/docker stop skydive-analyzer-{{ ansible_hostname }}
+    exec_start_pre: /usr/bin/{{ skydive_container_cli }} stop skydive-analyzer-{{ ansible_hostname }}
     exec_start: |
-      /usr/bin/docker run --rm \
+      /usr/bin/{{ skydive_container_cli }} run --rm \
         {{ skydive_analyzer_docker_extra_env }} --name=skydive-analyzer-{{ ansible_hostname }} \
         --net=host \
         --user {{ skydive_sysuser_result.uid }}:{{ skydive_sysuser_result.group }} \
@@ -27,6 +27,6 @@
         -p {{ skydive_etcd_port + 1 }}:{{ skydive_etcd_port + 1 }} \
         {{ skydive_docker_registry }}/{{ skydive_analyzer_docker_image }}:{{ skydive_analyzer_docker_image_tag or skydive_docker_image_tag }} \
         {{ skydive_analyzer_docker_command }}
-    exec_stop_post: /usr/bin/docker stop skydive-analyzer-{{ ansible_hostname }}
+    exec_stop_post: /usr/bin/{{ skydive_container_cli }} stop skydive-analyzer-{{ ansible_hostname }}
     user: root
     group: root

--- a/contrib/ansible/roles/skydive_analyzer/tasks/main.yml
+++ b/contrib/ansible/roles/skydive_analyzer/tasks/main.yml
@@ -31,7 +31,7 @@
   tags:
     - keystone
 
-- include_tasks: docker.yml
+- include_tasks: container.yml
   when: skydive_deployment_mode == "container"
 
 - include_tasks: package.yml

--- a/contrib/ansible/roles/skydive_common/defaults/main.yml
+++ b/contrib/ansible/roles/skydive_common/defaults/main.yml
@@ -28,3 +28,5 @@ skydive_cluster_password: secret
 
 skydive_sys_username: skydive
 skydive_sys_groupname: skydive
+
+skydive_container_cli: docker

--- a/contrib/ansible/roles/skydive_common/tasks/container.yml
+++ b/contrib/ansible/roles/skydive_common/tasks/container.yml
@@ -1,0 +1,45 @@
+---
+- name: "Install {{ skydive_container_cli }}"
+  package:
+    name: "{{ skydive_container_cli }}"
+    state: present
+
+- name: Enable Docker service
+  service:
+    name: docker
+    state: started
+    enabled: yes
+  when: skydive_container_cli == "docker"
+
+- name: Pull skydive image
+  shell: "{{ skydive_container_cli }} pull {{ skydive_docker_registry }}/{{ skydive_docker_image }}:{{ skydive_docker_image_tag }}"
+  when: skydive_load_docker_image is not defined
+
+- name: Run docker registry v2
+  # TODO: run this container in systemd when podman is used, so it can restart on failure.
+  shell: "{{ skydive_container_cli }} run -d -p 5000:5000 {% if skydive_container_cli == 'docker' %}--restart=always{% endif %} --name registry registry:2"
+  when: skydive_load_docker_image is defined
+
+- name: Set facts
+  set_fact: "skydive_docker_registry=localhost:5000"
+  when: skydive_load_docker_image is defined
+
+- name: Copy skydive image
+  copy:
+    src: "{{ skydive_load_docker_image | replace('file://', '') }}"
+    dest: /tmp
+    force: true
+    mode: 0755
+  when: skydive_load_docker_image is defined
+
+- name: Import skydive image
+  shell: "{{ skydive_container_cli }} load -i /tmp/{{ skydive_load_docker_image | replace('file://', '') | basename }}"
+  when: skydive_load_docker_image is defined
+
+- name: Tag skydive image
+  shell: "{{ skydive_container_cli }} tag skydive/skydive:devel {{ skydive_docker_registry }}/{{ skydive_docker_image }}:{{ skydive_docker_image_tag }}"
+  when: skydive_load_docker_image is defined
+
+- name: Push skydive image to registry
+  shell: "{{ skydive_container_cli }} push {{ skydive_docker_registry }}/{{ skydive_docker_image }}:{{ skydive_docker_image_tag }}"
+  when: skydive_load_docker_image is defined

--- a/contrib/ansible/roles/skydive_common/templates/skydive.service.j2
+++ b/contrib/ansible/roles/skydive_common/templates/skydive.service.j2
@@ -1,13 +1,15 @@
 [Unit]
 Description={{ service_name }}
+{% if skydive_container_cli == 'docker' %}
 After=docker.service
+{% endif %}
 
 [Service]
 EnvironmentFile=-/etc/environment
 EnvironmentFile=-/etc/sysconfig/{{ service_name }}
 {% if exec_start_pre is defined %}
 ExecStartPre=-{{ exec_start_pre }}
-ExecStartPre=-/usr/bin/docker rm {{ service_name }}-{{ ansible_hostname }}
+ExecStartPre=-/usr/bin/{{ skydive_container_cli }} rm {{ service_name }}-{{ ansible_hostname }}
 {% endif %}
 ExecStart={{ exec_start }}
 {% if exec_start_post is defined %}

--- a/contrib/ansible/roles/skydive_dev/tasks/docker-ce.yml
+++ b/contrib/ansible/roles/skydive_dev/tasks/docker-ce.yml
@@ -1,0 +1,45 @@
+---
+- package:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+     - docker
+     - docker-client
+     - docker-client-latest
+     - docker-common
+     - docker-latest
+     - docker-latest-logrotate
+     - docker-logrotate
+     - docker-selinux
+     - docker-engine-selinux
+     - docker-engine
+
+- yum_repository:
+    state: present
+    name: docker-ce-stable
+    description: "Docker CE Stable - $basearch"
+    gpgcheck: true
+    gpgkey: https://download.docker.com/linux/fedora/gpg
+    baseurl: "https://download.docker.com/linux/fedora/$releasever/$basearch/stable"
+
+- group:
+    name: docker
+    state: present
+
+- user:
+    name: vagrant
+    groups: docker
+    append: yes
+
+- package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+     - docker-ce
+     - docker-ce-cli
+     - containerd.io
+
+- service:
+    name: docker
+    state: restarted
+    enabled: yes

--- a/contrib/ansible/roles/skydive_dev/tasks/main.yml
+++ b/contrib/ansible/roles/skydive_dev/tasks/main.yml
@@ -57,12 +57,15 @@
      - podman
 
 - service:
-    name: "{{ item }}"
+    name: openvswitch
     state: started
     enabled: yes
-  with_items:
-    - openvswitch
-    - docker
+
+- service:
+    name: docker
+    state: started
+    enabled: yes
+  when: skydive_container_cli == "docker"
 
 - include_tasks: lxd.yml
   when: ansible_distribution == "Fedora" and ansible_architecture == "x86_64"
@@ -76,6 +79,7 @@
     - vagrant
 
 - include_tasks: docker.yml
+  when: skydive_container_cli == "docker"
   tags:
     - vagrant
 

--- a/contrib/ansible/roles/skydive_dev/tasks/main.yml
+++ b/contrib/ansible/roles/skydive_dev/tasks/main.yml
@@ -84,3 +84,5 @@
     - vagrant
 
 - include_tasks: vpp.yml
+
+- include_tasks: virtualbox.yml

--- a/contrib/ansible/roles/skydive_dev/tasks/virtualbox.yml
+++ b/contrib/ansible/roles/skydive_dev/tasks/virtualbox.yml
@@ -1,0 +1,11 @@
+---
+- package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - akmod-VirtualBox
+    - VirtualBox
+    - kernel-devel
+    - "kernel-devel-{{ ansible_kernel }}"
+
+- shell: "akmods --kernels `uname -r`"

--- a/contrib/vagrant/Vagrantfile
+++ b/contrib/vagrant/Vagrantfile
@@ -45,7 +45,7 @@ if DEVMODE then
   # default config from tests/tests.go:testConfig
   $skydive_extra_config["flow.expire"] = "600"
   $skydive_extra_config["flow.update"] = "10"
-  $skydive_extra_config["agent.topology.probes"] = "netlink netns ovsdb docker lldp runc"
+  $skydive_extra_config["agent.topology.probes"] = "netlink netns ovsdb docker lldp runc socketinfo"
   $skydive_extra_config["agent.topology.metrics_update"] = "5"
   $skydive_extra_config["agent.metadata.mydict.value"] = "123"
   $skydive_extra_config["analyzer.startup.capture_gremlin"] = "g.V().Has('Name','startup-vm2')"

--- a/contrib/vagrant/Vagrantfile
+++ b/contrib/vagrant/Vagrantfile
@@ -14,6 +14,8 @@ DEVMODE = ENV.fetch("DEVMODE", "") == "true" ? true : false
 AGENT_EXTRA_PROVISION_SCRIPT=ENV.fetch("AGENT_EXTRA_PROVISION_SCRIPT", "")
 ANALYZER_EXTRA_PROVISION_SCRIPT=ENV.fetch("ANALYZER_EXTRA_PROVISION_SCRIPT", "")
 
+ANSIBLE_EXTRA_CONFIG=ENV.fetch("ANSIBLE_EXTRA_CONFIG", "{}")
+
 $install_agent_deps = <<SCRIPT
 yum -y update centos-release
 yum -y install centos-release-openstack-queens
@@ -34,11 +36,10 @@ yum -y install libpcap libvirt-libs podman libselinux-python bridge-utils net-to
 #lxd init --auto
 SCRIPT
 
-$skydive_extra_config = {
-  "http.ws.pong_timeout" => 10,
-  "agent.topology.probes" => ["ovsdb", "docker"],
-  "agent.topology.netlink.metrics_update" => 5,
-}
+$skydive_extra_config = eval(ANSIBLE_EXTRA_CONFIG)
+$skydive_extra_config["http.ws.pong_timeout"] = 10
+$skydive_extra_config["agent.topology.probes"] = ["ovsdb", "docker"]
+$skydive_extra_config["agent.topology.netlink.metrics_update"] = 5
 
 if DEVMODE then
   # default config from tests/tests.go:testConfig

--- a/scripts/ci/cleanup.sh
+++ b/scripts/ci/cleanup.sh
@@ -62,10 +62,6 @@ EOF
   systemctl restart orientdb
   systemctl restart lxd
 
-  virsh net-destroy vagrant0
-  virsh net-destroy vagrant-libvirt
-  systemctl restart libvirtd
-
   for vm in dev_dev vagrant_analyzer1 vagrant_agent1 devstack_devstack
   do
     virsh destroy $vm
@@ -73,11 +69,16 @@ EOF
     virsh vol-delete $vm.img default
   done
 
+  virsh net-destroy vagrant0
+  virsh net-destroy vagrant-libvirt
+  systemctl restart libvirtd
+
   rm -rf /tmp/skydive_agent* /tmp/skydive-etcd
   rm -rf /var/lib/jenkins/.vagrant.d/tmp
 
   # time to restart services
   sleep 8
+  ip l del virbr0
 }
 
 function snapshot_items() {

--- a/scripts/ci/jobs/jobs.yml
+++ b/scripts/ci/jobs/jobs.yml
@@ -338,11 +338,11 @@
           test: scripts/ci/run-opencontrail-tests.sh
 
 - job:
-    name: 'skydive-functional-tests-backend-elasticsearch'
+    name: skydive-functional-tests-backend-elasticsearch
     defaults: skydive
     triggers:
       - skydive-pull-request:
-          name: "functional-tests-backend-elasticsearch"
+          name: functional-tests-backend-elasticsearch
           trigger-prefix: "(all )?"
           only-trigger-phrase: false
           cancel-builds-on-update: true
@@ -356,11 +356,11 @@
       - chuck-norris
 
 - job:
-    name: 'skydive-functional-tests-backend-orientdb'
+    name: skydive-functional-tests-backend-orientdb
     defaults: skydive
     triggers:
       - skydive-pull-request:
-          name: "functional-tests-backend-orientdb"
+          name: functional-tests-backend-orientdb
           trigger-prefix: "(all )?"
           only-trigger-phrase: false
           cancel-builds-on-update: true
@@ -754,7 +754,7 @@
       - chuck-norris
 
 - job:
-    name: 'skydive-functional-hw-tests'
+    name: skydive-functional-hw-tests
     defaults: skydive
     parameters:
       - skydive-default-parameters
@@ -762,7 +762,7 @@
           slave-name: baremetal
     triggers:
       - skydive-pull-request:
-          name: "functional-tests-ebpf"
+          name: functional-hw-tests
           trigger-prefix: "(all )?"
           only-trigger-phrase: false
           cancel-builds-on-update: true

--- a/scripts/ci/jobs/jobs.yml
+++ b/scripts/ci/jobs/jobs.yml
@@ -542,6 +542,7 @@
           only-trigger-phrase: true
           cancel-builds-on-update: false
     builders:
+      - skydive-cleanup
       - skydive-test:
           test: scripts/ci/run-kolla-tests.sh
     wrappers:
@@ -569,6 +570,7 @@
           only-trigger-phrase: true
           cancel-builds-on-update: false
     builders:
+      - skydive-cleanup
       - skydive-test:
           test: VAGRANT_DEFAULT_PROVIDER=libvirt scripts/ci/run-vagrant-tests.sh
     wrappers:

--- a/scripts/ci/run-vagrant-tests.sh
+++ b/scripts/ci/run-vagrant-tests.sh
@@ -61,7 +61,8 @@ function run_functional_tests {
   if [ "$mode" = "container" ]; then
       OPT="-nooftests"
   fi
-  vagrant ssh agent1 -c "AGENT1_IP=$AGENT1_IP SKYDIVE_ANALYZERS=\"$ANALYZER1_IP:8082\" sudo -E ./functionals -agenttestsonly -test.v $OPT"
+
+  vagrant ssh agent1 -c "AGENT1_IP=$AGENT1_IP SKYDIVE_ANALYZERS=\"$ANALYZER1_IP:8082\" sudo -E ./functionals -analyzer.listen $ANALYZER1_IP:8082 -agenttestsonly -test.v $OPT"
 
   if [ "$mode" = "package" ]; then
       for a in analyzer1 agent1; do
@@ -104,6 +105,7 @@ do
   vagrant ssh analyzer1 -- sudo ntpdate fr.pool.ntp.org
   vagrant ssh agent1 -- sudo ntpdate fr.pool.ntp.org
 
+  export ANSIBLE_EXTRA_CONFIG='{"agent":{"metadata":{"mydict":{"value":123},"myarrays":{"integers":[1,2,3],"bools":[true,true],"strings":["dog","cat","frog"]}}}}'
   DEPLOYMENT_MODE=$mode vagrant provision
 
   vagrant ssh analyzer1 -- sudo cat /etc/skydive/skydive.yml

--- a/statics/workflows/flow-matrix.yaml
+++ b/statics/workflows/flow-matrix.yaml
@@ -259,49 +259,72 @@ Source: |
             var endpoints = buildEndpoints()
             var g = new api.Graph()
 
-            for (var k in endpoints) {
-                var endpoint = endpoints[k]
-                for (var name in endpoint) {
-                    var nodeID = new UUID(5, "ns:URL", k+name).toString();
-                    var metadata = {
-                        "Name": name,
-                        "Type": "service",
-                        "Process": endpoint[name].serviceProcess,
-                        "Port": endpoint[name].servicePort
-                    }
-                    var node = new api.GraphNode()
-                    node.ID = nodeID.toString()
-                    node.Host = k
-                    node.Metadata = metadata
-                    g.nodes[node.ID] = node
-
-                    var edgeID = new UUID(5, "ns:URL", hosts[k].ID+nodeID.toString())
-                    var edge = new api.GraphEdge()
-                    edge.ID = edgeID.toString()
-                    edge.Host = k
-                    edge.Metadata = { "RelationType": "ownership" }
-                    edge.Parent = hosts[k].ID
-                    edge.Child = nodeID.toString()
-                    g.edges[edge.ID] = edge
-                }
-            }
-
             for (var i in matrix) {
                 var entry = matrix[i]
 
-                var parent = new UUID(5, "ns:URL", entry.clientHost+entry.clientName).toString()
-                var child = new UUID(5, "ns:URL", entry.serviceHost+entry.serviceName).toString()
-                var edgeID = new UUID(5, "ns:URL", parent+child)
+                var metadata = {
+                    "Name": entry.serviceName,
+                    "Type": "process",
+                    "ServiceType": "server",
+                    "Process": entry.serviceProcess,
+                    "Ports": []
+                }
 
+                var parentNodeID = new UUID(5, "ns:URL", entry.serviceHost+entry.serviceProcess+"service").toString()
+                if (parentNodeID in g.nodes) {
+                    metadata["Ports"] = g.nodes[parentNodeID].Metadata["Ports"]
+                }
+                if (metadata["Ports"].indexOf(entry.servicePort) == -1) {
+                    metadata["Ports"].push(entry.servicePort)
+                }
+
+                var parentNode = new api.GraphNode()
+                parentNode.ID = parentNodeID
+                parentNode.Host = entry.serviceHost
+                parentNode.Metadata = metadata
+                g.nodes[parentNodeID] = parentNode
+
+                var ownerEdgeID = new UUID(5, "ns:URL", hosts[entry.serviceHost].ID+parentNodeID).toString()
+                var ownerEdge = new api.GraphEdge()
+                ownerEdge.ID = ownerEdgeID
+                ownerEdge.Host = entry.serviceHost
+                ownerEdge.Metadata = { "RelationType": "ownership" }
+                ownerEdge.Parent = hosts[entry.serviceHost].ID
+                ownerEdge.Child = parentNodeID
+                g.edges[ownerEdgeID] = ownerEdge
+
+                var childNodeID = new UUID(5, "ns:URL", entry.clientHost+entry.clientProcess+"client").toString()
+                var metadata = {
+                    "Name": entry.clientName,
+                    "Type": "process",
+                    "ServiceType": "client",
+                    "Process": entry.clientProcess
+                }
+                var childNode = new api.GraphNode()
+                childNode.ID = childNodeID
+                childNode.Host = entry.clientHost
+                childNode.Metadata = metadata
+                g.nodes[childNodeID] = childNode
+
+                ownerEdgeID = new UUID(5, "ns:URL", hosts[entry.clientHost].ID+childNodeID).toString()
+                ownerEdge = new api.GraphEdge()
+                ownerEdge.ID = ownerEdgeID
+                ownerEdge.Host =  entry.clientHost
+                ownerEdge.Metadata = { "RelationType": "ownership" }
+                ownerEdge.Parent = hosts[entry.clientHost].ID
+                ownerEdge.Child = childNodeID
+                g.edges[ownerEdgeID] = ownerEdge
+
+                var edgeID = new UUID(5, "ns:URL", childNodeID+parentNodeID).toString()
                 var edge = new api.GraphEdge()
-                edge.ID = edgeID.toString()
+                edge.ID = edgeID
                 edge.Host = entry.serviceHost
                 edge.Metadata = { "RelationType": "connection",
-                                  "ServicePort": entry.servicePort }
-                edge.Parent = parent
-                edge.Child = child
+                                "Port": entry.servicePort }
+                edge.Parent = childNodeID
+                edge.Child = parentNodeID
 
-                g.edges[edge.ID] = edge
+                g.edges[edgeID] = edge
             }
 
             return g
@@ -309,11 +332,16 @@ Source: |
 
         var outputResult = function() {
             log("Output result in " + format)
-            switch (format) {
-                case "dot":
-                    return outputDot()
-                case "graph":
-                    return outputGraph()
+
+            try {
+                switch (format) {
+                    case "dot":
+                        return outputDot()
+                    case "graph":
+                        return outputGraph()
+                }
+            } catch(error) {
+                log("Error", error)
             }
         }
 

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -93,14 +93,8 @@ agent:
       - lldp0
 
   metadata:
-    info: This is compute node
     mydict:
       value: 123
-      onearray:
-      - name: first
-        value: 1
-      - name: last
-        value: 10
     myarrays:
       integers:
       - 1

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/mitchellh/mapstructure"
 
 	"github.com/skydive-project/skydive/api/types"
@@ -178,7 +179,7 @@ func TestFlowMatrixWorkflow(t *testing.T) {
 			}
 
 			if process == nil {
-				return fmt.Errorf("Expected to find a process named 'functionals' with port %d", sa.Port)
+				return fmt.Errorf("Expected to find a process named 'functionals' with port %d in %s", sa.Port, spew.Sdump(g.Nodes))
 			}
 
 			var connection *graph.Edge

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -19,19 +19,21 @@ package tests
 
 import (
 	"fmt"
+	"net"
 	"testing"
+	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/mitchellh/mapstructure"
 
 	"github.com/skydive-project/skydive/api/types"
 	"github.com/skydive-project/skydive/common"
 	"github.com/skydive-project/skydive/graffiti/graph"
-	"github.com/skydive-project/skydive/http"
+	"github.com/skydive-project/skydive/graffiti/graph/traversal"
+	shttp "github.com/skydive-project/skydive/http"
 	"github.com/skydive-project/skydive/js"
 )
 
-func lookupWorkflow(client *http.CrudClient, name string) (*types.Workflow, error) {
+func lookupWorkflow(client *shttp.CrudClient, name string) (*types.Workflow, error) {
 	var workflows map[string]types.Workflow
 	if err := client.List("workflow", &workflows); err != nil {
 		return nil, err
@@ -111,21 +113,73 @@ func TestCheckMTUWorkflow(t *testing.T) {
 	RunTest(t, test)
 }
 
+func flowMatrixServer(t *testing.T, readyChan chan bool) net.Listener {
+	l, err := net.Listen("tcp", ":22222")
+	if err != nil {
+		t.Fatal(err)
+	}
+	readyChan <- true
+
+	go func() {
+
+		c, err := l.Accept()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for {
+			var buf []byte
+
+			if _, err := c.Write(buf); err != nil {
+				return
+			}
+
+			time.Sleep(100 * time.Millisecond)
+		}
+	}()
+
+	return l
+}
+
+func flowMatrixClient(t *testing.T) {
+	c, err := net.Dial("tcp", "127.0.0.1:22222")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		var buf []byte
+
+		if _, err := c.Read(buf); err != nil {
+			return
+		}
+	}
+}
+
 func TestFlowMatrixWorkflow(t *testing.T) {
 	runtime, err := js.NewRuntime()
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	var l net.Listener
+	readyChan := make(chan bool, 1)
+
 	test := &Test{
 		setupFunction: func(c *TestContext) error {
 			runtime.Start()
 			runtime.RegisterAPIClient(c.client)
 
+			l = flowMatrixServer(t, readyChan)
+			<-readyChan
+
+			go flowMatrixClient(t)
+
 			return nil
 		},
 
 		tearDownFunction: func(c *TestContext) error {
+			l.Close()
+
 			return nil
 		},
 
@@ -140,9 +194,9 @@ func TestFlowMatrixWorkflow(t *testing.T) {
 				return fmt.Errorf("Error while calling workflow: %s", err)
 			}
 
-			g := &struct {
-				Nodes map[string]graph.Node `mapstructure:"nodes"`
-				Edges map[string]graph.Edge `mapstructure:"edges"`
+			subgraph := &struct {
+				Nodes map[string]*graph.Node `mapstructure:"nodes"`
+				Edges map[string]*graph.Edge `mapstructure:"edges"`
 			}{}
 
 			obj, err := result.Export()
@@ -150,7 +204,7 @@ func TestFlowMatrixWorkflow(t *testing.T) {
 				return fmt.Errorf("Failed to export: %s", err)
 			}
 
-			if err := mapstructure.Decode(obj, g); err != nil {
+			if err := mapstructure.Decode(obj, subgraph); err != nil {
 				return fmt.Errorf("Failed to map: %s", err)
 			}
 
@@ -163,37 +217,23 @@ func TestFlowMatrixWorkflow(t *testing.T) {
 				return fmt.Errorf("Expected FlowMatrix workflow to return true")
 			}
 
-			sa, err := common.ServiceAddressFromString(analyzerListen)
-			if err != nil {
-				return err
+			backend, _ := graph.NewMemoryBackend()
+			g := graph.NewGraph("test", backend, common.UnknownService)
+
+			for _, n := range subgraph.Nodes {
+				g.NodeAdded(n)
 			}
 
-			var process *graph.Node
-			for _, n := range g.Nodes {
-				name, _ := n.GetFieldString("Name")
-				port, _ := n.GetFieldInt64("Port")
-				if name == "functionals" && port == int64(sa.Port) {
-					process = &n
-					break
-				}
+			for _, e := range subgraph.Edges {
+				g.EdgeAdded(e)
 			}
 
-			if process == nil {
-				return fmt.Errorf("Expected to find a process named 'functionals' with port %d in %s", sa.Port, spew.Sdump(g.Nodes))
-			}
+			tr := traversal.NewGraphTraversal(g, false)
 
-			var connection *graph.Edge
-			for _, e := range g.Edges {
-				port, _ := e.GetFieldInt64("ServicePort")
-				relationType, _ := e.GetFieldString("RelationType")
-				if e.Parent == process.ID && e.Child == process.ID && port == int64(sa.Port) && relationType == "connection" {
-					connection = &e
-					break
-				}
-			}
-
-			if connection == nil {
-				return fmt.Errorf("Expected to find a connection 'functionals' and itself on port 64500")
+			ctx := traversal.StepContext{}
+			tv := tr.V(ctx).Has(ctx, "Name", "functionals", "ServiceType", "client").OutE(ctx).Has(ctx, "RelationType", "connection", "Port", 22222).OutV(ctx).Has(ctx, "ServiceType", "server", "Name", "functionals")
+			if len(tv.Values()) != 0 {
+				return fmt.Errorf("Should return at least one connection node, returned: %v, graph: %v, subgraph: %v", tv.Values(), g.String(), subgraph)
 			}
 
 			return nil


### PR DESCRIPTION
Background:
libpod aka Podman is library for running OCI-based containers in Pods.
It is likely going to replace Docker in newer versions of RHEL systems,
which means Docker won't be supported in the future.

The CLI is supposed to work like it did with Docker (with some changes);
so this patch is pretty basic. It adds skydive_container_cli variable
(default to docker for backward compatibiility) and replace the
hardcoded "docker" commands by using this variable instead.

Some adjustments were made:
- podman doesn't need docker socket access.
- podman doesn't support --restart natively, we need a systemd service.
- podman doesn't require to have docker started.

Future iterations will be made to support proper SystemD/Podman
integration like it was done in TripleO for other containers:
http://my1.fr/blog/openstack-containerization-with-podman-part-2-operations/

Closes #1517
Signed-off-by: Emilien Macchi <emilien@redhat.com>

skip skydive-go-fmt
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-scale-tests
skip skydive-cdd-overview-tests
skip skydive-unit-tests
skip skydive-compile-tests
skip skydive-k8s-tests
skip skydive-ppc64le-tests
skip skydive-functional-hw-tests