### PR TITLE
k8s: remove experimental note

### DIFF
--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -112,9 +112,6 @@ analyzer:
       # - istio
 
     k8s:
-      # EXPERIMENTAL: k8s probe is still under development and should not be used
-      # on production systems
-
       # kubeconfig resolution order:
       # - if config_file param is defined then use it;
       # - else if $KUBECONFIG environment is define then use it;


### PR DESCRIPTION
One the following are merged k8s is ready for productive use:
#1696 
#1690 
#1691 

