### PR TITLE
ci: refactor create docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -524,50 +524,6 @@ docker-image: static
 	cp $$GOPATH/bin/skydive contrib/docker/skydive.$$(uname -m)
 	docker build -t ${DOCKER_IMAGE}:${DOCKER_TAG} --build-arg ARCH=$$(uname -m) -f contrib/docker/Dockerfile contrib/docker/
 
-.PHONY: docker-build
-docker-build:
-	docker build -t skydive-compile \
-		--build-arg UID=$$(id -u) \
-		-f contrib/docker/Dockerfile.compile  contrib/docker
-	docker volume create govendor-cache
-	docker volume create gobuild-cache
-	docker rm skydive-compile-build || true
-	docker run --name skydive-compile-build \
-		--env UID=$$(id -u) \
-		--volume $$PWD:/root/go/src/github.com/skydive-project/skydive \
-		--volume govendor-cache:/root/go/.cache/govendor \
-		--volume gobuild-cache:/root/.cache/go-build \
-		skydive-compile
-	docker cp skydive-compile-build:/root/go/bin/skydive contrib/docker/skydive.$$(uname -m)
-	docker rm skydive-compile-build
-	docker build -t ${DOCKER_IMAGE}:${DOCKER_TAG} \
-		--label "Version=${VERSION}" \
-		--build-arg ARCH=$$(uname -m) \
-		-f contrib/docker/Dockerfile contrib/docker/
-
-.PHONY: docker-cross-build
-docker-cross-build: ebpf.build
-	docker build -t skydive-crosscompile-${TARGET_GOARCH} \
-		$${TARGET_ARCH:+--build-arg TARGET_ARCH=$${TARGET_ARCH}} \
-		$${TARGET_GOARCH:+--build-arg TARGET_GOARCH=$${TARGET_GOARCH}} \
-		$${DEBARCH:+--build-arg DEBARCH=$${DEBARCH}} \
-		--build-arg UID=$$(id -u) \
-		-f contrib/docker/Dockerfile.crosscompile contrib/docker
-	docker volume create govendor-cache
-	docker rm skydive-crosscompile-build-${TARGET_GOARCH} || true
-	docker run --name skydive-crosscompile-build-${TARGET_GOARCH} \
-		--env UID=$$(id -u) \
-		--volume $$PWD:/root/go/src/github.com/skydive-project/skydive \
-		--volume govendor-cache:/root/go/.cache/govendor \
-		skydive-crosscompile-${TARGET_GOARCH}
-	docker cp skydive-crosscompile-build-${TARGET_GOARCH}:/root/go/bin/linux_${TARGET_GOARCH}/skydive contrib/docker/skydive.${TARGET_GOARCH}
-	docker rm skydive-crosscompile-build-${TARGET_GOARCH}
-	docker build -t ${DOCKER_IMAGE}:${DOCKER_TAG} \
-		--label "Version=${VERSION}" \
-		--build-arg ARCH=${TARGET_GOARCH} \
-		$${BASE:+--build-arg BASE=$${BASE}} \
-		-f contrib/docker/Dockerfile.static contrib/docker/
-
 SKYDIVE_PROTO_FILES:= \
 	flow/flow.proto \
 	filters/filters.proto \

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,6 +1,6 @@
 ARG  BASE=ubuntu:18.04
 FROM $BASE
-ARG  ARCH=x86_64
+ARG  ARCH=amd64
 RUN apt-get -y update \
     && apt-get -y install openvswitch-common libpcap0.8 libxml2 libvirt0 \
     && rm -rf /var/lib/apt/lists/*

--- a/scripts/ci/create-docker-image.sh
+++ b/scripts/ci/create-docker-image.sh
@@ -21,26 +21,95 @@ if [ "${DOCKER_IMAGE%/*/*}" != "${DOCKER_IMAGE}" ]; then
     DOCKER_SERVER=${DOCKER_IMAGE%/*/*}
 fi
 
+DOCKER_DIR=contrib/docker
+GOVENDOR_VOL=govendor-cache
+GOVENDOR_DIR=/root/go/.cache/govendor
+GOBUILD_VOL=gobuild-cache
+GOBUILD_DIR=/root/.cache/go-build
+TOPLEVEL_VOL=$PWD
+TOPLEVEL_DIR=/root/go/src/github.com/skydive-project/skydive
+
+docker_tag() {
+    local arch=$1
+    echo ${DOCKER_TAG}-linux-${arch}
+}
+
+docker_skydive_builder() {
+    local arch=$1
+    local dockerfile=$2
+
+    # create docker image of builder and build skydive
+    local tag=skydive-compile
+    local image=skydive-compile-build
+    local uid=$( id -u )
+    docker build -t $tag \
+        ${TARGET_ARCH:+--build-arg TARGET_ARCH=${TARGET_ARCH}} \
+        ${TARGET_GOARCH:+--build-arg TARGET_GOARCH=${TARGET_GOARCH}} \
+        ${DEBARCH:+--build-arg DEBARCH=${DEBARCH}} \
+        --build-arg UID=$uid \
+        -f $DOCKER_DIR/$dockerfile $DOCKER_DIR
+    docker volume create $GOVENDOR_VOL
+    docker volume create $GOBUILD_VOL
+    docker rm $image || true
+    docker run --name $image \
+        --env UID=$uid \
+        --volume $TOPLEVEL_VOL:$TOPLEVEL_DIR \
+        --volume $GOVENDOR_VOL:$GOVENDOR_DIR \
+        --volume $GOBUILD_VOL:$GOBUILD_DIR \
+        $tag
+
+    # copy skydive executable our of builder docker image
+    local src=/root/go/bin/${TARGET_GOARCH:+linux_${TARGET_GOARCH}/}skydive
+    local dst=$DOCKER_DIR/skydive.$arch
+    docker cp $image:$src $dst
+    docker rm $image
+}
+
+docker_skydive_target() {
+    local arch=$1
+    local dockerfile=$2
+
+    # build target skydive docker image
+    local tag=$( docker_tag ${arch} )
+    docker build -t ${DOCKER_IMAGE}:$tag \
+        --label "Version=${VERSION}" \
+        --build-arg ARCH=$arch \
+        ${BASE:+--build-arg BASE=${BASE}} \
+        -f $DOCKER_DIR/$dockerfile $DOCKER_DIR
+}
+
+docker_native_build() {
+    local arch=$1
+
+    docker_skydive_builder $arch Dockerfile.compile
+    docker_skydive_target $arch Dockerfile
+}
+
+docker_cross_build() {
+    local arch=$1
+
+    docker_skydive_builder $arch Dockerfile.crosscompile
+    docker_skydive_target $arch Dockerfile.static
+}
+
 docker_build() {
     for arch in $ARCHES
     do
-        flags="DOCKER_IMAGE=${DOCKER_IMAGE} DOCKER_TAG=${arch}-${DOCKER_TAG}"
         case $arch in
           amd64)
-            # x86_64 image
-            make docker-build ${flags} ${BASE:+BASE=$BASE}
+            docker_native_build $arch
             ;;
           ppc64le)
-            make docker-cross-build ${flags} WITH_EBPF=true TARGET_ARCH=powerpc64le TARGET_GOARCH=$arch DEBARCH=ppc64el BASE=${BASE:-${arch}/ubuntu}
+            TARGET_ARCH=powerpc64le TARGET_GOARCH=$arch DEBARCH=ppc64el BASE=${BASE:-${arch}/ubuntu} docker_cross_build $arch
             ;;
           arm64)
-            make docker-cross-build ${flags} WITH_EBPF=true TARGET_ARCH=aarch64 TARGET_GOARCH=$arch BASE=${BASE:-aarch64/ubuntu}
+            TARGET_ARCH=aarch64 TARGET_GOARCH=$arch DEBARCH=$arch BASE=${BASE:-aarch64/ubuntu} docker_cross_build $arch
             ;;
           s390x)
-            make docker-cross-build ${flags} WITH_EBPF=true TARGET_ARCH=$arch TARGET_GOARCH=$arch BASE=${BASE:-${arch}/ubuntu}
+            TARGET_ARCH=$arch TARGET_GOARCH=$arch DEBARCH=$arch BASE=${BASE:-${arch}/ubuntu} docker_cross_build $arch
             ;;
           *)
-            make docker-cross-build ${flags} WITH_EBPF=true TARGET_ARCH=$arch TARGET_GOARCH=$arch BASE=${BASE:-${arch}/ubuntu}
+            TARGET_ARCH=$arch TARGET_GOARCH=$arch DEBARCH=$arch BASE=${BASE:-${arch}/ubuntu} docker_cross_build $arch
             ;;
         esac
     done
@@ -57,10 +126,20 @@ docker_login() {
     set -x
 }
 
+docker_image() {
+    local arch=$1
+    echo ${DOCKER_IMAGE}:$( docker_tag ${arch} )
+}
+
+docker_inspect() {
+    local arch=$1
+    docker inspect --format='{{index .RepoDigests 0}}' $( docker_image ${arch} )
+}
+
 docker_push() {
     for arch in $ARCHES
     do
-        docker push ${DOCKER_IMAGE}:${arch}-${DOCKER_TAG}
+        docker push $( docker_image ${arch} )
     done
 }
 
@@ -68,7 +147,7 @@ docker_manifest() {
     digests=""
     for arch in $ARCHES
     do
-        digest=$( docker inspect --format='{{index .RepoDigests 0}}' ${DOCKER_IMAGE}:${arch}-${DOCKER_TAG} )
+        digest=$( docker_inspect ${arch} )
         digests="${digests} $digest"
     done
 
@@ -82,7 +161,7 @@ docker_manifest() {
 
     for arch in $ARCHES
     do
-        digest=$( docker inspect --format='{{index .RepoDigests 0}}' ${DOCKER_IMAGE}:${arch}-${DOCKER_TAG} )
+        digest=$( docker_inspect ${arch} )
         docker manifest annotate --arch $arch "${DOCKER_IMAGE}:${DOCKER_TAG}" $digest
     done
 


### PR DESCRIPTION
moved all the related code (to building images) into `scripts/ci/create-docker-image.sh` and eliminated duplications between native to cross compilations.

@grooverdan - kindly check that the ppc64 still runs as expected (build appears to work).

@lebauce - note this change was made to support more easily features such as creating of snapshots etc.