### PR TITLE
bug: encoding of  python scripts

### DIFF
--- a/contrib/ansible/library/skydive_edge_list.py
+++ b/contrib/ansible/library/skydive_edge_list.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 #
 # Copyright (C) 2018 Red Hat, Inc.
 #

--- a/contrib/ansible/library/skydive_node_list.py
+++ b/contrib/ansible/library/skydive_node_list.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 #
 # Copyright (C) 2018 Red Hat, Inc.
 #


### PR DESCRIPTION
Set the encoding to utf-8 in python files with utf8
characters (for python2).