### PR TITLE
hold ended flows

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -528,6 +528,8 @@ func (f *Flow) Init(now int64, nodeTID string, uuids UUIDs) {
 
 	f.NodeTID = nodeTID
 	f.ParentUUID = uuids.ParentUUID
+
+	f.FinishType = FlowFinishType_NOT_FINISHED
 }
 
 // initFromPacket initializes the flow based on packet data, flow key and ids


### PR DESCRIPTION
Recently (in #1532), we started deleting flows immediately once we detect a TCP FIN/RST flags.
However, such flows can still see new packets, and thus we propose to add a "hold" duration to keep these flows in the flows table a bit longer.

Another change I made here is not report flows as "expired" if they are already reported as ended by other means (such as TCP FIN/RST).