### PR TITLE
k8s/test: add wordpress sample

### DIFF
--- a/tests/k8s/mysql-deployment.yaml
+++ b/tests/k8s/mysql-deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wordpress-mysql
+  labels:
+    app: wordpress
+    tier: mysql
+spec:
+  ports:
+    - port: 3306
+  selector:
+    app: wordpress
+    tier: mysql
+  clusterIP: None
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-pv-claim
+  labels:
+    app: wordpress
+    tier: mysql
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: wordpress-mysql
+  labels:
+    app: wordpress
+    tier: mysql
+spec:
+  selector:
+    matchLabels:
+      app: wordpress
+      tier: mysql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: wordpress
+        tier: mysql
+    spec:
+      containers:
+      - image: mysql:5.6
+        name: mysql
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-pass
+              key: password
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - name: mysql-persistent-storage
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: mysql-persistent-storage
+        persistentVolumeClaim:
+          claimName: mysql-pv-claim

--- a/tests/k8s/wordpress-deployment.yaml
+++ b/tests/k8s/wordpress-deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wordpress
+  labels:
+    app: wordpress
+    tier: frontend
+spec:
+  ports:
+    - port: 80
+  selector:
+    app: wordpress
+    tier: frontend
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wp-pv-claim
+  labels:
+    app: wordpress
+    tier: frontend
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: wordpress
+  labels:
+    app: wordpress
+    tier: frontend
+spec:
+  selector:
+    matchLabels:
+      app: wordpress
+      tier: frontend
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: wordpress
+        tier: frontend
+    spec:
+      containers:
+      - image: wordpress:4.8-apache
+        name: wordpress
+        env:
+        - name: WORDPRESS_DB_HOST
+          value: wordpress-mysql
+        - name: WORDPRESS_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-pass
+              key: password
+        ports:
+        - containerPort: 80
+          name: wordpress
+        volumeMounts:
+        - name: wordpress-persistent-storage
+          mountPath: /var/www/html
+      volumes:
+      - name: wordpress-persistent-storage
+        persistentVolumeClaim:
+          claimName: wp-pv-claim

--- a/tests/k8s/wordpress.sh
+++ b/tests/k8s/wordpress.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+SRC=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+WORDPRESS=https://k8s.io/examples/application/wordpress
+
+apply() {
+        kubectl apply $*
+}
+
+delete() {
+        kubectl delete --grace-period=0 --force $*
+}
+
+stop() {
+        kubectl delete secret mysql-pass
+        delete deployment -l app=wordpress
+        delete service -l app=wordpress
+        delete pvc -l app=wordpress
+}
+
+start() {
+        local password=abc123
+        kubectl create secret generic mysql-pass \
+                --from-literal="password=$password"
+        apply -f $SRC/mysql-deployment.yaml
+        apply -f $SRC/wordpress-deployment.yaml
+}
+
+status() {
+        kubectl get service -l app=wordpress
+        kubectl get deployment -l app=wordpress
+        kubectl get pods -l app=wordpress
+        kubectl get pvc -l app=wordpress
+}
+
+url() {
+        minikube service wordpress --url
+}
+
+case "$1" in
+        stop)
+                stop
+                ;;
+        start)
+                start
+                ;;
+        status)
+                status
+                ;;
+        url)
+                url
+                ;;
+        *)
+                echo "$0 [stop|start|status|url|help]"
+                exit 1
+                ;;
+esac
+exit 0

--- a/tests/k8s_test.go
+++ b/tests/k8s_test.go
@@ -622,3 +622,47 @@ func TestStorageScenario(t *testing.T) {
 		},
 	)
 }
+
+func TestWordpressScenario(t *testing.T) {
+	storage := "./k8s/wordpress.sh"
+	testRunner(
+		t,
+		[]Cmd{
+			{storage + " start", true},
+		},
+		[]Cmd{
+			{storage + " stop", false},
+		},
+		[]CheckFunction{
+			func(c *CheckContext) error {
+				// check wordpress-mysql nodes
+				if _, err := checkNodeCreation(t, c, k8s.Manager, "persistentvolumeclaim", "mysql-pv-claim"); err != nil {
+					return err
+				}
+
+				if _, err := checkNodeCreation(t, c, k8s.Manager, "deployment", "wordpress-mysql"); err != nil {
+					return err
+				}
+
+				if _, err := checkNodeCreation(t, c, k8s.Manager, "service", "wordpress-mysql"); err != nil {
+					return err
+				}
+
+				// check wordpress nodes
+				if _, err := checkNodeCreation(t, c, k8s.Manager, "persistentvolumeclaim", "wp-pv-claim"); err != nil {
+					return err
+				}
+
+				if _, err := checkNodeCreation(t, c, k8s.Manager, "deployment", "wordpress"); err != nil {
+					return err
+				}
+
+				if _, err := checkNodeCreation(t, c, k8s.Manager, "service", "wordpress"); err != nil {
+					return err
+				}
+
+				return nil
+			},
+		},
+	)
+}


### PR DESCRIPTION
added a new k8s sample and test scenario - wordpress backed by mysql and pvc

you can check the PR by:

Open the WebUI and run:

```
tests/k8s/wordpress.sh start
# verify wordress-mysql and wordpress deployments were created

tests/k8s/wordpress.sh status
# connect a Web to the service port to view wordpress execution

tests/k8s/wordpress.sh stop
# verify wordpress resources are removed
```

