### PR TITLE
Support for multiple interfaces of libvirt domain

### DIFF
--- a/topology/probes/libvirt/libvirt.go
+++ b/topology/probes/libvirt/libvirt.go
@@ -112,7 +112,8 @@ func (probe *Probe) getDomainInterfaces(
 	for _, itf := range d.Interfaces {
 		if constraint == "" || constraint == itf.Alias.Name {
 			itf.Host = domainNode
-			interfaces = append(interfaces, &itf)
+			itfObj := itf
+			interfaces = append(interfaces, &itfObj)
 		}
 	}
 	return


### PR DESCRIPTION
Libvirt Domain has multiple interfaces, but Libvirt Topology Probes
function getDomainInterfaces can only get one of them. Due to the
overlapping of the memory addresses of the loop variable `itf`.

issue: 1522