### PR TITLE
python: add more options to captures

### DIFF
--- a/contrib/python/api/setup.py
+++ b/contrib/python/api/setup.py
@@ -12,7 +12,7 @@ def get_install_requires():
 
 
 setup(name='skydive-client',
-      version='0.4.5',
+      version='0.5.0',
       description='Skydive Python client library',
       url='http://github.com/skydive-project/skydive',
       author='Sylvain Afchain',

--- a/contrib/python/api/skydive/alerts.py
+++ b/contrib/python/api/skydive/alerts.py
@@ -45,6 +45,7 @@ class Alert(object):
             obj["Name"] = self.name
         if self.description:
             obj["Description"] = self.description
+        return obj
 
     @classmethod
     def from_object(self, obj):

--- a/contrib/python/api/skydive/captures.py
+++ b/contrib/python/api/skydive/captures.py
@@ -26,24 +26,46 @@ class Capture(object):
     """
 
     def __init__(self, uuid,  query,
-                 name="", description=""):
+                 name="", description="", count=0,
+                 extra_tcp_metric=False, ip_defrag=False,
+                 reassemble_tcp=False, layer_key_mode="L2"):
         self.uuid = uuid
         self.name = name
         self.description = description
         self.query = query
+        self.count = count
+        self.extra_tcp_metric = extra_tcp_metric
+        self.ip_defrag = ip_defrag
+        self.reassemble_tcp = reassemble_tcp
+        self.layer_key_mode = layer_key_mode
 
     def repr_json(self):
         obj = {
             "UUID": self.uuid,
             "GremlinQuery": self.query,
+            "LayerKeyMode": self.layer_key_mode,
+            "Count": self.count,
         }
         if self.name:
             obj["Name"] = self.name
         if self.description:
             obj["Description"] = self.description
+        if self.extra_tcp_metric:
+            obj["ExtraTCPMetric"] = True
+        if self.ip_defrag:
+            obj["IPDefrag"] = True
+        if self.reassemble_tcp:
+            obj["ReassembleTCP"] = True
+        return obj
 
     @classmethod
     def from_object(self, obj):
         return self(obj["UUID"], obj["GremlinQuery"],
                     name=obj.get("Name"),
-                    description=obj.get("Description"))
+                    description=obj.get("Description"),
+                    count=obj.get("Count"),
+                    extra_tcp_metric=obj.get("ExtraTCPMetric"),
+                    ip_defrag=obj.get("IPDefrag"),
+                    reassemble_tcp=obj.get("ReassembleTCP"),
+                    layer_key_mode=obj.get("LayerKeyMode")
+                    )

--- a/contrib/python/api/skydive/rest/client.py
+++ b/contrib/python/api/skydive/rest/client.py
@@ -119,11 +119,26 @@ class RESTClient:
     def lookup_edges(self, gremlin):
         return self.lookup(gremlin, Edge)
 
-    def capture_create(self, query):
-        data = json.dumps(
-            {"GremlinQuery": query}
-        )
-        c = self.request("/api/capture", method="POST", data=data)
+    def capture_create(self, query, name="", description="",
+                       extra_tcp_metric=False, ip_defrag=False,
+                       reassemble_tcp=False, layer_key_mode="L2"):
+        data = {
+            "GremlinQuery": query,
+            "LayerKeyMode": layer_key_mode,
+        }
+
+        if name:
+            data["Name"] = name
+        if description:
+            data["Description"] = description
+        if extra_tcp_metric:
+            data["ExtraTCPMetric"] = True
+        if ip_defrag:
+            data["IPDefrag"] = True
+        if reassemble_tcp:
+            data["ReassembleTCP"] = True
+
+        c = self.request("/api/capture", method="POST", data=json.dumps(data))
         return Capture.from_object(c)
 
     def capture_list(self):

--- a/contrib/python/api/skydive/rules.py
+++ b/contrib/python/api/skydive/rules.py
@@ -46,6 +46,7 @@ class NodeRule(object):
             obj["Description"] = self.description
         if self.query:
             obj["Query"] = self.query
+        return obj
 
     @classmethod
     def from_object(self, obj):


### PR DESCRIPTION
This aims to provide the full support of the
capture API.

skip skydive-compile-tests
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-go-fmt
skip skydive-k8s-tests
skip skydive-scale-tests
skip skydive-selenium-tests
skip skydive-unit-tests
skip skydive-cdd-overview-tests
skip skydive-ppc64-tests