### PR TITLE
bookinfo: add support for ibmcloud

### DIFF
--- a/tests/bookinfo/bookinfo-ibmcloud-image-policy.yaml
+++ b/tests/bookinfo/bookinfo-ibmcloud-image-policy.yaml
@@ -1,0 +1,9 @@
+apiVersion: securityenforcement.admission.cloud.ibm.com/v1beta1
+kind: ImagePolicy
+metadata:
+  name: ibmcloud-image-policy
+spec:
+   repositories:
+    # This policy allows all images to be deployed into this namespace.
+    - name: "*"
+      policy:

--- a/tests/bookinfo/bookinfo.sh
+++ b/tests/bookinfo/bookinfo.sh
@@ -12,6 +12,9 @@ echo "export WITH_ISTIO=$WITH_ISTIO"
 [ -z "$WITH_NETPOL" ] && WITH_NETPOL=false
 echo "export WITH_NETPOL=$WITH_NETPOL"
 
+[ -z "$WITH_IBMCLOUD" ] && WITH_IBMCLOUD=false
+echo "export WITH_IBMCLOUD=$WITH_IBMCLOUD"
+
 [ -z "$SRVNAME" ] && SRVNAME=productpage
 echo "export SRVNAME=$SRVNAME"
 
@@ -30,6 +33,7 @@ delete() {
 }
 
 bookinfo() {
+	$WITH_IBMCLOUD && $1 $SCRIPTDIR/*ibmcloud*.yaml
 	$WITH_ISTIO && $1 $BOOKINFO_URL/networking/destination-rule-all.yaml
 	$WITH_ISTIO && $1 $BOOKINFO_URL/networking/bookinfo-gateway.yaml
 	$1 $BOOKINFO_URL/platform/kube/bookinfo.yaml


### PR DESCRIPTION
This was tested on IBMCloud here is the output:

```
$ ./bookinfo.sh start
export NAMESPACE=bookinfo
export WITH_ISTIO=false
export WITH_NETPOL=true
export WITH_IBMCLOUD=true
export SRVNAME=productpage
Error from server (AlreadyExists): namespaces "bookinfo" already exists
imagepolicy.securityenforcement.admission.cloud.ibm.com/ibmcloud-image-policy created
service/details unchanged
deployment.extensions/details-v1 unchanged
service/ratings unchanged
deployment.extensions/ratings-v1 unchanged
service/reviews unchanged
deployment.extensions/reviews-v1 unchanged
deployment.extensions/reviews-v2 unchanged
deployment.extensions/reviews-v3 unchanged
service/productpage unchanged
deployment.extensions/productpage-v1 unchanged
ingress.extensions/gateway unchanged
networkpolicy.networking.k8s.io/deny created
networkpolicy.networking.k8s.io/details created
networkpolicy.networking.k8s.io/ratings created
networkpolicy.networking.k8s.io/reviews-v1 created
networkpolicy.networking.k8s.io/reviews-v2 created
networkpolicy.networking.k8s.io/reviews-v3 created
```