### PR TITLE
ci: add mem profiling during functionals run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,9 @@ ifeq ($(COVERAGE), true)
   TEST_COVERPROFILE?=../functionals.cover
   EXTRA_ARGS+=-test.coverprofile=${TEST_COVERPROFILE}
 endif
+ifeq ($(WITH_PROF), true)
+  EXTRA_ARGS+=-profile
+endif
 TIMEOUT?=1m
 TEST_PATTERN?=
 UT_PACKAGES?=$(shell $(GOVENDOR) list -no-status +local | grep -Ev '/tests|/contrib')

--- a/common/profile.go
+++ b/common/profile.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package common
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"runtime"
+	"runtime/pprof"
+	"syscall"
+)
+
+// Profile start profiling loop
+func Profile() {
+	cpu := make(chan os.Signal, 1)
+	signal.Notify(cpu, syscall.SIGUSR1)
+
+	memory := make(chan os.Signal, 1)
+	signal.Notify(memory, syscall.SIGUSR2)
+
+	for {
+		select {
+		case <-cpu:
+			f, err := os.Create("/tmp/skydive-cpu.prof")
+			if err != nil {
+				log.Fatal("could not create CPU profile: ", err)
+			}
+			if err := pprof.StartCPUProfile(f); err != nil {
+				log.Fatal("could not start CPU profile: ", err)
+			}
+			log.Println("CPU profiling Started")
+
+			<-cpu
+
+			pprof.StopCPUProfile()
+			f.Close()
+			log.Println("CPU profiling Stopped")
+		case <-memory:
+			// Memory Profile
+			runtime.GC()
+			memProfile, err := os.Create("/tmp/skydive-memory.prof")
+			if err != nil {
+				log.Fatal(err)
+			}
+			if err := pprof.WriteHeapProfile(memProfile); err != nil {
+				log.Fatal(err)
+			}
+			memProfile.Close()
+			log.Println("Memory profiling written")
+		}
+	}
+}

--- a/scripts/ci/cleanup.sh
+++ b/scripts/ci/cleanup.sh
@@ -77,6 +77,9 @@ EOF
   rm -rf /tmp/skydive_agent* /tmp/skydive-etcd
   rm -rf /var/lib/jenkins/.vagrant.d/tmp
 
+  rm -rf /tmp/skydive-memory.prof*
+  rm -rf /tmp/skydive-cpu.prof*
+
   # time to restart services
   sleep 8
   ip l del virbr0

--- a/scripts/ci/jobs/jobs.yml
+++ b/scripts/ci/jobs/jobs.yml
@@ -158,6 +158,7 @@
           cd src/github.com/skydive-project/skydive
           . scripts/ci/install-go.sh
           [[ "$ghprbCommentBody" = *"insanelock"* ]] && export TAGS=mutexdebug
+          [[ "$ghprbCommentBody" = *"profile"* ]] && export WITH_PROF=true
           {test}
 
 - parameter:

--- a/scripts/ci/run-tests-utils.sh
+++ b/scripts/ci/run-tests-utils.sh
@@ -6,6 +6,16 @@ network_setup() {
         done
 }
 
+mem_prof() {
+        echo start memory profiling
+        while(true); do
+                echo trigger memory profiling snapshot
+                sudo pkill -USR2 functionals 2>/dev/null || true
+                sleep 10
+                sudo mv /tmp/skydive-memory.prof /tmp/skydive-memory.prof.$( date +%T ) 2>/dev/null || true
+        done
+}
+
 tests_run() {
         cd ${GOPATH}/src/github.com/skydive-project/skydive
 
@@ -25,11 +35,20 @@ tests_run() {
                 export TEST_COVERPROFILE=../functionals-$BACKEND.cover
         fi
 
+        if [ "$WITH_PROF" = "true" ]; then
+                mem_prof&
+                MEMPROFPID=$!
+        fi
+
         make test.functionals.batch \
                 GOFLAGS="$GOFLAGS" VERBOSE=true TAGS="$TAGS" GORACE="history_size=7" TIMEOUT=20m \
                 WITH_HELM="$WITH_HELM" WITH_EBPF="$WITH_EBPF" WITH_K8S="$WITH_K8S" WITH_ISTIO="$WITH_ISTIO" \
-                ARGS="$ARGS" TEST_PATTERN="$TEST_PATTERN" 2>&1 | tee $LOGFILE
+                WITH_PROF="$WITH_PROF" ARGS="$ARGS" TEST_PATTERN="$TEST_PATTERN" 2>&1 | tee $LOGFILE
         RETCODE=$?
+
+        if [ "$WITH_PROF" = "true" ]; then
+                kill $MEMPROFPID 2>/dev/null
+        fi
 
         go get -f -u github.com/tebeka/go2xunit
         go2xunit -fail -fail-on-race -suite-name-prefix tests \

--- a/skydive_prof.go
+++ b/skydive_prof.go
@@ -20,61 +20,12 @@
 package main
 
 import (
-	"log"
-	"os"
-	"os/signal"
-	"runtime"
-	"runtime/pprof"
-	"syscall"
-
 	"github.com/skydive-project/skydive/cmd/skydive"
+	"github.com/skydive-project/skydive/common"
 )
 
-func profile(cpu chan os.Signal, memory chan os.Signal) {
-	for {
-		select {
-		case <-cpu:
-			f, err := os.Create("/tmp/skydive-cpu.prof")
-			if err != nil {
-				log.Fatal("could not create CPU profile: ", err)
-			}
-			if err := pprof.StartCPUProfile(f); err != nil {
-				log.Fatal("could not start CPU profile: ", err)
-			}
-			log.Println("CPU profiling Started")
-
-			<-cpu
-
-			pprof.StopCPUProfile()
-			log.Println("CPU profiling Stopped")
-
-			return
-		case <-memory:
-			// Memory Profile
-			runtime.GC()
-			memProfile, err := os.Create("/tmp/skydive-memory.prof")
-			if err != nil {
-				log.Fatal(err)
-			}
-			if err := pprof.WriteHeapProfile(memProfile); err != nil {
-				log.Fatal(err)
-			}
-			memProfile.Close()
-			log.Println("Memory profiling written")
-
-			return
-		}
-	}
-}
-
 func main() {
-	cpu := make(chan os.Signal, 1)
-	signal.Notify(cpu, syscall.SIGUSR1)
-
-	memory := make(chan os.Signal, 1)
-	signal.Notify(memory, syscall.SIGUSR2)
-
-	go profile(cpu, memory)
+	go common.Profile()
 
 	skydive.RootCmd.Execute()
 }

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -226,6 +226,7 @@ var (
 	ovsOflowNative    bool
 	standalone        bool
 	topologyBackend   string
+	profile           bool
 )
 
 func initConfig(conf string, params ...helperParams) error {
@@ -811,6 +812,10 @@ func delaySec(sec int, err ...error) error {
 var initStandalone = false
 
 func runStandalone() {
+	if profile {
+		go common.Profile()
+	}
+
 	server, err := analyzer.NewServerFromConfig()
 	if err != nil {
 		panic(err)
@@ -839,6 +844,7 @@ func init() {
 	flag.StringVar(&analyzerProbes, "analyzer.topology.probes", "", "Specify the analyzer probes to enable")
 	flag.StringVar(&agentProbes, "agent.topology.probes", "", "Specify the extra agent probes to enable")
 	flag.BoolVar(&ovsOflowNative, "ovs.oflow.native", false, "Use native OpenFlow protocol instead of ovs-ofctl")
+	flag.BoolVar(&profile, "profile", false, "Start profiling")
 	flag.Parse()
 
 	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = 100


### PR DESCRIPTION
skip skydive-compile-tests
skip skydive-functional-tests-backend-orientdb
skip skydive-go-fmt
skip skydive-k8s-tests
skip skydive-scale-tests
skip skydive-selenium-tests
skip skydive-unit-tests
skip skydive-cdd-overview-tests
skip skydive-ppc64-tests