### PR TITLE
k8s/istio: edge metadata mechanism

### DIFF
--- a/tests/istio/virtualservice-pod.yaml
+++ b/tests/istio/virtualservice-pod.yaml
@@ -10,6 +10,7 @@ spec:
     - destination:
         host: reviews.prod.svc.cluster.local
         subset: v1
+      weight: 40
 ---
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
This PR adds the ability to present non-trivial metadata about k8s/istio edges.
An example of it's usage is the case of virtualservice-pod edge: You can observe that the weight of the traffic sent to the pod is now showed in the edge's metadata.