### PR TITLE
K8s: fix linker for non-namespace links

### DIFF
--- a/tests/k8s_test.go
+++ b/tests/k8s_test.go
@@ -602,16 +602,17 @@ func TestStorageScenario(t *testing.T) {
 					return err
 				}
 
-				// FIXME: works when stepping with debugger
-				// if err = checkEdge(t, c, sc, pvc, "storageclass"); err != nil {
-				// 	return err
-				// }
+				if err = checkEdge(t, c, sc, pvc, "storageclass"); err != nil {
+					return err
+				}
 
 				if err = checkEdge(t, c, pod, pvc, "pod"); err != nil {
 					return err
 				}
 
-				// FIXME: works when stepping with debugger
+				// FIXME: disabled as we can't guaranty that
+				// k8s will fulfill pvc:task-pv-claim with
+				// pv:task-pv-volume and not an existing pv
 				// if err = checkEdge(t, c, pvc, pv, "persistentvolumeclaim"); err != nil {
 				// 	return err
 				// }

--- a/topology/probes/istio/destinationrule.go
+++ b/topology/probes/istio/destinationrule.go
@@ -54,7 +54,7 @@ type destinationRuleSpec struct {
 func destinationRuleServiceAreLinked(a, b interface{}) bool {
 	dr := a.(*kiali.DestinationRule)
 	service := b.(*v1.Service)
-	return dr.Spec["host"] == service.Labels["app"]
+	return k8s.MatchNamespace(dr, service) && dr.Spec["host"] == service.Labels["app"]
 }
 
 func newDestinationRuleServiceLinker(g *graph.Graph) probe.Probe {

--- a/topology/probes/istio/gateway.go
+++ b/topology/probes/istio/gateway.go
@@ -49,6 +49,11 @@ func newGatewayProbe(client interface{}, g *graph.Graph) k8s.Subprobe {
 func gatewayVirtualServiceAreLinked(a, b interface{}) bool {
 	gateway := a.(*kiali.Gateway)
 	vs := b.(*kiali.VirtualService)
+
+	if !k8s.MatchNamespace(gateway, vs) {
+		return false
+	}
+
 	if gateways, ok := vs.Spec["gateways"]; ok {
 		gatewaysList := gateways.([]interface{})
 		for _, g := range gatewaysList {

--- a/topology/probes/istio/virtualservice.go
+++ b/topology/probes/istio/virtualservice.go
@@ -74,6 +74,11 @@ func (vsSpec virtualServiceSpec) getAppsVersions() map[string][]string {
 func virtualServicePodAreLinked(a, b interface{}) bool {
 	vs := a.(*kiali.VirtualService)
 	pod := b.(*v1.Pod)
+
+	if !k8s.MatchNamespace(vs, pod) {
+		return false
+	}
+
 	vsSpec := &virtualServiceSpec{}
 	if err := mapstructure.Decode(vs.Spec, vsSpec); err != nil {
 		return false

--- a/topology/probes/k8s/cache.go
+++ b/topology/probes/k8s/cache.go
@@ -151,6 +151,11 @@ func (c *KubeCache) onDelete(obj interface{}) {
 	}
 }
 
+// MatchNamespace true if namespaces are identical
+func MatchNamespace(obj1, obj2 metav1.Object) bool {
+	return obj1.GetNamespace() == obj2.GetNamespace()
+}
+
 func matchSelector(obj metav1.Object, selector labels.Selector) bool {
 	return selector.Matches(labels.Set(obj.GetLabels()))
 }

--- a/topology/probes/k8s/deployment.go
+++ b/topology/probes/k8s/deployment.go
@@ -54,7 +54,9 @@ func newDeploymentProbe(client interface{}, g *graph.Graph) Subprobe {
 }
 
 func deploymentPodAreLinked(a, b interface{}) bool {
-	return matchLabelSelector(b.(*v1.Pod), a.(*v1beta1.Deployment).Spec.Selector)
+	deployment := a.(*v1beta1.Deployment)
+	pod := b.(*v1.Pod)
+	return MatchNamespace(pod, deployment) && matchLabelSelector(pod, deployment.Spec.Selector)
 }
 
 func newDeploymentPodLinker(g *graph.Graph) probe.Probe {
@@ -62,7 +64,9 @@ func newDeploymentPodLinker(g *graph.Graph) probe.Probe {
 }
 
 func deploymentReplicaSetAreLinked(a, b interface{}) bool {
-	return matchLabelSelector(b.(*v1beta1.ReplicaSet), a.(*v1beta1.Deployment).Spec.Selector)
+	deployment := a.(*v1beta1.Deployment)
+	replicaset := b.(*v1beta1.ReplicaSet)
+	return MatchNamespace(replicaset, deployment) && matchLabelSelector(replicaset, deployment.Spec.Selector)
 }
 
 func newDeploymentReplicaSetLinker(g *graph.Graph) probe.Probe {

--- a/topology/probes/k8s/ingress.go
+++ b/topology/probes/k8s/ingress.go
@@ -55,6 +55,10 @@ func ingressServiceAreLinked(a, b interface{}) bool {
 	ingress := a.(*v1beta1.Ingress)
 	service := b.(*v1.Service)
 
+	if !MatchNamespace(ingress, service) {
+		return false
+	}
+
 	if ingress.Spec.Backend != nil && ingress.Spec.Backend.ServiceName == service.Name {
 		return true
 	}

--- a/topology/probes/k8s/linker.go
+++ b/topology/probes/k8s/linker.go
@@ -45,9 +45,8 @@ func (l *ABLinker) newEdge(parent, child *graph.Node) *graph.Edge {
 
 // GetABLinks implementing graph.Linker
 func (l *ABLinker) GetABLinks(aNode *graph.Node) (edges []*graph.Edge) {
-	namespace, _ := aNode.GetFieldString(MetadataField("Namespace"))
 	if a := l.aCache.GetByNode(aNode); a != nil {
-		for _, b := range l.bCache.getByNamespace(namespace) {
+		for _, b := range l.bCache.List() {
 			uid := b.(metav1.Object).GetUID()
 			if bNode := l.graph.GetNode(graph.Identifier(uid)); bNode != nil {
 				if l.areLinked(a, b) {
@@ -61,9 +60,8 @@ func (l *ABLinker) GetABLinks(aNode *graph.Node) (edges []*graph.Edge) {
 
 // GetBALinks implementing graph.Linker
 func (l *ABLinker) GetBALinks(bNode *graph.Node) (edges []*graph.Edge) {
-	namespace, _ := bNode.GetFieldString(MetadataField("Namespace"))
 	if b := l.bCache.GetByNode(bNode); b != nil {
-		for _, a := range l.aCache.getByNamespace(namespace) {
+		for _, a := range l.aCache.List() {
 			uid := a.(metav1.Object).GetUID()
 			if aNode := l.graph.GetNode(graph.Identifier(uid)); aNode != nil {
 				if l.areLinked(a, b) {

--- a/topology/probes/k8s/pod.go
+++ b/topology/probes/k8s/pod.go
@@ -68,9 +68,11 @@ func newPodProbe(client interface{}, g *graph.Graph) Subprobe {
 func podPVCAreLinked(a, b interface{}) bool {
 	pod := a.(*v1.Pod)
 	pvc := b.(*v1.PersistentVolumeClaim)
-	if pod.Namespace != pvc.Namespace {
+
+	if !MatchNamespace(pod, pvc) {
 		return false
 	}
+
 	for _, vol := range pod.Spec.Volumes {
 		if vol.VolumeSource.PersistentVolumeClaim != nil && vol.VolumeSource.PersistentVolumeClaim.ClaimName == pvc.Name {
 			return true

--- a/topology/probes/k8s/service.go
+++ b/topology/probes/k8s/service.go
@@ -54,7 +54,9 @@ func newServiceProbe(client interface{}, g *graph.Graph) Subprobe {
 }
 
 func servicePodAreLinked(a, b interface{}) bool {
-	return matchMapSelector(b.(*v1.Pod), a.(*v1.Service).Spec.Selector)
+	service := a.(*v1.Service)
+	pod := b.(*v1.Pod)
+	return MatchNamespace(pod, service) && matchMapSelector(pod, service.Spec.Selector)
 }
 
 func newServicePodLinker(g *graph.Graph) probe.Probe {
@@ -62,7 +64,9 @@ func newServicePodLinker(g *graph.Graph) probe.Probe {
 }
 
 func serviceEndpointsAreLinked(a, b interface{}) bool {
-	return matchMapSelector(b.(*v1.Endpoints), a.(*v1.Service).Spec.Selector)
+	endpoints := b.(*v1.Endpoints)
+	service := a.(*v1.Service)
+	return MatchNamespace(endpoints, service) && matchMapSelector(endpoints, service.Spec.Selector)
 }
 
 func newServiceEndpointsLinker(g *graph.Graph) probe.Probe {

--- a/topology/probes/k8s/statefulset.go
+++ b/topology/probes/k8s/statefulset.go
@@ -57,7 +57,9 @@ func newStatefulSetProbe(client interface{}, g *graph.Graph) Subprobe {
 }
 
 func statefulSetPodAreLinked(a, b interface{}) bool {
-	return matchLabelSelector(b.(*v1.Pod), a.(*v1beta1.StatefulSet).Spec.Selector)
+	statefulset := a.(*v1beta1.StatefulSet)
+	pod := b.(*v1.Pod)
+	return MatchNamespace(pod, statefulset) && matchLabelSelector(pod, statefulset.Spec.Selector)
 }
 
 func newStatefulSetPodLinker(g *graph.Graph) probe.Probe {


### PR DESCRIPTION
this PR fixes a bug causing linker links to resources outside namespace to fail sometimes, specifically:
- storageclass --> namespace/pvc
- namespace/pvc --> pv

the fix removes automatic filtering by namespace in linker GetABLinks()/GetBALinks() and now in cases where namespace filtering is needed it the responsibility of implementer of XXXAreLinked() call back.

to test this works:

```
tests/k8s/storage.sh start
```

now check WebUI that links exists:
- [pod] default/task-pv-pod --> [pvc] default/task-pv-claim
- [sc] standard --> [pvc] default/task-pv-claim
- [sc] standard --> [pv] default/task-pv-volume
