### PR TITLE
k8s: delete orphaned containers

### DIFF
--- a/topology/probes/k8s/container.go
+++ b/topology/probes/k8s/container.go
@@ -137,7 +137,8 @@ func newContainerProbe(client interface{}, g *graph.Graph) Subprobe {
 	}
 
 	containerFilter := newTypesFilter(Manager, "container")
-	c.containerIndexer = newObjectIndexerFromFilter(g, c.EventHandler, containerFilter, MetadataFields("Namespace", "Pod")...)
+	c.containerIndexer = newObjectIndexerFromFilter(g, c, containerFilter, MetadataFields("Namespace", "Pod")...)
+	c.containerIndexer.Start()
 	c.KubeCache = RegisterKubeCache(client.(*kubernetes.Clientset).CoreV1().RESTClient(), &v1.Pod{}, "pods", c)
 	return c
 }


### PR DESCRIPTION
This PR fixes a bug in which when a pod is deleted its' child containers are not and remain orphaned (and flowing in space).

Test by running:

```
kubectl apply -f tests/k8s/pod.yaml
kubectl delete -f tests/k8s/pod.yaml
```

Verify in UI that not orphaned containers exist. (fixing the state if running this sequence on the current master).