### PR TITLE
reconnect/connect to libvirt in the loop

### DIFF
--- a/cmd/allinone/allinone.go
+++ b/cmd/allinone/allinone.go
@@ -134,7 +134,7 @@ var AllInOneCmd = &cobra.Command{
 
 		os.Setenv("SKYDIVE_ANALYZERS", fmt.Sprintf("%s:%d", addr, svcAddr.Port))
 		os.Setenv("SKYDIVE_LOGGING_FILE_PATH", logFile+"-agent"+extension)
-		
+
 		agentAttr := &os.ProcAttr{
 			Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
 			Env:   os.Environ(),


### PR DESCRIPTION
There possible situation when libvirt daemon may be stopped during skydive agent startup
but this is not a reason to fail the libvirt probe initialization

Change-Id: Id948e54af4140173154bd829a9c9a61b59f7a22a
Signed-off-by: Sergey Glazyrin <s.glazyrin@partner.samsung.com>