### PR TITLE
topologyrule: Allow all the relation type

### DIFF
--- a/statics/js/components/edgerule-form.js
+++ b/statics/js/components/edgerule-form.js
@@ -28,12 +28,12 @@ Vue.component('edgerule-form', {
         </div>\
         <div class="form-group">\
           <label for="type">Relationship type</label>\
-          <select id="type" v-model="type" class="form-control custom-select">\
-            <option disabled value="">Select Relationship type</option>\
-            <option value="layer2">Layer 2</option>\
-            <option value="ownership">Ownership</option>\
-            <option value="both">Both (ownership & layer2)</option>\
-          </select>\
+          <input list="relation-types" id="type" type="text" v-model="type" class="form-control input-sm">\
+          </input>\
+          <datalist id="relation-types">\
+            <option value="layer2">\
+            <option value="ownership">\
+          </datalist>\
         </div>\
         <div class="form-group">\
           <label for="metadata">Metadata</label>\

--- a/tests/topology_test.go
+++ b/tests/topology_test.go
@@ -775,6 +775,7 @@ func TestEdgeRuleCreate(t *testing.T) {
 		setupCmds: []Cmd{
 			{"ovs-vsctl add-br br-srcnode", true},
 			{"ovs-vsctl add-br br-dstnode", true},
+			{"sleep 5", false},
 		},
 
 		setupFunction: func(c *TestContext) error {
@@ -799,7 +800,7 @@ func TestEdgeRuleCreate(t *testing.T) {
 				query = query.BothE().Has("RelationType", "layer2")
 				query = query.BothV().Has("Name", "br-dstnode", "Type", "ovsbridge")
 				if _, err := c.gh.GetNode(query); err != nil {
-					return errors.New("Failed to find a layer2 link")
+					return fmt.Errorf("Failed to find a layer2 link, error: %v", err)
 				}
 
 				return nil


### PR DESCRIPTION
now edge-rule allows only ownership and layer2 in
relation type. now allowing all.

removed 'both' type.