### PR TITLE
Build: clean generated file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,6 +241,7 @@ flow/layers/generated.proto: flow/layers/layers.go
 .PHONY: .proto.clean
 .proto.clean:
 	find . \( -name *.pb.go ! -path './vendor/*' \) -exec rm {} \;
+	rm flow/layers/generated.proto
 
 GEN_EASYJSON_FILES_ALL := $(patsubst %.go,%_easyjson.go,$(EASYJSON_FILES_ALL))
 GEN_EASYJSON_FILES_TAG := $(patsubst %.go,%_easyjson.go,$(EASYJSON_FILES_TAG))


### PR DESCRIPTION
Also cleans the generated.proto file. Not doing so gives weird
behaviour when switching to old  branches.