### PR TITLE
custom flow transformer - do not report new flows

### DIFF
--- a/contrib/objectstore/subscriber/flowtransformer/custom1/custom1.go
+++ b/contrib/objectstore/subscriber/flowtransformer/custom1/custom1.go
@@ -1,6 +1,10 @@
 package custom1
 
 import (
+	"time"
+
+	"github.com/pmylund/go-cache"
+
 	"github.com/skydive-project/skydive/flow"
 )
 
@@ -19,10 +23,25 @@ type Flow struct {
 
 // FlowTransformer is a custom transformer for flows
 type FlowTransformer struct {
+	seenFlows *cache.Cache
 }
 
 // Transform transforms a flow before being stored
 func (m *FlowTransformer) Transform(f *flow.Flow) interface{} {
+	// do not report new flows (i.e. the first time you see them)
+	if f.FinishType != flow.FlowFinishType_TIMEOUT {
+		_, seen := m.seenFlows.Get(f.UUID)
+		if f.FinishType == flow.FlowFinishType_NOT_FINISHED {
+			m.seenFlows.Set(f.UUID, true, cache.DefaultExpiration)
+			if !seen {
+				return nil
+			}
+		} else {
+			m.seenFlows.Set(f.UUID, true, time.Minute)
+		}
+	} else {
+		m.seenFlows.Delete(f.UUID)
+	}
 	return &Flow{
 		UUID:             f.UUID,
 		LayersPath:       f.LayersPath,
@@ -36,7 +55,9 @@ func (m *FlowTransformer) Transform(f *flow.Flow) interface{} {
 	}
 }
 
-// New returns a new Custom1Marshaller
+// New returns a new FlowTransformer
 func New() *FlowTransformer {
-	return &FlowTransformer{}
+	return &FlowTransformer{
+		seenFlows: cache.New(10*time.Minute, 10*time.Minute),
+	}
 }


### PR DESCRIPTION
The architects of security-advisor asked us to discard newly created flows (when they are first reported by the analyzer), unless they are expired/finished.
This PR implements their requested logic, as part of their `custom1` flow transformer.
@safchain I appreciate your help.