### PR TITLE
docker: fix container name field

### DIFF
--- a/tests/docker_test.go
+++ b/tests/docker_test.go
@@ -38,7 +38,7 @@ func TestDockerSimple(t *testing.T) {
 
 		checks: []CheckFunction{func(c *CheckContext) error {
 			gremlin := c.gremlin.V().Has("Type", "netns", "Manager", "docker")
-			gremlin = gremlin.Out("Type", "container", "Docker.ContainerName", "/test-skydive-docker-simple")
+			gremlin = gremlin.Out("Type", "container", "Docker.ContainerName", "test-skydive-docker-simple")
 
 			nodes, err := c.gh.GetNodes(gremlin)
 			if err != nil {
@@ -72,7 +72,7 @@ func TestDockerShareNamespace(t *testing.T) {
 
 		checks: []CheckFunction{func(c *CheckContext) error {
 			gremlin := c.gremlin.V().Has("Type", "netns", "Manager", "docker")
-			gremlin = gremlin.Out().Has("Type", "container", "Docker.ContainerName", g.Within("/test-skydive-docker-share-ns", "/test-skydive-docker-share-ns2"))
+			gremlin = gremlin.Out().Has("Type", "container", "Docker.ContainerName", g.Within("test-skydive-docker-share-ns", "test-skydive-docker-share-ns2"))
 			nodes, err := c.gh.GetNodes(gremlin)
 			if err != nil {
 				return err
@@ -102,7 +102,7 @@ func TestDockerNetHost(t *testing.T) {
 		mode: Replay,
 
 		checks: []CheckFunction{func(c *CheckContext) error {
-			gremlin := c.gremlin.V().Has("Docker.ContainerName", "/test-skydive-docker-net-host", "Type", "container")
+			gremlin := c.gremlin.V().Has("Docker.ContainerName", "test-skydive-docker-net-host", "Type", "container")
 			nodes, err := c.gh.GetNodes(gremlin)
 			if err != nil {
 				return err
@@ -141,7 +141,7 @@ func TestDockerLabels(t *testing.T) {
 		mode: Replay,
 
 		checks: []CheckFunction{func(c *CheckContext) error {
-			gremlin := c.gremlin.V().Has("Docker.ContainerName", "/test-skydive-docker-labels", "Type", "container", "Docker.Labels.a.b.c", "123", "Docker.Labels.a~b/c@d", "456")
+			gremlin := c.gremlin.V().Has("Docker.ContainerName", "test-skydive-docker-labels", "Type", "container", "Docker.Labels.a.b.c", "123", "Docker.Labels.a~b/c@d", "456")
 			_, err := c.gh.GetNode(gremlin)
 			return err
 		}},

--- a/topology/probes/docker/docker.go
+++ b/topology/probes/docker/docker.go
@@ -110,7 +110,7 @@ func (probe *Probe) registerContainer(id string) {
 
 	dockerMetadata := graph.Metadata{
 		"ContainerID":   info.ID,
-		"ContainerName": info.Name,
+		"ContainerName": info.Name[1:],
 	}
 
 	if len(info.Config.Labels) != 0 {


### PR DESCRIPTION
removed the leading back-slash in the `ContainerName` field:

![image](https://user-images.githubusercontent.com/2760739/54876171-20e98c80-4e14-11e9-9700-badfb98731d7.png)
