### PR TITLE
k8s: enhance ingress, deploymnet, service linkers

### DIFF
--- a/topology/probes/k8s/cache.go
+++ b/topology/probes/k8s/cache.go
@@ -160,6 +160,17 @@ func matchSelector(obj metav1.Object, selector labels.Selector) bool {
 	return selector.Matches(labels.Set(obj.GetLabels()))
 }
 
+func matchLabelSelector(obj metav1.Object, labelSelector *metav1.LabelSelector) bool {
+	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	return err == nil && selector.Matches(labels.Set(obj.GetLabels()))
+}
+
+func matchMapSelector(obj metav1.Object, mapSelector map[string]string) bool {
+	labelSelector := &metav1.LabelSelector{MatchLabels: mapSelector}
+	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	return err == nil && selector.Matches(labels.Set(obj.GetLabels()))
+}
+
 func filterObjectsBySelector(objects []interface{}, labelSelector *metav1.LabelSelector) (out []metav1.Object) {
 	selector, _ := metav1.LabelSelectorAsSelector(labelSelector)
 	for _, obj := range objects {

--- a/topology/probes/k8s/deployment.go
+++ b/topology/probes/k8s/deployment.go
@@ -26,7 +26,9 @@ import (
 	"fmt"
 
 	"github.com/skydive-project/skydive/graffiti/graph"
+	"github.com/skydive-project/skydive/probe"
 
+	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -54,4 +56,28 @@ func (h *deploymentHandler) Map(obj interface{}) (graph.Identifier, graph.Metada
 
 func newDeploymentProbe(client interface{}, g *graph.Graph) Subprobe {
 	return NewResourceCache(client.(*kubernetes.Clientset).ExtensionsV1beta1().RESTClient(), &v1beta1.Deployment{}, "deployments", g, &deploymentHandler{})
+}
+
+type deploymentPodLinker struct {
+	ABLinker
+}
+
+func deploymentPodAreLinked(a, b interface{}) bool {
+	return matchLabelSelector(b.(*v1.Pod), a.(*v1beta1.Deployment).Spec.Selector)
+}
+
+func newDeploymentPodLinker(g *graph.Graph) probe.Probe {
+	return NewABLinker(g, Manager, "deployment", Manager, "pod", new(deploymentPodLinker), deploymentPodAreLinked)
+}
+
+type deploymentReplicaSetLinker struct {
+	ABLinker
+}
+
+func deploymentReplicaSetAreLinked(a, b interface{}) bool {
+	return matchLabelSelector(b.(*v1beta1.ReplicaSet), a.(*v1beta1.Deployment).Spec.Selector)
+}
+
+func newDeploymentReplicaSetLinker(g *graph.Graph) probe.Probe {
+	return NewABLinker(g, Manager, "deployment", Manager, "replicaset", new(deploymentReplicaSetLinker), deploymentReplicaSetAreLinked)
 }

--- a/topology/probes/k8s/ingress.go
+++ b/topology/probes/k8s/ingress.go
@@ -28,6 +28,7 @@ import (
 	"github.com/skydive-project/skydive/graffiti/graph"
 	"github.com/skydive-project/skydive/probe"
 
+	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -55,6 +56,30 @@ func newIngressProbe(client interface{}, g *graph.Graph) Subprobe {
 	return NewResourceCache(client.(*kubernetes.Clientset).ExtensionsV1beta1().RESTClient(), &v1beta1.Ingress{}, "ingresses", g, &ingressHandler{})
 }
 
+type ingressServiceLinker struct {
+	ABLinker
+}
+
+func ingressServiceAreLinked(a, b interface{}) bool {
+	ingress := a.(*v1beta1.Ingress)
+	service := b.(*v1.Service)
+
+	if ingress.Spec.Backend != nil && ingress.Spec.Backend.ServiceName == service.Name {
+		return true
+	}
+
+	for _, rule := range ingress.Spec.Rules {
+		if rule.HTTP != nil {
+			for _, path := range rule.HTTP.Paths {
+				if path.Backend.ServiceName == service.Name {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
 func newIngressServiceLinker(g *graph.Graph) probe.Probe {
-	return newResourceLinker(g, GetSubprobesMap(Manager), "ingress", MetadataFields("Namespace", "Backend.ServiceName"), "service", MetadataFields("Namespace", "Name"), graph.Metadata{"RelationType": "ingress"})
+	return NewABLinker(g, Manager, "ingress", Manager, "service", new(ingressServiceLinker), ingressServiceAreLinked)
 }

--- a/topology/probes/k8s/k8s.go
+++ b/topology/probes/k8s/k8s.go
@@ -95,11 +95,14 @@ func NewK8sProbe(g *graph.Graph) (*Probe, error) {
 
 	linkerHandlers := []LinkHandler{
 		newContainerDockerLinker,
+		newDeploymentPodLinker,
+		newDeploymentReplicaSetLinker,
 		newPodContainerLinker,
 		newHostNodeLinker,
 		newNodePodLinker,
 		newIngressServiceLinker,
 		newNetworkPolicyLinker,
+		newServiceEndpointsLinker,
 		newServicePodLinker,
 	}
 

--- a/topology/probes/k8s/linker.go
+++ b/topology/probes/k8s/linker.go
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2018 IBM Corp.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package k8s
+
+import (
+	"github.com/skydive-project/skydive/graffiti/graph"
+	"github.com/skydive-project/skydive/logging"
+	"github.com/skydive-project/skydive/probe"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// AreLinked return true if (a, b) should be linked
+type AreLinked func(a, b interface{}) bool
+
+// ABLinker basis for a simple A to B linker
+type ABLinker struct {
+	Manager   string
+	Type      string
+	Graph     *graph.Graph
+	ACache    *ResourceCache
+	BCache    *ResourceCache
+	AreLinked AreLinked
+}
+
+// ABLinkerInterface returns the embbed ABLinker
+type ABLinkerInterface interface {
+	GetABLinker() *ABLinker
+}
+
+// GetABLinker returns inner object
+func (l *ABLinker) GetABLinker() *ABLinker {
+	return l
+}
+
+// NewEdgeMetadata create a new edge metadata
+func (l *ABLinker) NewEdgeMetadata() graph.Metadata {
+	return NewEdgeMetadata(l.Manager, l.Type)
+}
+
+// GenEdgeID generate a new ID for edge
+func (l *ABLinker) GenEdgeID(aNode, bNode *graph.Node) graph.Identifier {
+	return graph.GenID(string(aNode.ID), string(bNode.ID), "RelationType", l.Type)
+}
+
+// AppendNewEdge create and append a new edge to list of edges
+func (l *ABLinker) AppendNewEdge(inputEdges []*graph.Edge, aNode, bNode *graph.Node) []*graph.Edge {
+	i := l.GenEdgeID(aNode, bNode)
+	if l.Graph.GetEdge(i) != nil {
+		return inputEdges
+	}
+	edge, err := l.Graph.NewEdge(i, aNode, bNode, l.NewEdgeMetadata(), "")
+	if err != nil {
+		logging.GetLogger().Error(err)
+		return inputEdges
+	}
+
+	return append(inputEdges, edge)
+}
+
+// GetABLinks implementing graph.Linker
+func (l *ABLinker) GetABLinks(aNode *graph.Node) (edges []*graph.Edge) {
+	namespace, _ := aNode.GetFieldString(MetadataField("Namespace"))
+	if a := l.ACache.GetByNode(aNode); a != nil {
+		for _, b := range l.BCache.getByNamespace(namespace) {
+			uid := b.(metav1.Object).GetUID()
+			if bNode := l.Graph.GetNode(graph.Identifier(uid)); bNode != nil {
+				if l.AreLinked(a, b) {
+					edges = l.AppendNewEdge(edges, aNode, bNode)
+				}
+			}
+		}
+	}
+	return
+}
+
+// GetBALinks implementing graph.Linker
+func (l *ABLinker) GetBALinks(bNode *graph.Node) (edges []*graph.Edge) {
+	namespace, _ := bNode.GetFieldString(MetadataField("Namespace"))
+	if b := l.BCache.GetByNode(bNode); b != nil {
+		for _, a := range l.ACache.getByNamespace(namespace) {
+			uid := a.(metav1.Object).GetUID()
+			if aNode := l.Graph.GetNode(graph.Identifier(uid)); aNode != nil {
+				if l.AreLinked(a, b) {
+					edges = l.AppendNewEdge(edges, aNode, bNode)
+				}
+			}
+		}
+	}
+	return
+}
+
+// NewABLinker create and initialize an ABLinker based linker
+func NewABLinker(g *graph.Graph, aManager, aType, bManager, bType string, outerLinker graph.Linker, areLinked AreLinked) probe.Probe {
+	aProbe := GetSubprobe(aManager, aType)
+	bProbe := GetSubprobe(bManager, bType)
+
+	if aProbe == nil || bProbe == nil {
+		return nil
+	}
+
+	innerLinker := outerLinker.(ABLinkerInterface).GetABLinker()
+	innerLinker.Manager = aManager
+	innerLinker.Type = aType
+	innerLinker.Graph = g
+	innerLinker.ACache = aProbe.(*ResourceCache)
+	innerLinker.BCache = bProbe.(*ResourceCache)
+	innerLinker.AreLinked = areLinked
+
+	rl := graph.NewResourceLinker(
+		g,
+		[]graph.ListenerHandler{aProbe},
+		[]graph.ListenerHandler{bProbe},
+		outerLinker,
+		graph.Metadata{"RelationType": aType},
+	)
+
+	linker := &Linker{
+		ResourceLinker: rl,
+	}
+	rl.AddEventListener(linker)
+
+	return linker
+}

--- a/topology/probes/k8s/service.go
+++ b/topology/probes/k8s/service.go
@@ -26,11 +26,9 @@ import (
 	"fmt"
 
 	"github.com/skydive-project/skydive/graffiti/graph"
-	"github.com/skydive-project/skydive/logging"
 	"github.com/skydive-project/skydive/probe"
 
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -61,78 +59,25 @@ func newServiceProbe(client interface{}, g *graph.Graph) Subprobe {
 }
 
 type servicePodLinker struct {
-	graph        *graph.Graph
-	serviceCache *ResourceCache
-	podCache     *ResourceCache
+	ABLinker
 }
 
-func (spl *servicePodLinker) newEdgeMetadata() graph.Metadata {
-	m := NewEdgeMetadata(Manager, "association")
-	m.SetField("RelationType", "service")
-	return m
-}
-
-func (spl *servicePodLinker) GetABLinks(srvNode *graph.Node) (edges []*graph.Edge) {
-	if srv := spl.serviceCache.GetByNode(srvNode); srv != nil {
-		srv := srv.(*v1.Service)
-		labelSelector := &metav1.LabelSelector{MatchLabels: srv.Spec.Selector}
-		selectedPods := objectsToNodes(spl.graph, spl.podCache.getBySelector(spl.graph, srv.Namespace, labelSelector))
-		metadata := spl.newEdgeMetadata()
-		for _, podNode := range selectedPods {
-			id := graph.GenID(string(srvNode.ID), string(podNode.ID), "RelationType", "service")
-
-			edge, err := spl.graph.NewEdge(id, srvNode, podNode, metadata, "")
-			if err != nil {
-				logging.GetLogger().Error(err)
-				continue
-			}
-
-			edges = append(edges, edge)
-		}
-	}
-	return
-}
-
-func (spl *servicePodLinker) GetBALinks(podNode *graph.Node) (edges []*graph.Edge) {
-	namespace, _ := podNode.GetFieldString(MetadataField("Namespace"))
-	name, _ := podNode.GetFieldString(MetadataField("Name"))
-	pod := spl.podCache.getByKey(namespace, name)
-	for _, srv := range spl.serviceCache.getByNamespace(namespace) {
-		srv := srv.(*v1.Service)
-		labelSelector := &metav1.LabelSelector{MatchLabels: srv.Spec.Selector}
-		if len(filterObjectsBySelector([]interface{}{pod}, labelSelector)) != 1 {
-			continue
-		}
-		if srvNode := spl.graph.GetNode(graph.Identifier(srv.GetUID())); srvNode != nil {
-			edges = append(edges, spl.graph.CreateEdge("", srvNode, podNode, spl.newEdgeMetadata(), graph.TimeUTC(), ""))
-		}
-	}
-	return
+func servicePodAreLinked(a, b interface{}) bool {
+	return matchMapSelector(b.(*v1.Pod), a.(*v1.Service).Spec.Selector)
 }
 
 func newServicePodLinker(g *graph.Graph) probe.Probe {
-	serviceProbe := GetSubprobe(Manager, "service")
-	podProbe := GetSubprobe(Manager, "pod")
-	if serviceProbe == nil || podProbe == nil {
-		return nil
-	}
+	return NewABLinker(g, Manager, "service", Manager, "pod", new(servicePodLinker), servicePodAreLinked)
+}
 
-	rl := graph.NewResourceLinker(
-		g,
-		[]graph.ListenerHandler{serviceProbe},
-		[]graph.ListenerHandler{podProbe},
-		&servicePodLinker{
-			graph:        g,
-			serviceCache: serviceProbe.(*ResourceCache),
-			podCache:     podProbe.(*ResourceCache),
-		},
-		graph.Metadata{"RelationType": "service"},
-	)
+type serviceEndpointsLinker struct {
+	ABLinker
+}
 
-	linker := &Linker{
-		ResourceLinker: rl,
-	}
-	rl.AddEventListener(linker)
+func serviceEndpointsAreLinked(a, b interface{}) bool {
+	return matchMapSelector(b.(*v1.Endpoints), a.(*v1.Service).Spec.Selector)
+}
 
-	return linker
+func newServiceEndpointsLinker(g *graph.Graph) probe.Probe {
+	return NewABLinker(g, Manager, "service", Manager, "endpoints", new(serviceEndpointsLinker), serviceEndpointsAreLinked)
 }


### PR DESCRIPTION
The PR enhanced the following links (improving functionality and simplifying implementation for existing functionality)

- ingress --> service
- deployment --> pod
- deployment --> replicaset
- service --> pod
- service --> endpoints

How to test ?
- degradation - can be tested by running standard k8s integration tests
- new functionality - can be tested by viewing the bookinfo sample via the UI (enhancements to the bookinfo testing, effecting also istio to be done in a separate PR)

 