### PR TITLE
K8s empty service links

### DIFF
--- a/topology/probes/k8s/cache.go
+++ b/topology/probes/k8s/cache.go
@@ -156,19 +156,21 @@ func MatchNamespace(obj1, obj2 metav1.Object) bool {
 	return obj1.GetNamespace() == obj2.GetNamespace()
 }
 
-func matchSelector(obj metav1.Object, selector labels.Selector) bool {
+func matchSelector(obj metav1.Object, selector labels.Selector, matchEmpty ...bool) bool {
+	if selector.Empty() && len(matchEmpty) > 0 && !matchEmpty[0] {
+		return false
+	}
 	return selector.Matches(labels.Set(obj.GetLabels()))
 }
 
-func matchLabelSelector(obj metav1.Object, labelSelector *metav1.LabelSelector) bool {
+func matchLabelSelector(obj metav1.Object, labelSelector *metav1.LabelSelector, matchEmpty ...bool) bool {
 	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
-	return err == nil && selector.Matches(labels.Set(obj.GetLabels()))
+	return err == nil && matchSelector(obj, selector, matchEmpty...)
 }
 
-func matchMapSelector(obj metav1.Object, mapSelector map[string]string) bool {
+func matchMapSelector(obj metav1.Object, mapSelector map[string]string, matchEmpty ...bool) bool {
 	labelSelector := &metav1.LabelSelector{MatchLabels: mapSelector}
-	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
-	return err == nil && selector.Matches(labels.Set(obj.GetLabels()))
+	return matchLabelSelector(obj, labelSelector, matchEmpty...)
 }
 
 func filterObjectsBySelector(objects []interface{}, labelSelector *metav1.LabelSelector, namespace ...string) (out []metav1.Object) {

--- a/topology/probes/k8s/service.go
+++ b/topology/probes/k8s/service.go
@@ -56,7 +56,7 @@ func newServiceProbe(client interface{}, g *graph.Graph) Subprobe {
 func servicePodAreLinked(a, b interface{}) bool {
 	service := a.(*v1.Service)
 	pod := b.(*v1.Pod)
-	return MatchNamespace(pod, service) && matchMapSelector(pod, service.Spec.Selector)
+	return MatchNamespace(pod, service) && matchMapSelector(pod, service.Spec.Selector, false)
 }
 
 func newServicePodLinker(g *graph.Graph) probe.Probe {
@@ -66,7 +66,7 @@ func newServicePodLinker(g *graph.Graph) probe.Probe {
 func serviceEndpointsAreLinked(a, b interface{}) bool {
 	endpoints := b.(*v1.Endpoints)
 	service := a.(*v1.Service)
-	return MatchNamespace(endpoints, service) && matchMapSelector(endpoints, service.Spec.Selector)
+	return MatchNamespace(endpoints, service) && (endpoints.Name == service.Name || matchMapSelector(endpoints, service.Spec.Selector, false))
 }
 
 func newServiceEndpointsLinker(g *graph.Graph) probe.Probe {


### PR DESCRIPTION
this fixes the case in which a service (such as default/kubernetes) will point to all pods in case of an empty label selector (which is incorrect).

to check you can create a pod in the default namespace and make sure default/kubernetes service does **not** point to it.

to create the pod you can use:

```
kubectl apply -f tests/k8s/pod.yaml
```

NOTE: depends to https://github.com/skydive-project/skydive/pull/1690