### PR TITLE
Add Flow life cycle fields

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -872,6 +872,15 @@ func (f *Flow) newTransportLayer(packet *Packet, opts Opts) error {
 		if opts.TCPMetric {
 			f.TCPMetric = &TCPMetric{}
 		}
+
+		if transportPacket.FIN {
+			f.Status = FlowStatus_ENDED
+			f.FinishType = FlowFinishType_TCP_FIN
+		}
+		if transportPacket.RST {
+			f.Status = FlowStatus_ENDED
+			f.FinishType = FlowFinishType_TCP_RST
+		}
 	} else if layer := packet.Layer(layers.LayerTypeUDP); layer != nil {
 		f.Transport = &TransportLayer{Protocol: FlowProtocol_UDP}
 

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -874,11 +874,9 @@ func (f *Flow) newTransportLayer(packet *Packet, opts Opts) error {
 		}
 
 		if transportPacket.FIN {
-			f.Status = FlowStatus_ENDED
 			f.FinishType = FlowFinishType_TCP_FIN
 		}
 		if transportPacket.RST {
-			f.Status = FlowStatus_ENDED
 			f.FinishType = FlowFinishType_TCP_RST
 		}
 	} else if layer := packet.Layer(layers.LayerTypeUDP); layer != nil {

--- a/flow/flow.proto
+++ b/flow/flow.proto
@@ -191,10 +191,8 @@ message Flow {
 /* number of raw packet captured */
   int64 RawPacketsCaptured = 37;
 
-/* counts the number of times this flow was reported */
-  int64 ReportCounter = 60;
 /* describes the way the flow was ended (e.g. by RST, FIN) */
-  FlowFinishType FinishType = 61;
+  FlowFinishType FinishType = 60;
 }
 
 message FlowSet {

--- a/flow/flow.proto
+++ b/flow/flow.proto
@@ -56,9 +56,10 @@ message TransportLayer {
 }
 
 enum FlowFinishType {
-  TIMEOUT = 0;
-  TCP_FIN = 1;
-  TCP_RST = 2;
+  NOT_FINISHED = 0;
+  TIMEOUT = 1;
+  TCP_FIN = 2;
+  TCP_RST = 3;
 }
 
 enum ICMPType {

--- a/flow/flow.proto
+++ b/flow/flow.proto
@@ -55,6 +55,18 @@ message TransportLayer {
   int64 ID = 4;
 }
 
+enum FlowStatus {
+  STARTED = 0;
+  UPDATED = 1;
+  ENDED = 2;
+}
+
+enum FlowFinishType {
+  TIMEOUT = 0;
+  TCP_FIN = 1;
+  TCP_RST = 2;
+}
+
 enum ICMPType {
   UNKNOWN = 0;
   DESTINATION_UNREACHABLE = 1;
@@ -183,6 +195,13 @@ message Flow {
   repeated RawPacket LastRawPackets = 36;
 /* number of raw packet captured */
   int64 RawPacketsCaptured = 37;
+
+/* Flow life cycle status (Started, Updated, Ended) */
+  FlowStatus Status = 60;
+/* counts the number of times this flow was reported */
+  int64 ReportCounter = 61;
+/* describes the way the flow was ended (e.g. by RST, FIN) */
+  FlowFinishType FinishType = 62;
 }
 
 message FlowSet {

--- a/flow/flow.proto
+++ b/flow/flow.proto
@@ -55,12 +55,6 @@ message TransportLayer {
   int64 ID = 4;
 }
 
-enum FlowStatus {
-  STARTED = 0;
-  UPDATED = 1;
-  ENDED = 2;
-}
-
 enum FlowFinishType {
   TIMEOUT = 0;
   TCP_FIN = 1;
@@ -196,12 +190,10 @@ message Flow {
 /* number of raw packet captured */
   int64 RawPacketsCaptured = 37;
 
-/* Flow life cycle status (Started, Updated, Ended) */
-  FlowStatus Status = 60;
 /* counts the number of times this flow was reported */
-  int64 ReportCounter = 61;
+  int64 ReportCounter = 60;
 /* describes the way the flow was ended (e.g. by RST, FIN) */
-  FlowFinishType FinishType = 62;
+  FlowFinishType FinishType = 61;
 }
 
 message FlowSet {

--- a/flow/table.go
+++ b/flow/table.go
@@ -199,7 +199,6 @@ func (ft *Table) expire(expireBefore int64) {
 			}
 
 			logging.GetLogger().Debugf("Expire flow %s Duration %v", f.UUID, duration)
-			f.ReportCounter++
 			f.FinishType = FlowFinishType_TIMEOUT
 			expiredFlows = append(expiredFlows, f)
 
@@ -253,7 +252,6 @@ func (ft *Table) update(updateFrom, updateTime int64) {
 	for k, f := range ft.table {
 		if f.XXX_state.updateVersion > ft.updateVersion {
 			ft.updateMetric(f, updateFrom, updateTime)
-			f.ReportCounter++
 			updatedFlows = append(updatedFlows, f)
 			if f.FinishType != FlowFinishType_NOT_FINISHED {
 				delete(ft.table, k)

--- a/flow/table.go
+++ b/flow/table.go
@@ -255,7 +255,7 @@ func (ft *Table) update(updateFrom, updateTime int64) {
 			ft.updateMetric(f, updateFrom, updateTime)
 			f.ReportCounter++
 			updatedFlows = append(updatedFlows, f)
-			if f.FinishType != "" {
+			if f.FinishType != FlowFinishType_NOT_FINISHED {
 				delete(ft.table, k)
 			}
 		} else {


### PR DESCRIPTION
Per @eranra suggestion, we suggest to add the  following fields to the Flow struct:
1. `Status` - will be one of {started, updated, ended}. (`started` for the first time a flow is reported, `ended` for the last time it is reported (expired or otherwise detected as ended by TCP flags), and `updated` otherwise).
2. `FinishType` for the reason the flow has ended (will be omitempty for cases where flow has not yet ended). Possible values are currently timeout, tcp_rst, tcp_fin. This can be extended to other types.
3. `ReportCounter` counts the number of times a flow has been reported.

I have not yet wrote any unit testing.
Would first like to get your opinion on this: @lebauce @nplanel 

Thanks!