### PR TITLE
istio: add weight label on edges from virtualservice to pod

### DIFF
--- a/statics/js/components/graph-layout.js
+++ b/statics/js/components/graph-layout.js
@@ -352,7 +352,7 @@ var TopologyGraphLayout = function(vm, selector) {
 
 TopologyGraphLayout.prototype = {
 
-  linkLabelFactory: function(link) {
+  linkL2LabelFactory: function(link) {
     let type, driver;
     switch (this.linkLabelType) {
       case "latency":
@@ -367,7 +367,6 @@ TopologyGraphLayout.prototype = {
     driver.setup(this);
     return driver;
   },
-
   notifyHandlers: function(ev, v1) {
     var self = this;
 
@@ -1482,29 +1481,37 @@ TopologyGraphLayout.prototype = {
   updateLinkLabelData: function() {
     var self = this;
 
-    const driver = self.linkLabelFactory();
+    const l2 = self.linkL2LabelFactory();
 
     for (var i in this.links) {
       var link = this.links[i];
 
       if (!link.source.visible || !link.target.visible)
         continue;
-      if (link.metadata.RelationType !== "layer2")
-        continue;
 
-      driver.updateData(link);
+      if (link.metadata.RelationType === "layer2") {
+        l2.updateData(link);
 
-      if (driver.hasData(link)) {
+	if (l2.hasData(link)) {
+	  this.linkLabelData[link.id] = {
+	    id: "link-label-" + link.id,
+	    link: link,
+	    text: driver.getText(link),
+	    active: driver.isActive(link),
+	    warning: driver.isWarning(link),
+	    alert: driver.isAlert(link),
+	  };
+	} else {
+	  delete this.linkLabelData[link.id];
+	}
+      }
+
+      if (link.metadata.hasOwnProperty('weight')) {
         this.linkLabelData[link.id] = {
-          id: "link-label-" + link.id,
-          link: link,
-          text: driver.getText(link),
-          active: driver.isActive(link),
-          warning: driver.isWarning(link),
-          alert: driver.isAlert(link),
-        };
-      } else {
-        delete this.linkLabelData[link.id];
+	  id: "link-label-" + link.id,
+	  link: link,
+	  text: `${link.metadata.weight}%`,
+	};
       }
     }
   },


### PR DESCRIPTION
This PR adds weight label on edges from virtualservice to pod, according to weight field in the edge metadata (if exists). 
For checking, look at the UI after executing the following command:
`kubectl create -f tests/istio/virtualservice-pod.yaml`