### PR TITLE
customize flow timeout by application

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -119,6 +119,8 @@ func init() {
 	cfg.SetDefault("flow.expire", 600)
 	cfg.SetDefault("flow.update", 60)
 	cfg.SetDefault("flow.protocol", "udp")
+	cfg.SetDefault("flow.application_timeout.arp", 10)
+	cfg.SetDefault("flow.application_timeout.dns", 10)
 
 	cfg.SetDefault("host_id", host)
 

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -458,6 +458,12 @@ flow:
     udp:
       # 1194: OPENVPN
 
+  # application specific flow timeout, in seconds
+  # this timeout is enforced in addition to the general flow.expire timeout
+  application_timeout:
+    # - arp: 10
+    # - dns: 10
+
 ui:
   # Specify the extra assets folder. Javascript and CSS files present in this
   # folder will be added to the WebUI.


### PR DESCRIPTION
We want to allow setting custom expire timeout for flow by their Application field.
For example, you may want to set DNS flows to timeout faster than the default 10 minutes.

I haven't yet tested this, but would like to get your feedback on the idea & implementation approach.
Thanks!