### PR TITLE
ui: enable k8s filters implicitly

### DIFF
--- a/statics/js/components/topology.js
+++ b/statics/js/components/topology.js
@@ -480,7 +480,7 @@ var TopologyComponent = {
     },
 
     isK8SEnabled: function() {
-      return app.getConfigValue('k8s_enabled')
+      return app.getConfigValue('k8s_enabled') || (globalVars["probes"].indexOf("k8s") >= 0);
     },
 
     metadataLinks: function(m) {


### PR DESCRIPTION
In the case that:

```
analyzer:
  topology:
    probes:
      - k8s
```

no need to set:

```
ui:
  k8s_enabled: true
```

as k8s filters  are enabled implicitly