### PR TITLE
Contrib k8s runc

### DIFF
--- a/contrib/kubernetes/README.md
+++ b/contrib/kubernetes/README.md
@@ -1,0 +1,19 @@
+# Skydive Kubernetes
+
+To install run:
+
+```
+kubectl apply -f skydive.yaml
+```
+
+To expose UI management port:
+
+```
+kubectl port-forward service/skydive-analyzer 8082:8082
+```
+
+To uninstall run:
+
+```
+kubectl delete -f skydive.yaml
+```

--- a/contrib/kubernetes/skydive.yaml
+++ b/contrib/kubernetes/skydive.yaml
@@ -41,7 +41,7 @@ metadata:
     app: skydive-agent
   name: skydive-agent-config
 data:
-  SKYDIVE_AGENT_TOPOLOGY_PROBES: "runc docker"
+  SKYDIVE_AGENT_TOPOLOGY_PROBES: runc docker
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -105,6 +105,8 @@ spec:
         env:
         - name: SKYDIVE_ANALYZERS
           value: "$(SKYDIVE_ANALYZER_SERVICE_HOST):$(SKYDIVE_ANALYZER_SERVICE_PORT_API)"
+        - name: SKYDIVE_AGENT_TOPOLOGY_RUNC_RUN_PATH
+          value: /var/run/runc /var/run/runc-ctrs /var/run/containerd/runc
         envFrom:
         - configMapRef:
             name: skydive-agent-config
@@ -117,10 +119,12 @@ spec:
           mountPath: /host/run
         - name: ovsdb
           mountPath: /var/run/openvswitch/db.sock
-        - mountPath: /var/run/runc
-          name: runc
-        - mountPath: /var/run/runc-ctrs
-          name: runc-ctrs
+        - name: runc
+          mountPath: /var/run/runc
+        - name: runc-ctrs
+          mountPath: /var/run/runc-ctrs
+        - name: containerd-runc
+          mountPath: /var/run/containerd/runc
       volumes:
       - name: docker
         hostPath:
@@ -131,9 +135,12 @@ spec:
       - name: ovsdb
         hostPath:
           path: /var/run/openvswitch/db.sock
-      - hostPath:
-          path: /run/runc
-        name: runc
-      - hostPath:
-          path: /run/runc-ctrs
-        name: runc-ctrs
+      - name: runc
+        hostPath:
+          path: /var/run/runc
+      - name: runc-ctrs
+        hostPath:
+          path: /var/run/runc-ctrs
+      - name: containerd-runc
+        hostPath:
+          path: /var/run/containerd/runc

--- a/contrib/openshift/skydive-template.yaml
+++ b/contrib/openshift/skydive-template.yaml
@@ -162,7 +162,7 @@ objects:
             value: ${SKYDIVE_LOGGING_LEVEL}
           - name: SKYDIVE_AGENT_TOPOLOGY_PROBES
             value: "ovsdb runc docker"
-          - name: SKYDIVE_RUNC_PATH
+          - name: SKYDIVE_AGENT_TOPOLOGY_RUNC_RUN_PATH
             value: "/run/containerd/runc /run/runc /run/runc-ctrs"
           image: skydive/skydive
           imagePullPolicy: Always


### PR DESCRIPTION
This PR fixes the contrib/k8s skydive template so that it is compatible with runC. To test do the following steps:

(1)
First create a runC container as explained here: https://blog.selectel.com/managing-containers-runc/

(2)
Next skydive as a k8s pod:

```
scripts/ci/install-minikube.sh
kubectl apply -f contrib/kubernetes/skydive.yaml
kubectl port-forward service/skydive-analyzer 8082:8082
```

(3)
Finally check in the WebUI that the `mycontainer` runC container exists.