### PR TITLE
devmode: bump fedora box to 29

### DIFF
--- a/contrib/dev/Vagrantfile
+++ b/contrib/dev/Vagrantfile
@@ -117,7 +117,7 @@ EOF
 SCRIPT
 
 def fedora_box(override, type)
-  major = "27"
+  major = "29"
   override.vm.box = "fedora/#{major}-cloud-base"
 end
 


### PR DESCRIPTION
skip skydive-go-fmt
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-scale-tests
skip skydive-cdd-overview-tests
skip skydive-unit-tests
skip skydive-compile-tests
skip skydive-k8s-tests
skip skydive-ppc64le-tests