### PR TITLE
Istio: add gateway-virtualservice link

### DIFF
--- a/tests/istio/gateway-virtualservice.yaml
+++ b/tests/istio/gateway-virtualservice.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: skydive-test-gateway-virtualservice
+spec:
+  selector:
+    istio: ingressgateway 
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: skydive-test-gateway-virtualservice
+spec:
+  hosts:
+  - reviews.prod.svc.cluster.local
+  gateways:
+  - skydive-test-gateway-virtualservice
+  http:
+  - route:
+    - destination:
+        host: reviews.prod.svc.cluster.local
+        subset: v1

--- a/tests/istio_test.go
+++ b/tests/istio_test.go
@@ -104,6 +104,32 @@ func TestIstioDestinationRuleServiceScenario(t *testing.T) {
 	)
 }
 
+func TestIstioGatewayVirtualServiceScenario(t *testing.T) {
+	file := "gateway-virtualservice"
+	name := objName + "-" + file
+	testRunner(
+		t,
+		setupFromConfigFile(istio.Manager, file),
+		tearDownFromConfigFile(istio.Manager, file),
+		[]CheckFunction{
+			func(c *CheckContext) error {
+				gateway, err := checkNodeCreation(t, c, istio.Manager, "gateway", name)
+				if err != nil {
+					return err
+				}
+				virtualservice, err := checkNodeCreation(t, c, istio.Manager, "virtualservice", name)
+				if err != nil {
+					return err
+				}
+				if err = checkEdge(t, c, gateway, virtualservice, "gateway"); err != nil {
+					return err
+				}
+				return nil
+			},
+		},
+	)
+}
+
 func TestBookInfoScenario(t *testing.T) {
 	bookinfo := "WITH_ISTIO=true ./bookinfo/bookinfo.sh"
 	testRunner(

--- a/topology/probes/istio/istio.go
+++ b/topology/probes/istio/istio.go
@@ -61,6 +61,7 @@ func NewIstioProbe(g *graph.Graph) (*k8s.Probe, error) {
 	linkerHandlers := []k8s.LinkHandler{
 		newVirtualServicePodLinker,
 		newDestinationRuleServiceLinker,
+		newGatewayVirtualServiceLinker,
 	}
 
 	linkers := k8s.InitLinkers(linkerHandlers, g)


### PR DESCRIPTION
This PR adds links between gateways and virtualservices.
The relevant tests are `TestBookInfoScenario` and `TestIstioGatewayVirtualServiceScenario`, which can be found at `tests/istio_test.go`.