### PR TITLE
Use 'epel-7-x86_64' mock target to have Golang on CentOS

### DIFF
--- a/analyzer/server.go
+++ b/analyzer/server.go
@@ -225,15 +225,6 @@ func NewServerFromConfig() (*Server, error) {
 	uiServer.AddGlobalVar("interface-metric-keys", (&topology.InterfaceMetric{}).GetFieldKeys())
 	uiServer.AddGlobalVar("probes", config.Get("analyzer.topology.probes"))
 
-	// add decoders for specific metadata keys, this aims to keep the same
-	// object type between the agent and the analyzer
-	// Decoder will be used while unmarshal the metadata
-	graph.NodeMetadataDecoders["RoutingTables"] = netlink.RoutingTablesMetadataDecoder
-	graph.NodeMetadataDecoders["FDB"] = netlink.NeighborMetadataDecoder
-	graph.NodeMetadataDecoders["Neighbors"] = netlink.NeighborMetadataDecoder
-	graph.NodeMetadataDecoders["Metric"] = topology.InterfaceMetricMetadataDecoder
-	graph.NodeMetadataDecoders["LastUpdateMetric"] = topology.InterfaceMetricMetadataDecoder
-
 	persistent, err := newGraphBackendFromConfig(etcdClient)
 	if err != nil {
 		return nil, err
@@ -381,4 +372,15 @@ func ClusterAuthenticationOpts() *shttp.AuthenticationOpts {
 		Password: config.GetString("analyzer.auth.cluster.password"),
 		Cookie:   config.GetStringMapString("http.cookie"),
 	}
+}
+
+func init() {
+	// add decoders for specific metadata keys, this aims to keep the same
+	// object type between the agent and the analyzer
+	// Decoder will be used while unmarshal the metadata
+	graph.NodeMetadataDecoders["RoutingTables"] = netlink.RoutingTablesMetadataDecoder
+	graph.NodeMetadataDecoders["FDB"] = netlink.NeighborMetadataDecoder
+	graph.NodeMetadataDecoders["Neighbors"] = netlink.NeighborMetadataDecoder
+	graph.NodeMetadataDecoders["Metric"] = topology.InterfaceMetricMetadataDecoder
+	graph.NodeMetadataDecoders["LastUpdateMetric"] = topology.InterfaceMetricMetadataDecoder
 }

--- a/config/config.go
+++ b/config/config.go
@@ -88,7 +88,7 @@ func init() {
 	cfg.SetDefault("agent.topology.neutron.region_name", "RegionOne")
 	cfg.SetDefault("agent.topology.neutron.tenant_name", "service")
 	cfg.SetDefault("agent.topology.neutron.username", "neutron")
-	cfg.SetDefault("agent.topology.runc.run_path", []string{"/run/containerd/runc", "/run/runc"})
+	cfg.SetDefault("agent.topology.runc.run_path", []string{"/run/containerd/runc", "/run/runc", "/run/runc-ctrs"})
 	cfg.SetDefault("agent.topology.socketinfo.host_update", 10)
 
 	cfg.SetDefault("analyzer.auth.cluster.backend", "noauth")

--- a/contrib/vagrant/Vagrantfile
+++ b/contrib/vagrant/Vagrantfile
@@ -22,7 +22,7 @@ systemctl start openvswitch
 systemctl start docker
 systemctl enable openvswitch
 systemctl enable docker
-yum -y install libpcap libselinux-python bridge-utils net-tools yum-plugin-copr.noarch
+yum -y install libpcap libvirt-libs podman libselinux-python bridge-utils net-tools yum-plugin-copr.noarch
 #curl -o /etc/yum.repos.d/_copr_ganto-lxc3.repo https://copr.fedorainfracloud.org/coprs/ganto/lxc3/repo/epel-7/ganto-lxc3-epel-7.repo
 #yum repolist
 #yum -y install lxd

--- a/contrib/vagrant/Vagrantfile
+++ b/contrib/vagrant/Vagrantfile
@@ -44,7 +44,7 @@ if DEVMODE then
   # default config from tests/tests.go:testConfig
   $skydive_extra_config["flow.expire"] = "600"
   $skydive_extra_config["flow.update"] = "10"
-  $skydive_extra_config["agent.topology.probes"] = "netlink netns ovsdb docker lldp"
+  $skydive_extra_config["agent.topology.probes"] = "netlink netns ovsdb docker lldp runc"
   $skydive_extra_config["agent.topology.metrics_update"] = "5"
   $skydive_extra_config["agent.metadata.mydict.value"] = "123"
   $skydive_extra_config["analyzer.startup.capture_gremlin"] = "g.V().Has('Name','startup-vm2')"

--- a/scripts/ci/run-packaging-tests.sh
+++ b/scripts/ci/run-packaging-tests.sh
@@ -14,7 +14,7 @@ VERSION=$(make -s version | cut -d '-' -f 1)
 TAG=$(make -s version | cut -d '-' -f 2- | tr '-' '.')
 for srpm in $(ls rpmbuild/SRPMS/skydive-${VERSION}*${TAG}.src.rpm)
 do
-    for root in centos-7-x86_64 epel-7-x86_64 fedora-27-x86_64 fedora-28-x86_64
+    for root in epel-7-x86_64 fedora-27-x86_64 fedora-28-x86_64
     do
         mock -r $root -D "fullver $FULLVER" --rebuild $srpm
     done

--- a/scripts/ci/run-vagrant-tests.sh
+++ b/scripts/ci/run-vagrant-tests.sh
@@ -21,7 +21,7 @@ if [ "$DEVMODE" = "true" ]; then
     make srpm
     VERSION=$(make -s version | cut -d '-' -f 1)
     TAG=$(make -s version | cut -s -d '-' -f 2- | tr '-' '.')
-    mock -r centos-7-x86_64 -D "fullver $(make -s version)" --resultdir . --rebuild rpmbuild/SRPMS/skydive-${VERSION}*${TAG}.src.rpm
+    mock -r epel-7-x86_64 -D "fullver $(make -s version)" --resultdir . --rebuild rpmbuild/SRPMS/skydive-${VERSION}*${TAG}.src.rpm
     mkdir -p rpmbuild/RPMS/{x86_64,noarch}
     mv skydive*-${VERSION}-*${TAG}*.x86_64.rpm rpmbuild/RPMS/x86_64/
     mv skydive*-${VERSION}-*${TAG}*.noarch.rpm rpmbuild/RPMS/noarch/

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -786,15 +786,15 @@ func init() {
 
 	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = 100
 
+	if err := initConfig(testConfig); err != nil {
+		panic(fmt.Sprintf("Failed to initialize config: %s", err))
+	}
+
+	if err := config.InitLogging(); err != nil {
+		panic(fmt.Sprintf("Failed to initialize logging system: %s", err))
+	}
+
 	if standalone {
-		if err := initConfig(testConfig); err != nil {
-			panic(fmt.Sprintf("Failed to initialize config: %s", err))
-		}
-
-		if err := config.InitLogging(); err != nil {
-			panic(fmt.Sprintf("Failed to initialize logging system: %s", err))
-		}
-
 		server, err := analyzer.NewServerFromConfig()
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
skip skydive-go-fmt
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-scale-tests
skip skydive-cdd-overview-tests
skip skydive-unit-tests
skip skydive-compile-tests
skip skydive-k8s-tests
skip skydive-vpp-tests