### PR TITLE
Add flow field exclusion in flow subscriber

### DIFF
--- a/contrib/objectstore/main.go
+++ b/contrib/objectstore/main.go
@@ -39,6 +39,12 @@ func main() {
 	subscriberUsername := cfg.GetString("subscriber_username")
 	subscriberPassword := cfg.GetString("subscriber_password")
 	maxSecondsPerStream := cfg.GetInt("max_seconds_per_stream")
+	excludedFieldsMap := cfg.GetStringMap("excluded_fields")
+
+	excludedFields := make([]string, 0, len(excludedFieldsMap))
+	for field := range excludedFieldsMap {
+		excludedFields = append(excludedFields, field)
+	}
 
 	authOptions := &shttp.AuthenticationOpts{
 		Username: subscriberUsername,
@@ -58,7 +64,7 @@ func main() {
 	}
 	structClient := wsClient.UpgradeToStructSpeaker()
 
-	s := subscriber.New(endpoint, region, bucket, accessKey, secretKey, objectPrefix, maxSecondsPerStream)
+	s := subscriber.New(endpoint, region, bucket, accessKey, secretKey, objectPrefix, maxSecondsPerStream, excludedFields)
 
 	// subscribe to the flow updates
 	structClient.AddStructMessageHandler(s, []string{"flow"})

--- a/contrib/objectstore/skydive-objectstore.yml.default
+++ b/contrib/objectstore/skydive-objectstore.yml.default
@@ -8,3 +8,22 @@
 # subscriber_username:
 # subscriber_password:
 # max_seconds_per_stream: 86400
+# excluded_fields:
+    # Application:
+    # Link:
+    # ICMP:
+    # DHCPv4:
+    # DNS:
+    # VRRPv2:
+    # TCPMetric:
+    # IPMetric:
+    # RTT:
+    # TrackingID:
+    # L3TrackingID:
+    # ParentUUID:
+    # NodeTID:
+    # LastRawPackets:
+    # RawPacketsCaptured:
+    # XXX_state:
+    # Metric.Start:
+    # Metric.Last:

--- a/contrib/objectstore/subscriber/fieldexcluder/fieldexcluder.go
+++ b/contrib/objectstore/subscriber/fieldexcluder/fieldexcluder.go
@@ -1,0 +1,61 @@
+package fieldexcluder
+
+import (
+	"reflect"
+	"strings"
+)
+
+func getStructFields(v reflect.Value) map[string]reflect.Value {
+	res := make(map[string]reflect.Value)
+	for i := 0; i < v.NumField(); i++ {
+		res[v.Type().Field(i).Name] = v.Field(i)
+	}
+	return res
+}
+
+func matchExcludedFields(field string, excludedFields []string) []string {
+	res := make([]string, 0)
+	for _, f := range excludedFields {
+		if strings.HasPrefix(f, field) {
+			if f == field {
+				return nil
+			}
+			res = append(res, f[len(field)+1:])
+		}
+	}
+	return res
+}
+
+func generateExcludeFieldsFunction(v reflect.Value, excludedFields []string) func(interface{}) map[string]interface{} {
+	if len(excludedFields) == 0 || v.Kind().String() != "struct" {
+		return nil
+	}
+
+	fieldMap := getStructFields(v)
+	fieldFuncsMap := make(map[string]func(interface{}) map[string]interface{})
+	for field := range fieldMap {
+		excludedSubFields := matchExcludedFields(strings.ToLower(field), excludedFields)
+		if excludedSubFields != nil {
+			fieldFuncsMap[field] = generateExcludeFieldsFunction(fieldMap[field], excludedSubFields)
+		}
+	}
+
+	return func(val interface{}) map[string]interface{} {
+		v := reflect.ValueOf(val)
+		res := make(map[string]interface{}, len(fieldFuncsMap))
+		for field, subFunc := range fieldFuncsMap {
+			fieldValue := v.FieldByName(field).Interface()
+			if subFunc == nil {
+				res[field] = fieldValue
+			} else {
+				res[field] = subFunc(fieldValue)
+			}
+		}
+		return res
+	}
+}
+
+// GenerateExcludeFieldsFunction returns a function that filters out fields determined by excludedFields
+func GenerateExcludeFieldsFunction(value interface{}, excludedFields []string) func(interface{}) map[string]interface{} {
+	return generateExcludeFieldsFunction(reflect.ValueOf(value), excludedFields)
+}


### PR DESCRIPTION
This PR addresses issue #1588.
It adds a general fieldexcluder package that allows removing fields (including subfields) from a general struct typed value (we use it to filter fields specifically from flow.Flow).
It is currently used only by the objectstore flow subscriber.
The objectstore flow subscriber was added with a new configuration parameters `excluded_fields`, to support this feature.

@eranra @safchain @andrekassis