### PR TITLE
tests: use fedora 29 for devstack

### DIFF
--- a/devstack/plugin.sh
+++ b/devstack/plugin.sh
@@ -68,7 +68,7 @@ if [ "x$PUBLIC_INTERFACE" != "x" ]; then
 fi
 
 ELASTICSEARCH_BASE_URL=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution
-ELASTICSEARCH_VERSION=5.6.10
+ELASTICSEARCH_VERSION=5.6.14
 
 USE_ELASTICSEARCH=0
 if [ "${SKYDIVE_FLOWS_STORAGE}" == "elasticsearch" ] || [ "${SKYDIVE_GRAPH_STORAGE}" == "elasticsearch" ]; then

--- a/scripts/ci/devstack/Vagrantfile
+++ b/scripts/ci/devstack/Vagrantfile
@@ -21,7 +21,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
              os.networks = ENV.fetch("OS_NETWORKS", "private").split()
          end
          devstack.vm.provider :libvirt do |domain, override|
-             override.vm.box = "fedora/27-cloud-base"
+             override.vm.box = "fedora/29-cloud-base"
              override.ssh.username = 'vagrant'
              domain.memory = 8192
              domain.cpus = 4

--- a/scripts/ci/jobs/jobs.yml
+++ b/scripts/ci/jobs/jobs.yml
@@ -170,10 +170,11 @@
       - string:
           name: REF
           default: "{ref}"
-          description: The tag or branch to build
+          description: "The tag or branch to build (ex: origin/pr/1234/merge for the PR 1234)"
       - string:
           name: REFSPEC
           default: "{refspec}"
+          description: "Refspec (ex: +refs/pull/*:refs/remotes/origin/pr/* for a PR, +refs/tags/*:refs/remotes/origin/tags/* for a tag)"
       - string:
           name: DRY_RUN
           default: "{dry-run}"


### PR DESCRIPTION
skip skydive-go-fmt
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-scale-tests
skip skydive-cdd-overview-tests
skip skydive-unit-tests
skip skydive-compile-tests
skip skydive-k8s-tests
skip skydive-ppc64le-tests