### PR TITLE
add objectstore marshaller

### DIFF
--- a/contrib/objectstore/main.go
+++ b/contrib/objectstore/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/skydive-project/skydive/common"
 	"github.com/skydive-project/skydive/config"
 	"github.com/skydive-project/skydive/contrib/objectstore/subscriber"
+	"github.com/skydive-project/skydive/contrib/objectstore/subscriber/flowtransformer"
 	shttp "github.com/skydive-project/skydive/http"
 	"github.com/skydive-project/skydive/logging"
 	"github.com/skydive-project/skydive/websocket"
@@ -39,6 +40,13 @@ func main() {
 	subscriberUsername := cfg.GetString("subscriber_username")
 	subscriberPassword := cfg.GetString("subscriber_password")
 	maxSecondsPerStream := cfg.GetInt("max_seconds_per_stream")
+	flowTransformerName := cfg.GetString("flow_transformer")
+
+	flowTransformer, err := flowtransformer.New(flowTransformerName)
+	if err != nil {
+		logging.GetLogger().Errorf("Failed to initialize flow transformer: %s", err.Error())
+		os.Exit(1)
+	}
 
 	authOpts := &shttp.AuthenticationOpts{
 		Username: subscriberUsername,
@@ -58,7 +66,7 @@ func main() {
 	}
 	structClient := wsClient.UpgradeToStructSpeaker()
 
-	s := subscriber.New(endpoint, region, bucket, accessKey, secretKey, objectPrefix, maxSecondsPerStream)
+	s := subscriber.New(endpoint, region, bucket, accessKey, secretKey, objectPrefix, maxSecondsPerStream, flowTransformer)
 
 	// subscribe to the flow updates
 	structClient.AddStructMessageHandler(s, []string{"flow"})

--- a/contrib/objectstore/skydive-objectstore.yml.default
+++ b/contrib/objectstore/skydive-objectstore.yml.default
@@ -8,3 +8,4 @@
 # subscriber_username:
 # subscriber_password:
 # max_seconds_per_stream: 86400
+# flow_transformer: custom1

--- a/contrib/objectstore/subscriber/flowtransformer/custom1/custom1.go
+++ b/contrib/objectstore/subscriber/flowtransformer/custom1/custom1.go
@@ -1,0 +1,42 @@
+package custom1
+
+import (
+	"github.com/skydive-project/skydive/flow"
+)
+
+// Flow represents a transformed flow
+type Flow struct {
+	UUID             string
+	LayersPath       string
+	Network          *flow.FlowLayer
+	Transport        *flow.TransportLayer
+	LastUpdateMetric *flow.FlowMetric
+	Metric           *flow.FlowMetric
+	Start            int64
+	Last             int64
+	FinishType       flow.FlowFinishType
+}
+
+// FlowTransformer is a custom transformer for flows
+type FlowTransformer struct {
+}
+
+// Transform transforms a flow before being stored
+func (m *FlowTransformer) Transform(f *flow.Flow) interface{} {
+	return &Flow{
+		UUID:             f.UUID,
+		LayersPath:       f.LayersPath,
+		Network:          f.Network,
+		Transport:        f.Transport,
+		LastUpdateMetric: f.LastUpdateMetric,
+		Metric:           f.Metric,
+		Start:            f.Start,
+		Last:             f.Last,
+		FinishType:       f.FinishType,
+	}
+}
+
+// New returns a new Custom1Marshaller
+func New() *FlowTransformer {
+	return &FlowTransformer{}
+}

--- a/contrib/objectstore/subscriber/flowtransformer/flowtransformer.go
+++ b/contrib/objectstore/subscriber/flowtransformer/flowtransformer.go
@@ -1,0 +1,25 @@
+package flowtransformer
+
+import (
+	"fmt"
+	"github.com/skydive-project/skydive/contrib/objectstore/subscriber/flowtransformer/custom1"
+	"github.com/skydive-project/skydive/flow"
+)
+
+// FlowTransformer allows generic transformations of a flow
+type FlowTransformer interface {
+	// Transform transforms a flow before being stored
+	Transform(flow *flow.Flow) interface{}
+}
+
+// New creates a new flow transformer based on a name string
+func New(flowTransformerName string) (FlowTransformer, error) {
+	switch flowTransformerName {
+	case "custom1":
+		return custom1.New(), nil
+	case "":
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Marshaller '%s' is not supported", flowTransformerName)
+	}
+}


### PR DESCRIPTION
This PR allows the object store flow subscriber to use a custom marshaller to transform the stored flows.
It includes one marshaller at the moment (named custom1) which is needed for a specific client using skydive.

This PR replaces the more generic (but perhaps less efficient) PR #1620.
As suggested here:
https://github.com/skydive-project/skydive/pull/1620#discussion_r250611550

@safchain @eranra 