### PR TITLE
istio: add link from virtualservice to service

### DIFF
--- a/tests/istio/virtualservice-service-pod.yaml
+++ b/tests/istio/virtualservice-service-pod.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: skydive-test-virtualservice-pod
+  name: skydive-test-virtualservice-service-pod
 spec:
   hosts:
   - reviews.prod.svc.cluster.local
@@ -14,7 +14,7 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: skydive-test-virtualservice-pod
+  name: skydive-test-virtualservice-service-pod
   labels:
     app: reviews.prod.svc.cluster.local
     version: v1
@@ -25,13 +25,15 @@ spec:
     ports:
     - containerPort: 80
 ---
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
+apiVersion: v1
+kind: Service
 metadata:
-  name: skydive-test-virtualservice-pod
+  name: skydive-test-virtualservice-service-pod
+  labels:
+    app: reviews.prod.svc.cluster.local
 spec:
-  host: reviews.prod.svc.cluster.local
-  subsets:
-  - name: v1
-    labels:
-      version: v1
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: reviews.prod.svc.cluster.local

--- a/topology/probes/istio/istio.go
+++ b/topology/probes/istio/istio.go
@@ -65,6 +65,7 @@ func NewIstioProbe(g *graph.Graph) (*k8s.Probe, error) {
 
 	linkerHandlers := []k8s.LinkHandler{
 		newVirtualServicePodLinker,
+		newVirtualServiceServiceLinker,
 	}
 
 	linkers := k8s.InitLinkers(linkerHandlers, g)

--- a/topology/probes/istio/virtualservice.go
+++ b/topology/probes/istio/virtualservice.go
@@ -96,6 +96,26 @@ func virtualServicePodAreLinked(a, b interface{}) bool {
 	return false
 }
 
+func virtualServiceServiceAreLinked(a, b interface{}) bool {
+	vs := a.(*kiali.VirtualService)
+	service := b.(*v1.Service)
+	vsSpec := &virtualServiceSpec{}
+	if err := mapstructure.Decode(vs.Spec, vsSpec); err != nil {
+		return false
+	}
+	vsAppsVersions := vsSpec.getAppsVersions()
+	for app := range vsAppsVersions {
+		if app == service.Labels["app"] {
+			return true
+		}
+	}
+	return false
+}
+
 func newVirtualServicePodLinker(g *graph.Graph) probe.Probe {
 	return k8s.NewABLinker(g, Manager, "virtualservice", k8s.Manager, "pod", virtualServicePodAreLinked)
+}
+
+func newVirtualServiceServiceLinker(g *graph.Graph) probe.Probe {
+	return k8s.NewABLinker(g, Manager, "virtualservice", k8s.Manager, "service", virtualServiceServiceAreLinked)
 }


### PR DESCRIPTION
This PR creates link between virtualservice and service probes. 
It also extends Istio test such that now it checks this connection.