### PR TITLE
lldp: prefer SysName and MgmtAddress to ChassisID for switch node id

### DIFF
--- a/topology/probes/lldp/lldp.go
+++ b/topology/probes/lldp/lldp.go
@@ -344,7 +344,10 @@ func (p *Probe) getOrCreate(id graph.Identifier, m graph.Metadata) *graph.Node {
 // - when the interface is listed in the configuration file or we are in auto discovery mode
 func (p *Probe) handleNode(n *graph.Node) {
 	firstLayerType, _ := probes.GoPacketFirstLayerType(n)
-	mac, _ := n.GetFieldString("MAC")
+	mac, _ := n.GetFieldString("BondSlave.PermMAC")
+	if mac == "" {
+		mac, _ = n.GetFieldString("MAC")
+	}
 	name, _ := n.GetFieldString("Name")
 
 	if name != "" && mac != "" && firstLayerType == layers.LayerTypeEthernet {

--- a/topology/probes/netlink/netlink.go
+++ b/topology/probes/netlink/netlink.go
@@ -452,6 +452,25 @@ func (u *NetNsProbe) addLinkToTopology(link netlink.Link) {
 		metadata["MAC"] = mac
 	}
 
+	if bondSlave := attrs.BondSlave; bondSlave != nil {
+		slaveMetadata := map[string]interface{}{
+			"Type":                   bondSlave.Type,
+			"State":                  bondSlave.State.String(),
+			"MiiStatus":              bondSlave.MiiStatus.String(),
+			"LinkFailureCount":       int64(bondSlave.LinkFailureCount),
+			"QueueId":                int64(bondSlave.QueueId),
+			"AggregatorId":           int64(bondSlave.AggregatorId),
+			"AdActorOperPortState":   int64(bondSlave.AdActorOperPortState),
+			"AdPartnerOperPortState": int64(bondSlave.AdPartnerOperPortState),
+		}
+
+		if permMAC := bondSlave.PermHardwareAddr.String(); permMAC != "" {
+			slaveMetadata["PermMAC"] = permMAC
+		}
+
+		metadata["BondSlave"] = slaveMetadata
+	}
+
 	if attrs.MasterIndex != 0 {
 		metadata["MasterIndex"] = int64(attrs.MasterIndex)
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2321,16 +2321,18 @@
 			"revisionTime": "2017-01-07T13:32:03Z"
 		},
 		{
-			"checksumSHA1": "pM8xHSOdh8TqBFpABuy6ppVvUng=",
+			"checksumSHA1": "ECJTPO6zYwANY8d0jARwdMZghLw=",
+			"origin": "github.com/lebauce/netlink",
 			"path": "github.com/vishvananda/netlink",
-			"revision": "1e2e7ab670e05e2fd29bf5d0bcab2f9907e9f9f4",
-			"revisionTime": "2019-01-02T22:56:57Z"
+			"revision": "fa328be7c8d264c2e920e9ba7ec39444d89bf7c5",
+			"revisionTime": "2019-01-22T10:33:56Z"
 		},
 		{
-			"checksumSHA1": "oJA2n0pDDV6bxnZAwDyg6pWhpQk=",
+			"checksumSHA1": "X5zvw0Sx4QyDtZrF8Ic3ZGifXLo=",
+			"origin": "github.com/lebauce/netlink/nl",
 			"path": "github.com/vishvananda/netlink/nl",
-			"revision": "1e2e7ab670e05e2fd29bf5d0bcab2f9907e9f9f4",
-			"revisionTime": "2019-01-02T22:56:57Z"
+			"revision": "fa328be7c8d264c2e920e9ba7ec39444d89bf7c5",
+			"revisionTime": "2019-01-22T10:33:56Z"
 		},
 		{
 			"checksumSHA1": "JCH45h0NMsN7LFN18mwjzNgDaYI=",


### PR DESCRIPTION
Some switches - such as Cisco Nexus - sends a different chassis ID
for each port, so you use SysName and MgmtAddress if present and
fallback to chassis ID otherwise.