### PR TITLE
Update OpenShift Template - various changes

### DIFF
--- a/contrib/openshift/README.md
+++ b/contrib/openshift/README.md
@@ -8,6 +8,7 @@ This OpenShift template allows you to instantiate skydive in OpenShift.
 
 ```
 oc adm new-project --node-selector='' skydive
+oc project skydive
 ```
 
 ####  Skype analyzer and agent need  extended  privileges

--- a/contrib/openshift/README.md
+++ b/contrib/openshift/README.md
@@ -10,12 +10,12 @@ This OpenShift template allows you to instantiate skydive in OpenShift.
 oc adm new-project --node-selector='' skydive
 ```
 
-####  Skype analyser and agent need  extended  privileges
+####  Skype analyzer and agent need  extended  privileges
 
 ```
-# analyser and agen run as privileged container
+# analyzer and agent run as privileged container
 oc adm policy add-scc-to-user privileged -z default
-# analyser need cluster-reader access get all informations from the cluster
+# analyzer need cluster-reader access get all informations from the cluster
 oc adm policy add-cluster-role-to-user cluster-reader -z default
 ```
 

--- a/contrib/openshift/README.md
+++ b/contrib/openshift/README.md
@@ -24,7 +24,7 @@ oc adm policy add-cluster-role-to-user cluster-reader -z default
 
 ```
 # adjust VERSION for the current version - for example: v0.20.1 or master
-VERSION=v0.21.0
+VERSION=master
 oc process -f https://raw.githubusercontent.com/skydive-project/skydive/${VERSION}/contrib/openshift/skydive-template.yaml | oc apply -f -
 ```
 

--- a/contrib/openshift/README.md
+++ b/contrib/openshift/README.md
@@ -16,10 +16,13 @@ VERSION=v0.20.1
 oc create -f https://raw.githubusercontent.com/skydive-project/skydive/${VERSION}/contrib/openshift/skydive-template.yaml
 ```
 
-You need the DeploymentConfig to run in privileged:
+Skype analyser and agent need  extended  privileges
 
 ```
-oc adm policy add-scc-to-user privileged system:serviceaccount:skydive:default
+# analyser and agen run as privileged container
+oc adm policy add-scc-to-user privileged -z default
+# analyser need cluster-reader access get all informations from the cluster
+oc adm policy add-cluster-role-to-user cluster-reader -z default
 ```
 
 Instanciate the template:

--- a/contrib/openshift/README.md
+++ b/contrib/openshift/README.md
@@ -1,22 +1,16 @@
 # OpenShift template for skydive agent
 
-This OpenShift template allows you to instantiate skydive in OpenShift.
+This OpenShift template allows you to instantiate skydive in OpenShift. 
 
-Assuming you work on project skydive:
+**Important**: For Skydive installation you need cluster-admin privileges. During the installation you have to grant same privileges to skydive.
 
-```
-oc new-project skydive
-```
-
-Install the template
+#### Create a new project with an empty node selector to asume that Skydive runs on all nodes. 
 
 ```
-# adjust VERSION for the current version - for example: v0.20.1 or master
-VERSION=v0.20.1
-oc create -f https://raw.githubusercontent.com/skydive-project/skydive/${VERSION}/contrib/openshift/skydive-template.yaml
+oc adm new-project --node-selector='' skydive
 ```
 
-Skype analyser and agent need  extended  privileges
+####  Skype analyser and agent need  extended  privileges
 
 ```
 # analyser and agen run as privileged container
@@ -25,31 +19,31 @@ oc adm policy add-scc-to-user privileged -z default
 oc adm policy add-cluster-role-to-user cluster-reader -z default
 ```
 
-Instanciate the template:
+
+####  Install from OpenShift template
 
 ```
-oc new-app --template=skydive
+# adjust VERSION for the current version - for example: v0.20.1 or master
+VERSION=v0.20.1
+oc process -f https://raw.githubusercontent.com/skydive-project/skydive/${VERSION}/contrib/openshift/skydive-template.yaml | oc apply -f -
 ```
 
-Check that everything is working and created:
+#### Check that everything is working and created:
+
+ - Overall status: `oc status`
+ - List all pods: `oc get pods`
+ - List all daemonsets: `oc get daemonset`
+
+# Installation parameters
+
+The skydive template provide some installation 
 
 ```
-oc get pods
-oc get ds
+$ VERSION=v0.20.1
+$ oc process --parameters -f https://raw.githubusercontent.com/skydive-project/skydive/${VERSION}/contrib/openshift/skydive-template.yaml
+NAME                    DESCRIPTION                              GENERATOR           VALUE
+SKYDIVE_LOGGING_LEVEL   Loglevel of Skydive agent and analyzer                       INFO
+
+# Installation with loglevel debug:
+$ oc process --param=SKYDIVE_LOGGING_LEVEL=DEBUG -f https://raw.githubusercontent.com/skydive-project/skydive/${VERSION}/contrib/openshift/skydive-template.yaml  | oc apply -f -
 ```
-
-Expose your route:
-
-```
-oc delete route skydive-analyzer
-oc expose svc skydive-analyzer
-```
-
-# FAQ
-
-## How to deploy the skydive agent on all nodes
-
-The current template only deploys the skydive agents to default compute nodes with selectors in `osm_default_node_selector` or in  `_openshift_node_group_name_` as there is no **node-selector** defined in the `skydive-template.yaml`.
-You can execute the command below to add the skydive agent to the other nodes.
-
-`oc patch namespace skydive -p '{"metadata": {"annotations": {"openshift.io/node-selector": ""}}}'`

--- a/contrib/openshift/README.md
+++ b/contrib/openshift/README.md
@@ -24,7 +24,7 @@ oc adm policy add-cluster-role-to-user cluster-reader -z default
 
 ```
 # adjust VERSION for the current version - for example: v0.20.1 or master
-VERSION=v0.20.1
+VERSION=v0.21.0
 oc process -f https://raw.githubusercontent.com/skydive-project/skydive/${VERSION}/contrib/openshift/skydive-template.yaml | oc apply -f -
 ```
 
@@ -33,6 +33,7 @@ oc process -f https://raw.githubusercontent.com/skydive-project/skydive/${VERSIO
  - Overall status: `oc status`
  - List all pods: `oc get pods`
  - List all daemonsets: `oc get daemonset`
+ - List all routes: `oc get routes`
 
 # Installation parameters
 

--- a/contrib/openshift/README.md
+++ b/contrib/openshift/README.md
@@ -11,7 +11,9 @@ oc new-project skydive
 Install the template
 
 ```
-oc create -f skydive-template.yaml
+# adjust VERSION for the current version - for example: v0.20.1 or master
+VERSION=v0.20.1
+oc create -f https://raw.githubusercontent.com/skydive-project/skydive/${VERSION}/contrib/openshift/skydive-template.yaml
 ```
 
 You need the DeploymentConfig to run in privileged:

--- a/contrib/openshift/skydive-template.yaml
+++ b/contrib/openshift/skydive-template.yaml
@@ -163,7 +163,7 @@ objects:
           - name: SKYDIVE_AGENT_TOPOLOGY_PROBES
             value: "ovsdb runc docker"
           - name: SKYDIVE_RUNC_PATH
-            value: "/run/containerd/runc /var/run/runc /var/run/runc-ctrs"
+            value: "/run/containerd/runc /run/runc /run/runc-ctrs"
           image: skydive/skydive
           imagePullPolicy: Always
           name: skydive-agent
@@ -174,15 +174,15 @@ objects:
           securityContext:
             privileged: true
           volumeMounts:
-          - mountPath: /var/run/docker.sock
+          - mountPath: /run/docker.sock
             name: docker
-          - mountPath: /var/run/netns
+          - mountPath: /run/netns
             name: netns
-          - mountPath: /var/run/openvswitch/db.sock
+          - mountPath: /run/openvswitch/db.sock
             name: ovsdb
-          - mountPath: /var/run/runc
+          - mountPath: /run/runc
             name: runc
-          - mountPath: /var/run/runc-ctrs
+          - mountPath: /run/runc-ctrs
             name: runc-ctrs
           - mountPath: /run/containerd/runc
             name: containerd-runc
@@ -193,22 +193,22 @@ objects:
         terminationGracePeriodSeconds: 30
         volumes:
         - hostPath:
-            path: /var/run/docker.sock
+            path: /run/docker.sock
           name: docker
         - hostPath:
-            path: /var/run/netns
+            path: /run/netns
           name: netns
         - hostPath:
-            path: /var/run/runc
+            path: /run/runc
           name: runc
         - hostPath:
-            path: /var/run/runc-ctrs
+            path: /run/runc-ctrs
           name: runc-ctrs
         - hostPath:
             path: /run/containerd/runc
           name: containerd-runc
         - hostPath:
-            path: /var/run/openvswitch/db.sock
+            path: /run/openvswitch/db.sock
           name: ovsdb
 - apiVersion: v1
   kind: Route

--- a/contrib/openshift/skydive-template.yaml
+++ b/contrib/openshift/skydive-template.yaml
@@ -69,7 +69,9 @@ objects:
           - name: SKYDIVE_ANALYZER_TOPOLOGY_BACKEND
             value: elasticsearch
           - name: SKYDIVE_ANALYZER_TOPOLOGY_PROBES
-            value: k8s
+            value: ${SKYDIVE_ANALYZER_TOPOLOGY_PROBES}
+          - name: SKYDIVE_ANALYZER_TOPOLOGY_K8S_PROBES
+            value: ${SKYDIVE_ANALYZER_TOPOLOGY_K8S_PROBES}
           - name: SKYDIVE_ETCD_LISTEN
             value: 0.0.0.0:12379
           - name: SKYDIVE_LOGGING_LEVEL
@@ -230,3 +232,13 @@ parameters:
   name: SKYDIVE_LOGGING_LEVEL
   required: true
   value: INFO
+- description: Topology probes for anaylyser, default is empty. Add 'k8s' to add k8s/openshift objects to skydive
+  displayName: Analyzer topology probes
+  name: SKYDIVE_ANALYZER_TOPOLOGY_PROBES
+  required: false
+  value: ""
+- description: Probes for k8s/openshift, default is empty. If you only want same objects add those objects, for examples "cluster service pod node"
+  displayName: K8s/OpenShift probes
+  name: SKYDIVE_ANALYZER_TOPOLOGY_K8S_PROBES
+  required: false
+  value: ""

--- a/contrib/openshift/skydive-template.yaml
+++ b/contrib/openshift/skydive-template.yaml
@@ -72,6 +72,8 @@ objects:
             value: k8s
           - name: SKYDIVE_ETCD_LISTEN
             value: 0.0.0.0:12379
+          - name: SKYDIVE_LOGGING_LEVEL
+            value: ${SKYDIVE_LOGGING_LEVEL}
           image: skydive/skydive
           imagePullPolicy: Always
           livenessProbe:
@@ -155,7 +157,7 @@ objects:
           - name: SKYDIVE_ANALYZERS
             value: $(SKYDIVE_ANALYZER_SERVICE_HOST):$(SKYDIVE_ANALYZER_SERVICE_PORT_API)
           - name: SKYDIVE_LOGGING_LEVEL
-            value: DEBUG
+            value: ${SKYDIVE_LOGGING_LEVEL}
           - name: SKYDIVE_AGENT_TOPOLOGY_PROBES
             value: "ovsdb runc docker"
           - name: SKYDIVE_RUNC_PATH
@@ -217,3 +219,9 @@ objects:
       name: skydive-analyzer
       weight: 100
     wildcardPolicy: None
+parameters:
+- description: Loglevel of Skydive agent and analyzer
+  displayName: Loglevel
+  name: SKYDIVE_LOGGING_LEVEL
+  required: true
+  value: INFO

--- a/contrib/openshift/skydive-template.yaml
+++ b/contrib/openshift/skydive-template.yaml
@@ -220,6 +220,8 @@ objects:
   spec:
     port:
       targetPort: api
+    tls:
+      termination: edge
     to:
       kind: Service
       name: skydive-analyzer

--- a/contrib/openshift/skydive-template.yaml
+++ b/contrib/openshift/skydive-template.yaml
@@ -12,7 +12,7 @@ objects:
   data:
     SKYDIVE_ANALYZER_FLOW_BACKEND: elasticsearch
     SKYDIVE_ANALYZER_TOPOLOGY_BACKEND: elasticsearch
-    SKYDIVE_ANALYZER_TOPOLOGY_PROBES: ""
+    SKYDIVE_ANALYZER_TOPOLOGY_PROBES: "k8s"
     SKYDIVE_ETCD_LISTEN: 0.0.0.0:12379
 - apiVersion: v1
   kind: Service

--- a/contrib/openshift/skydive-template.yaml
+++ b/contrib/openshift/skydive-template.yaml
@@ -4,17 +4,6 @@ metadata:
   name: skydive
 objects:
 - apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    labels:
-      app: skydive-analyzer
-    name: skydive-analyzer-config
-  data:
-    SKYDIVE_ANALYZER_FLOW_BACKEND: elasticsearch
-    SKYDIVE_ANALYZER_TOPOLOGY_BACKEND: elasticsearch
-    SKYDIVE_ANALYZER_TOPOLOGY_PROBES: "k8s"
-    SKYDIVE_ETCD_LISTEN: 0.0.0.0:12379
-- apiVersion: v1
   kind: Service
   metadata:
     labels:
@@ -74,9 +63,15 @@ objects:
         - args:
           - analyzer
           - --listen=0.0.0.0:8082
-          envFrom:
-          - configMapRef:
-              name: skydive-analyzer-config
+          env:
+          - name: SKYDIVE_ANALYZER_FLOW_BACKEND
+            value: elasticsearch
+          - name: SKYDIVE_ANALYZER_TOPOLOGY_BACKEND
+            value: elasticsearch
+          - name: SKYDIVE_ANALYZER_TOPOLOGY_PROBES
+            value: k8s
+          - name: SKYDIVE_ETCD_LISTEN
+            value: 0.0.0.0:12379
           image: skydive/skydive
           imagePullPolicy: Always
           livenessProbe:

--- a/contrib/openshift/skydive-template.yaml
+++ b/contrib/openshift/skydive-template.yaml
@@ -182,6 +182,8 @@ objects:
             name: runc
           - mountPath: /var/run/runc-ctrs
             name: runc-ctrs
+          - mountPath: /run/containerd/runc
+            name: containerd-runc
         dnsPolicy: ClusterFirst
         hostNetwork: true
         hostPID: true
@@ -200,6 +202,9 @@ objects:
         - hostPath:
             path: /var/run/runc-ctrs
           name: runc-ctrs
+        - hostPath:
+            path: /run/containerd/runc
+          name: containerd-runc
         - hostPath:
             path: /var/run/openvswitch/db.sock
           name: ovsdb

--- a/contrib/openshift/skydive-template.yaml
+++ b/contrib/openshift/skydive-template.yaml
@@ -15,14 +15,6 @@ objects:
     SKYDIVE_ANALYZER_TOPOLOGY_PROBES: ""
     SKYDIVE_ETCD_LISTEN: 0.0.0.0:12379
 - apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    labels:
-      app: skydive-agent
-    name: skydive-agent-config
-  data:
-    SKYDIVE_AGENT_TOPOLOGY_PROBES: "ovsdb runc docker"
-- apiVersion: v1
   kind: Service
   metadata:
     labels:
@@ -167,9 +159,12 @@ objects:
           env:
           - name: SKYDIVE_ANALYZERS
             value: $(SKYDIVE_ANALYZER_SERVICE_HOST):$(SKYDIVE_ANALYZER_SERVICE_PORT_API)
-          envFrom:
-          - configMapRef:
-              name: skydive-agent-config
+          - name: SKYDIVE_LOGGING_LEVEL
+            value: DEBUG
+          - name: SKYDIVE_AGENT_TOPOLOGY_PROBES
+            value: "ovsdb runc docker"
+          - name: SKYDIVE_RUNC_PATH
+            value: "/run/containerd/runc /var/run/runc /var/run/runc-ctrs"
           image: skydive/skydive
           imagePullPolicy: Always
           name: skydive-agent
@@ -182,8 +177,8 @@ objects:
           volumeMounts:
           - mountPath: /var/run/docker.sock
             name: docker
-          - mountPath: /host/run
-            name: run
+          - mountPath: /var/run/netns
+            name: netns
           - mountPath: /var/run/openvswitch/db.sock
             name: ovsdb
           - mountPath: /var/run/runc
@@ -201,12 +196,12 @@ objects:
           name: docker
         - hostPath:
             path: /var/run/netns
-          name: run
+          name: netns
         - hostPath:
-            path: /run/runc
+            path: /var/run/runc
           name: runc
         - hostPath:
-            path: /run/runc-ctrs
+            path: /var/run/runc-ctrs
           name: runc-ctrs
         - hostPath:
             path: /var/run/openvswitch/db.sock

--- a/contrib/openshift/skydive-template.yaml
+++ b/contrib/openshift/skydive-template.yaml
@@ -237,7 +237,7 @@ parameters:
   name: SKYDIVE_ANALYZER_TOPOLOGY_PROBES
   required: false
   value: ""
-- description: Probes for k8s/openshift, default is empty. If you only want same objects add those objects, for examples "cluster service pod node"
+- description: Probes for k8s/openshift, default is empty. If you only want same objects add those objects, for examples "namespace cluster service pod node"
   displayName: K8s/OpenShift probes
   name: SKYDIVE_ANALYZER_TOPOLOGY_K8S_PROBES
   required: false


### PR DESCRIPTION
Hi folks,

after deploying & playing  with Skydive on OpenShift Container Platform and ran into Issue #1391 here some improvements for skydive on OpenShift:

 - Change installation process to use git URL's instead of files. You don't have to clone the repo for an installation.
 - OpenShift provides per default SSL encryption, so change the route from HTTP to HTTPS
 - Add k8s analyser probe - inspired from pull request #1419 with some cleanups
 - Cleanup Skydive configuration, idea is use only environment variables on one place for analyser and agent.
     - Removed the configmap, from my point of view config map make only sense if you share the same configurations to many other objects, with skydive that is not the case. Analyser and agent has it own config map.
    - Additional for the agend deploymentconfig you some benefits to add the environment variables direct to the deploymentconfig:
        - If you change the config, the configchangetrigger redeploy
   skydive-analyzer with the new configuration
        - The configuration is versioned between different deployments
        - You can easily rollback to an old configuration
 - Parameterize OpenShift template - add the possibility  to set loglevel add installation process
 - Cleanup README

Let's discuss the changes, hope it helps to improve the skydive installation on openshift.

Thanks
Robert

