### PR TITLE
k8s: bookinfo driver script

### DIFF
--- a/tests/bookinfo/bookinfo-networkpolicy-fix.yaml
+++ b/tests/bookinfo/bookinfo-networkpolicy-fix.yaml
@@ -1,0 +1,14 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: reviews-v3
+spec:
+  podSelector:
+    matchLabels:
+      app: reviews
+      version: v3
+  ingress:
+  - from:
+      - podSelector:
+          matchLabels:
+            app: productpage

--- a/tests/bookinfo/bookinfo-networkpolicy.yaml
+++ b/tests/bookinfo/bookinfo-networkpolicy.yaml
@@ -1,0 +1,66 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: details
+spec:
+  podSelector:
+    matchLabels:
+      app: details
+  ingress:
+  - from:
+      - podSelector:
+          matchLabels:
+            app: productpage
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: ratings
+spec:
+  podSelector:
+    matchLabels:
+      app: ratings
+  ingress:
+  - from:
+      - podSelector:
+          matchLabels:
+            app: reviews
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: reviews-v1
+spec:
+  podSelector:
+    matchLabels:
+      app: reviews
+      version: v1
+  ingress:
+  - from:
+      - podSelector:
+          matchLabels:
+            app: productpage
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: reviews-v2
+spec:
+  podSelector:
+    matchLabels:
+      app: reviews
+      version: v2
+  ingress:
+  - from:
+      - podSelector:
+          matchLabels:
+            app: productpage

--- a/tests/bookinfo/bookinfo.sh
+++ b/tests/bookinfo/bookinfo.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+BOOKINFO_URL=https://raw.githubusercontent.com/istio/istio/release-1.0/samples/bookinfo
+
+if [ -z "$NAMESPACE" ]; then
+	NAMESPACE=default
+fi
+echo "export NAMESPACE=$NAMESPACE"
+
+if [ -z "$WITH_ISTIO" ]; then
+	WITH_ISTIO=false
+fi
+echo "export WITH_ISTIO=$WITH_ISTIO"
+
+if [ -z "$WITH_NETPOL_FIX" ]; then
+	WITH_NETPOL_FIX=true
+fi
+echo "export WITH_NETPOL_FIX=$WITH_NETPOL_FIX"
+
+apply() {
+	kubectl apply -n $NAMESPACE -f $1
+}
+
+delete() {
+	kubectl delete --grace-period=0 --force -n $NAMESPACE -f $1
+}
+
+stop() {
+	$WITH_ISTIO && delete $BOOKINFO_URL/networking/destination-rule-all.yaml
+	$WITH_ISTIO && delete $BOOKINFO_URL/networking/bookinfo-gateway.yaml
+	delete $BOOKINFO_URL/platform/kube/bookinfo.yaml
+	delete $BOOKINFO_URL/platform/kube/bookinfo-ingress.yaml
+	delete $SCRIPTDIR/bookinfo-networkpolicy.yaml
+	$WITH_NETPOL_FIX && delete $SCRIPTDIR/bookinfo-networkpolicy-fix.yaml
+
+	kubectl delete namespace $NAMESPACE
+}
+
+start() {
+	kubectl create namespace $NAMESPACE
+
+	$WITH_ISTIO && apply $BOOKINFO_URL/networking/destination-rule-all.yaml
+	$WITH_ISTIO && apply $BOOKINFO_URL/networking/bookinfo-gateway.yaml
+	apply $BOOKINFO_URL/platform/kube/bookinfo.yaml
+	apply $BOOKINFO_URL/platform/kube/bookinfo-ingress.yaml
+	apply $SCRIPTDIR/bookinfo-networkpolicy.yaml
+	$WITH_NETPOL_FIX && apply $SCRIPTDIR/bookinfo-networkpolicy-fix.yaml
+}
+
+case "$1" in
+	stop)
+		stop
+		;;
+	start)
+		start
+		;;
+	*)
+		echo "$0 [stop|start|help]"
+		exit 1
+		;;
+esac
+exit 0

--- a/tests/istio_test.go
+++ b/tests/istio_test.go
@@ -33,10 +33,6 @@ import (
 	"github.com/skydive-project/skydive/topology/probes/k8s"
 )
 
-const (
-	bookinfo = "https://raw.githubusercontent.com/istio/istio/release-1.0/samples/bookinfo"
-)
-
 /* -- test creation of single resource -- */
 func TestIstioDestinationRuleNode(t *testing.T) {
 	testNodeCreationFromConfig(t, istio.Manager, "destinationrule", objName+"-destinationrule")
@@ -100,15 +96,10 @@ func TestBookInfoScenario(t *testing.T) {
 	testRunner(
 		t,
 		[]Cmd{
-			{"kubectl apply -f " + bookinfo + "/networking/destination-rule-all.yaml", true},
-			{"kubectl apply -f " + bookinfo + "/networking/bookinfo-gateway.yaml", true},
-			{"kubectl apply -f " + bookinfo + "/platform/kube/bookinfo.yaml", true},
+			{"./bookinfo/bookinfo.sh start", true},
 		},
 		[]Cmd{
-			{"istioctl delete virtualservice bookinfo", false},
-			{"istioctl delete gateway bookinfo-gateway", false},
-			{"istioctl delete destinationrule details productpage ratings reviews", false},
-			{"kubectl delete deployment details-v1 productpage-v1 ratings-v1 reviews-v1 reviews-v2 reviews-v3", false},
+			{"./bookinfo/bookinfo.sh stop", false},
 		},
 		[]CheckFunction{
 			func(c *CheckContext) error {


### PR DESCRIPTION
add an independent driver script for the bookinfo sample - so it can be re-used by both k8s and istio testing, as well as being used for driving the bookinfo demo.

to run the script:

```
./tests/bookinfo/bookinfo.sh start
```