### PR TITLE
Istio: add link from destinationrule to service

### DIFF
--- a/tests/istio/destinationrule-service.yaml
+++ b/tests/istio/destinationrule-service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: skydive-test-destinationrule-service
+  labels:
+    app: reviews.prod.svc.cluster.local
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: reviews.prod.svc.cluster.local
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: skydive-test-destinationrule-service
+spec:
+  host: reviews.prod.svc.cluster.local
+  subsets:
+  - name: v1
+    labels:
+      version: v1

--- a/tests/istio/virtualservice-pod.yaml
+++ b/tests/istio/virtualservice-pod.yaml
@@ -24,14 +24,3 @@ spec:
     image: nginx
     ports:
     - containerPort: 80
----
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-  name: skydive-test-virtualservice-pod
-spec:
-  host: reviews.prod.svc.cluster.local
-  subsets:
-  - name: v1
-    labels:
-      version: v1

--- a/topology/probes/istio/destinationrule.go
+++ b/topology/probes/istio/destinationrule.go
@@ -22,7 +22,9 @@ import (
 
 	kiali "github.com/kiali/kiali/kubernetes"
 	"github.com/skydive-project/skydive/graffiti/graph"
+	"github.com/skydive-project/skydive/probe"
 	"github.com/skydive-project/skydive/topology/probes/k8s"
+	"k8s.io/api/core/v1"
 )
 
 type destinationRuleHandler struct {
@@ -43,4 +45,18 @@ func (h *destinationRuleHandler) Dump(obj interface{}) string {
 
 func newDestinationRuleProbe(client interface{}, g *graph.Graph) k8s.Subprobe {
 	return k8s.NewResourceCache(client.(*kiali.IstioClient).GetIstioNetworkingApi(), &kiali.DestinationRule{}, "destinationrules", g, &destinationRuleHandler{})
+}
+
+type destinationRuleSpec struct {
+	App string `mapstructure:"host"`
+}
+
+func destinationRuleServiceAreLinked(a, b interface{}) bool {
+	dr := a.(*kiali.DestinationRule)
+	service := b.(*v1.Service)
+	return dr.Spec["host"] == service.Labels["app"]
+}
+
+func newDestinationRuleServiceLinker(g *graph.Graph) probe.Probe {
+	return k8s.NewABLinker(g, Manager, "destinationrule", k8s.Manager, "service", destinationRuleServiceAreLinked)
 }

--- a/topology/probes/istio/istio.go
+++ b/topology/probes/istio/istio.go
@@ -60,6 +60,7 @@ func NewIstioProbe(g *graph.Graph) (*k8s.Probe, error) {
 
 	linkerHandlers := []k8s.LinkHandler{
 		newVirtualServicePodLinker,
+		newDestinationRuleServiceLinker,
 	}
 
 	linkers := k8s.InitLinkers(linkerHandlers, g)


### PR DESCRIPTION
This PR creates link between destinationrule and service probes.
It also adds Istio test that checks this connection.