### PR TITLE
Runc guest hosts

### DIFF
--- a/contrib/kubernetes/skydive.yaml
+++ b/contrib/kubernetes/skydive.yaml
@@ -125,6 +125,10 @@ spec:
           mountPath: /var/run/runc-ctrs
         - name: containerd-runc
           mountPath: /var/run/containerd/runc
+        - name: data-kubelet
+          mountPath: /var/data/kubelet
+        - name: lib-kubelet
+          mountPath: /var/lib/kubelet
       volumes:
       - name: docker
         hostPath:
@@ -144,3 +148,9 @@ spec:
       - name: containerd-runc
         hostPath:
           path: /var/run/containerd/runc
+      - name: data-kubelet
+        hostPath:
+          path: /var/data/kubelet
+      - name: lib-kubelet
+        hostPath:
+          path: /var/lib/kubelet

--- a/topology/probes/runc/hosts.go
+++ b/topology/probes/runc/hosts.go
@@ -1,0 +1,85 @@
+// +build linux
+
+/*
+ * Copyright (C) 2019 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package runc
+
+import (
+	"bufio"
+	"net"
+	"os"
+	"strings"
+)
+
+type hosts struct {
+	IP       string              `json:"IP,omitempty"`
+	Hostname string              `json:"Hostname,omitempty"`
+	ByIP     map[string][]string `json:"ByIP,omitempty"`
+}
+
+func newHosts() *hosts {
+	hosts := new(hosts)
+	hosts.ByIP = make(map[string][]string)
+	return hosts
+}
+
+func readHosts(path string) (*hosts, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	hosts := newHosts()
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if err := scanner.Err(); err != nil {
+			return nil, err
+		}
+
+		if i := strings.IndexByte(line, '#'); i >= 0 {
+			// Discard comment.
+			line = line[0:i]
+		}
+
+		f := strings.Fields(line)
+		if len(f) < 2 {
+			continue
+		}
+
+		ip := net.ParseIP(f[0])
+		if ip == nil {
+			continue
+		}
+
+		if ip.IsLoopback() {
+			continue
+		}
+
+		hosts.IP = ip.String()
+		hosts.ByIP[hosts.IP] = make([]string, 0)
+		for i := 1; i < len(f); i++ {
+			hosts.Hostname = strings.ToLower(f[i])
+			hosts.ByIP[hosts.IP] = append(hosts.ByIP[hosts.IP], hosts.Hostname)
+		}
+	}
+
+	return hosts, nil
+}

--- a/topology/probes/runc/runc_test.go
+++ b/topology/probes/runc/runc_test.go
@@ -18,10 +18,44 @@
 package runc
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/skydive-project/skydive/common"
 )
+
+const stateBasename = "state.json"
+
+const stateContent = `{
+  "id": "c96f6a897a632970bd4d0aa34f94452a4ce236b1dc239bf010bcf12f98d5bc56",
+  "init_process_pid": 31046,
+  "init_process_start": 541882281,
+  "created": "2019-02-19T09:11:38.404438797Z",
+  "config": {
+    "mounts": [
+      {
+        "source": "/var/data/cripersistentstorage/io.containerd.grpc.v1.cri/sandboxes/87537844e40aaa9672ea2505600a94325221e901d04237356aff20c64849cbe0/resolv.conf",
+        "destination": "/etc/resolv.conf"
+      },
+      {
+        "source": "/var/data/kubelet/pods/5b9a9c62-3426-11e9-9f59-76f6e92e93c2/etc-hosts",
+        "destination": "/etc/hosts"
+      }
+    ]
+  }
+}`
+
+const hostsBasename = "etc-hosts"
+
+const hostsContent = `# Kubernetes-managed hosts file.
+127.0.0.1	localhost
+::1	localhost ip6-localhost ip6-loopback
+fe00::0	ip6-localnet # 1 space
+fe00::0	 ip6-mcastprefix # 2 spaces
+fe00::1	ip6-allnodes # 1 tab
+fe00::2		ip6-allrouters # 1 space; 1 tab
+172.30.247.227	myapp`
 
 func TestLabels(t *testing.T) {
 	var state containerState
@@ -34,5 +68,85 @@ func TestLabels(t *testing.T) {
 	value, err := common.GetField(labels, "io.kubernetes.container.ports.containerPort")
 	if err != nil || value.(float64) != 9090 {
 		t.Error("unable to find expected label value")
+	}
+}
+
+func tempFile(filename, content string) (string, error) {
+	tmpfile, err := ioutil.TempFile("", filename)
+	if err != nil {
+		return "", err
+	}
+
+	_, errWrite := tmpfile.Write([]byte(content))
+
+	errClose := tmpfile.Close()
+
+	if errWrite != nil {
+		return "", errWrite
+	}
+
+	if errClose != nil {
+		return "", errClose
+	}
+
+	return tmpfile.Name(), nil
+}
+
+func TestParseState(t *testing.T) {
+	filename, err := tempFile(stateBasename, stateContent)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+	defer os.Remove(filename)
+
+	_, err = parseState(filename)
+	if err != nil {
+		t.Errorf("unable to parse state file: %s", filename)
+	}
+}
+
+func TestGetHostsFromState(t *testing.T) {
+	filename, err := tempFile(stateBasename, stateContent)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+	defer os.Remove(filename)
+
+	state, err := parseState(filename)
+	if err != nil {
+		t.Errorf("unable to parse state file: %s", filename)
+	}
+
+	_, err = getHostsFromState(state)
+	if err != nil {
+		t.Errorf("unable to find /etc/hosts entry in file: %s", filename)
+	}
+}
+
+func TestReadHosts(t *testing.T) {
+	filename, err := tempFile(hostsBasename, hostsContent)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+	defer os.Remove(filename)
+
+	hosts, err := readHosts(filename)
+	if err != nil {
+		t.Errorf("unable to parse file: %s", filename)
+	}
+
+	const ip = "172.30.247.227"
+	const hostname = "myapp"
+
+	if hosts.IP != ip {
+		t.Errorf("wrong IP: expected %s, actual %s", ip, hosts.IP)
+	}
+
+	if hosts.Hostname != hostname {
+		t.Errorf("wrong Hostname: expected %s, actual %s", hostname, hosts.Hostname)
+	}
+
+	if _, ok := hosts.ByIP[ip]; !ok {
+		t.Errorf("unable to find ip address entry: %s", ip)
 	}
 }


### PR DESCRIPTION
This PR enhances runC with information extracted from guest `/etc/hosts` in cases that this file is mapped from the host machine by runC, as is the case when using k8s 1.12.x (as is now the default in IBM Kubernetes Services). 

To test:

```
sed -e %skydive/skydive%aidans/skydive% contrib/kubernetes/skydive.yaml > skydive2.yaml
kubectl apply -f skydive2.yaml
kubectl port-forward service/skydive-analyzer 8082:8082
```

Now open runC container and check that you see in Metadata `Runc.Hosts` field.
