### PR TITLE
gremlin: dedup, hash a node even if not having a key

### DIFF
--- a/graffiti/graph/traversal/traversal.go
+++ b/graffiti/graph/traversal/traversal.go
@@ -922,7 +922,6 @@ func (tv *GraphTraversalV) Dedup(ctx StepContext, s ...interface{}) *GraphTraver
 	tv.GraphTraversal.RLock()
 	defer tv.GraphTraversal.RUnlock()
 
-nodeLoop:
 	for _, n := range tv.nodes {
 		if it.Done() {
 			break
@@ -932,15 +931,10 @@ nodeLoop:
 		if len(keys) != 0 {
 			values := make([]interface{}, len(keys))
 			for i, key := range keys {
-				v, err := n.GetField(key)
-				if err != nil {
-					continue nodeLoop
-				}
-				values[i] = v
+				values[i], _ = n.GetField(key)
 			}
 
-			kvisited, err = hashstructure.Hash(values, nil)
-			if err != nil {
+			if kvisited, err = hashstructure.Hash(values, nil); err != nil {
 				skip = true
 			}
 		} else {

--- a/graffiti/graph/traversal/traversal_test.go
+++ b/graffiti/graph/traversal/traversal_test.go
@@ -631,8 +631,8 @@ func TestTraversalParser(t *testing.T) {
 	// next traversal test
 	query = `G.V().Dedup("Type")`
 	res = execTraversalQuery(t, g, query)
-	if len(res.Values()) != 1 {
-		t.Fatalf("Should return 1 nodes, returned: %v", res.Values())
+	if len(res.Values()) != 2 {
+		t.Fatalf("Should return 2 nodes, returned: %v", res.Values())
 	}
 
 	// next traversal test


### PR DESCRIPTION
It is useful in case like following

Dedup('LastUpdateMetric.Start', 'SFlow.LastUpdateMetric.Start')

In such case some of the nodes have either LastUpdateMetric
and some other have SFlow.LastUpdateMetric.