### PR TITLE
added libvirt to list of probes in yaml file

### DIFF
--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -188,7 +188,7 @@ agent:
   topology:
     # Probes used to capture topology information like interfaces,
     # bridges, namespaces, etc...
-    # Available: ovsdb, docker, neutron, opencontrail, socketinfo, lxd, lldp
+    # Available: ovsdb, docker, neutron, opencontrail, socketinfo, lxd, lldp, libvirt, runc
     probes:
       # - ovsdb
       # - docker
@@ -197,6 +197,7 @@ agent:
       # - socketinfo
       # - lxd
       # - lldp
+      # - libvirt
       # - runc
 
     netlink:


### PR DESCRIPTION
The libvirt probe did not appear as a possibility in the etc/skydive.yaml file.
I added libvirt (commented) to the list of probes available.