### PR TITLE
ci: delete virbr0 interface for vagrant during cleanup

### DIFF
--- a/contrib/ansible/roles/skydive_dev/tasks/docker-ce.yml
+++ b/contrib/ansible/roles/skydive_dev/tasks/docker-ce.yml
@@ -1,0 +1,45 @@
+---
+- package:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+     - docker
+     - docker-client
+     - docker-client-latest
+     - docker-common
+     - docker-latest
+     - docker-latest-logrotate
+     - docker-logrotate
+     - docker-selinux
+     - docker-engine-selinux
+     - docker-engine
+
+- yum_repository:
+    state: present
+    name: docker-ce-stable
+    description: "Docker CE Stable - $basearch"
+    gpgcheck: true
+    gpgkey: https://download.docker.com/linux/fedora/gpg
+    baseurl: "https://download.docker.com/linux/fedora/$releasever/$basearch/stable"
+
+- group:
+    name: docker
+    state: present
+
+- user:
+    name: vagrant
+    groups: docker
+    append: yes
+
+- package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+     - docker-ce
+     - docker-ce-cli
+     - containerd.io
+
+- service:
+    name: docker
+    state: restarted
+    enabled: yes

--- a/contrib/ansible/roles/skydive_dev/tasks/main.yml
+++ b/contrib/ansible/roles/skydive_dev/tasks/main.yml
@@ -80,3 +80,5 @@
     - vagrant
 
 - include_tasks: vpp.yml
+
+- include_tasks: virtualbox.yml

--- a/contrib/ansible/roles/skydive_dev/tasks/virtualbox.yml
+++ b/contrib/ansible/roles/skydive_dev/tasks/virtualbox.yml
@@ -1,0 +1,11 @@
+---
+- package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - akmod-VirtualBox
+    - VirtualBox
+    - kernel-devel
+    - "kernel-devel-{{ ansible_kernel }}"
+
+- shell: "akmods --kernels `uname -r`"

--- a/scripts/ci/cleanup.sh
+++ b/scripts/ci/cleanup.sh
@@ -62,10 +62,6 @@ EOF
   systemctl restart orientdb
   systemctl restart lxd
 
-  virsh net-destroy vagrant0
-  virsh net-destroy vagrant-libvirt
-  systemctl restart libvirtd
-
   for vm in dev_dev vagrant_analyzer1 vagrant_agent1 devstack_devstack
   do
     virsh destroy $vm
@@ -73,11 +69,16 @@ EOF
     virsh vol-delete $vm.img default
   done
 
+  virsh net-destroy vagrant0
+  virsh net-destroy vagrant-libvirt
+  systemctl restart libvirtd
+
   rm -rf /tmp/skydive_agent* /tmp/skydive-etcd
   rm -rf /var/lib/jenkins/.vagrant.d/tmp
 
   # time to restart services
   sleep 8
+  ip l del virbr0
 }
 
 function snapshot_items() {

--- a/scripts/ci/jobs/jobs.yml
+++ b/scripts/ci/jobs/jobs.yml
@@ -338,11 +338,11 @@
           test: scripts/ci/run-opencontrail-tests.sh
 
 - job:
-    name: 'skydive-functional-tests-backend-elasticsearch'
+    name: skydive-functional-tests-backend-elasticsearch
     defaults: skydive
     triggers:
       - skydive-pull-request:
-          name: "functional-tests-backend-elasticsearch"
+          name: functional-tests-backend-elasticsearch
           trigger-prefix: "(all )?"
           only-trigger-phrase: false
           cancel-builds-on-update: true
@@ -356,11 +356,11 @@
       - chuck-norris
 
 - job:
-    name: 'skydive-functional-tests-backend-orientdb'
+    name: skydive-functional-tests-backend-orientdb
     defaults: skydive
     triggers:
       - skydive-pull-request:
-          name: "functional-tests-backend-orientdb"
+          name: functional-tests-backend-orientdb
           trigger-prefix: "(all )?"
           only-trigger-phrase: false
           cancel-builds-on-update: true
@@ -754,7 +754,7 @@
       - chuck-norris
 
 - job:
-    name: 'skydive-functional-hw-tests'
+    name: skydive-functional-hw-tests
     defaults: skydive
     parameters:
       - skydive-default-parameters
@@ -762,7 +762,7 @@
           slave-name: baremetal
     triggers:
       - skydive-pull-request:
-          name: "functional-tests-ebpf"
+          name: functional-hw-tests
           trigger-prefix: "(all )?"
           only-trigger-phrase: false
           cancel-builds-on-update: true

--- a/scripts/ci/jobs/jobs.yml
+++ b/scripts/ci/jobs/jobs.yml
@@ -542,6 +542,7 @@
           only-trigger-phrase: true
           cancel-builds-on-update: false
     builders:
+      - skydive-cleanup
       - skydive-test:
           test: scripts/ci/run-kolla-tests.sh
     wrappers:
@@ -569,6 +570,7 @@
           only-trigger-phrase: true
           cancel-builds-on-update: false
     builders:
+      - skydive-cleanup
       - skydive-test:
           test: VAGRANT_DEFAULT_PROVIDER=libvirt scripts/ci/run-vagrant-tests.sh
     wrappers:


### PR DESCRIPTION
skip skydive-go-fmt
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-scale-tests
skip skydive-cdd-overview-tests
skip skydive-unit-tests
skip skydive-compile-tests
skip skydive-k8s-tests
skip skydive-ppc64le-tests
skip skydive-functional-tests-ebpf
skip skydive-functional-hw-tests