### PR TITLE
contrib/k8s: enable k8s probe with rbac

### DIFF
--- a/contrib/kubernetes/skydive.yaml
+++ b/contrib/kubernetes/skydive.yaml
@@ -1,4 +1,22 @@
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: skydive-service-account
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: skydive-default-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: skydive-service-account
+    namespace: default
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: skydive-analyzer
@@ -55,12 +73,16 @@ spec:
         app: skydive
         tier: analyzer
     spec:
+      serviceAccountName: skydive-service-account
       containers:
       - name: skydive-analyzer
         image: skydive/skydive
         args:
         - analyzer
         - --listen=0.0.0.0:8082
+        env:
+        - name: SKYDIVE_ANALYZER_TOPOLOGY_PROBES
+          value: k8s
         ports:
         - containerPort: 8082
         - containerPort: 8082


### PR DESCRIPTION
To test:

```
kubectl apply -f contrib/kubernetes/skydive.yaml
kubectl port-forward service/skydive-analyzer 8082:8082
```