### PR TITLE
k8s/istio: small refactor to linkers initialization code

### DIFF
--- a/topology/probes/istio/istio.go
+++ b/topology/probes/istio/istio.go
@@ -25,7 +25,6 @@ package istio
 import (
 	"github.com/skydive-project/skydive/config"
 	"github.com/skydive-project/skydive/graffiti/graph"
-	"github.com/skydive-project/skydive/probe"
 	"github.com/skydive-project/skydive/topology/probes/k8s"
 
 	kiali "github.com/kiali/kiali/kubernetes"
@@ -68,12 +67,7 @@ func NewIstioProbe(g *graph.Graph) (*k8s.Probe, error) {
 		newVirtualServicePodLinker,
 	}
 
-	var linkers []probe.Probe
-	for _, linkHandler := range linkerHandlers {
-		if linker := linkHandler(g); linker != nil {
-			linkers = append(linkers, linker)
-		}
-	}
+	linkers := k8s.InitLinkers(linkerHandlers, g)
 
 	probe := k8s.NewProbe(g, Manager, k8s.GetSubprobesMap(Manager), linkers)
 

--- a/topology/probes/k8s/k8s.go
+++ b/topology/probes/k8s/k8s.go
@@ -27,15 +27,11 @@ import (
 
 	"github.com/skydive-project/skydive/config"
 	"github.com/skydive-project/skydive/graffiti/graph"
-	"github.com/skydive-project/skydive/probe"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
-
-// LinkHandler handles links between two k8s or istio objects
-type LinkHandler func(g *graph.Graph) probe.Probe
 
 // NewConfig returns a new Kubernetes configuration object
 func NewConfig(kubeConfig string) (*rest.Config, error) {
@@ -103,12 +99,7 @@ func NewK8sProbe(g *graph.Graph) (*Probe, error) {
 		newServicePodLinker,
 	}
 
-	var linkers []probe.Probe
-	for _, linkHandler := range linkerHandlers {
-		if linker := linkHandler(g); linker != nil {
-			linkers = append(linkers, linker)
-		}
-	}
+	linkers := InitLinkers(linkerHandlers, g)
 
 	probe := NewProbe(g, Manager, subprobes[Manager], linkers)
 

--- a/topology/probes/k8s/probe.go
+++ b/topology/probes/k8s/probe.go
@@ -33,6 +33,19 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 )
 
+// LinkHandler creates a linker
+type LinkHandler func(g *graph.Graph) probe.Probe
+
+// InitLinkers initializes the listed linkers
+func InitLinkers(linkerHandlers []LinkHandler, g *graph.Graph) (linkers []probe.Probe) {
+	for _, handler := range linkerHandlers {
+		if linker := handler(g); linker != nil {
+			linkers = append(linkers, linker)
+		}
+	}
+	return
+}
+
 var subprobes = make(map[string]map[string]Subprobe)
 
 // PutSubprobe puts a new subprobe in the subprobes map


### PR DESCRIPTION
Now individual links can be disabled (as there is no why via Gremlin to do this) and this is required in various demo/productive scenarios.

To test you can disable the node2pod links by using:

```
analyzer:
  topology:
    k8s:
      linkers:
      - container2docker
      - pod2container
      - host2node
      #- node2pod
      - ingress2service
      - networkpolicy2pod
      - service2pod
```
