### PR TITLE
k8s: UP/DOWN State for pod, pvc, pv resources

### DIFF
--- a/topology/probes/k8s/graph.go
+++ b/topology/probes/k8s/graph.go
@@ -70,6 +70,15 @@ func NewMetadata(manager, ty string, kubeMeta graph.Metadata, extra interface{},
 	return m
 }
 
+// SetState field of node metadata
+func SetState(m *graph.Metadata, isUp bool) {
+	state := "DOWN"
+	if isUp {
+		state = "UP"
+	}
+	m.SetField("State", state)
+}
+
 // NewEdgeMetadata creates a new edge metadata
 func NewEdgeMetadata(manager, name string) graph.Metadata {
 	m := graph.Metadata{

--- a/topology/probes/k8s/persistentvolume.go
+++ b/topology/probes/k8s/persistentvolume.go
@@ -47,7 +47,10 @@ func (h *persistentVolumeHandler) Map(obj interface{}) (graph.Identifier, graph.
 		m.SetFieldAndNormalize("ClaimRef", pv.Spec.ClaimRef.Name)
 	}
 
-	return graph.Identifier(pv.GetUID()), NewMetadata(Manager, "persistentvolume", m, pv, pv.Name)
+	metadata := NewMetadata(Manager, "persistentvolume", m, pv, pv.Name)
+	SetState(&metadata, pv.Status.Phase != "Failed")
+
+	return graph.Identifier(pv.GetUID()), metadata
 }
 
 func newPersistentVolumeProbe(client interface{}, g *graph.Graph) Subprobe {

--- a/topology/probes/k8s/persistentvolumeclaim.go
+++ b/topology/probes/k8s/persistentvolumeclaim.go
@@ -45,7 +45,10 @@ func (h *persistentVolumeClaimHandler) Map(obj interface{}) (graph.Identifier, g
 	m.SetFieldAndNormalize("VolumeMode", pvc.Spec.VolumeMode)
 	m.SetFieldAndNormalize("Status", pvc.Status.Phase)
 
-	return graph.Identifier(pvc.GetUID()), NewMetadata(Manager, "persistentvolumeclaim", m, pvc, pvc.Name)
+	metadata := NewMetadata(Manager, "persistentvolumeclaim", m, pvc, pvc.Name)
+	SetState(&metadata, pvc.Status.Phase == "Bound")
+
+	return graph.Identifier(pvc.GetUID()), metadata
 }
 
 func newPersistentVolumeClaimProbe(client interface{}, g *graph.Graph) Subprobe {

--- a/topology/probes/k8s/pod.go
+++ b/topology/probes/k8s/pod.go
@@ -58,7 +58,10 @@ func (h *podHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	}
 	m.SetField("Status", reason)
 
-	return graph.Identifier(pod.GetUID()), NewMetadata(Manager, "pod", m, pod, pod.Name)
+	metadata := NewMetadata(Manager, "pod", m, pod, pod.Name)
+	SetState(&metadata, reason == "Running")
+
+	return graph.Identifier(pod.GetUID()), metadata
 }
 
 func newPodProbe(client interface{}, g *graph.Graph) Subprobe {


### PR DESCRIPTION
added for the sake of being able to debug cascading errors for k8s storage scenarios.

to test run:

```
tests/k8s/storage.sh stop
tests/k8s/storage.sh start
```

and obverse via WebUI how the following nodes are created initially:
- task-pv-pod - DOWN (red)
- task-pv-claim - DOWN (red)
- task-pv-volume - UP (standard) 

and eventually all settle on UP (standard)
