### PR TITLE
ansible: fix opstools repo installation

### DIFF
--- a/contrib/ansible/roles/skydive_common/tasks/package.yml
+++ b/contrib/ansible/roles/skydive_common/tasks/package.yml
@@ -1,7 +1,11 @@
 ---
+- name: Upgrade all packages
+  yum: name=* state=latest
+  when: ansible_os_family == "RedHat
+
 - name: Install opstools repository
   package:
-    name: https://buildlogs.centos.org/centos/7/opstools/x86_64/common/centos-release-opstools-1-4.el7.noarch.rpm
+    name: centos-release-opstools
     state: present
   when: ansible_distribution == 'CentOS' and skydive_package_location is not defined
 


### PR DESCRIPTION
skip skydive-compile-tests
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-go-fmt
skip skydive-k8s-tests
skip skydive-scale-tests
skip skydive-selenium-tests
skip skydive-unit-tests
skip skydive-cdd-overview-tests
skip skydive-ppc64-tests