### PR TITLE
filter flows by tag

### DIFF
--- a/contrib/objectstore/subscriber/flowtransformer.go
+++ b/contrib/objectstore/subscriber/flowtransformer.go
@@ -26,7 +26,7 @@ import (
 // FlowTransformer allows generic transformations of a flow
 type FlowTransformer interface {
 	// Transform transforms a flow before being stored
-	Transform(flow *flow.Flow) interface{}
+	Transform(flow *flow.Flow, tag Tag) interface{}
 }
 
 // NewFlowTransformer creates a new flow transformer based on a name string

--- a/contrib/objectstore/subscriber/objectstore.go
+++ b/contrib/objectstore/subscriber/objectstore.go
@@ -87,14 +87,15 @@ func (s *Subscriber) StoreFlows(flows []*flow.Flow) error {
 	// transform flows and save to in-memory arrays, based on tag
 	if flows != nil {
 		for _, fl := range flows {
+			flowTag := s.flowClassifier.GetFlowTag(fl)
+
 			var transformedFlow interface{}
 			if s.flowTransformer != nil {
-				transformedFlow = s.flowTransformer.Transform(fl)
+				transformedFlow = s.flowTransformer.Transform(fl, flowTag)
 			} else {
 				transformedFlow = fl
 			}
 			if transformedFlow != nil {
-				flowTag := s.flowClassifier.GetFlowTag(fl)
 				s.flows[flowTag] = append(s.flows[flowTag], transformedFlow)
 			}
 		}

--- a/contrib/objectstore/subscriber/secadvisor.go
+++ b/contrib/objectstore/subscriber/secadvisor.go
@@ -44,7 +44,12 @@ type SecurityAdvisorFlowTransformer struct {
 }
 
 // Transform transforms a flow before being stored
-func (ft *SecurityAdvisorFlowTransformer) Transform(f *flow.Flow) interface{} {
+func (ft *SecurityAdvisorFlowTransformer) Transform(f *flow.Flow, tag Tag) interface{} {
+	// do not report flows that are neither ingress or egress
+	if tag != tagIngress && tag != tagEgress {
+		return nil
+	}
+
 	// do not report new flows (i.e. the first time you see them)
 	if f.FinishType != flow.FlowFinishType_TIMEOUT {
 		_, seen := ft.seenFlows.Get(f.UUID)


### PR DESCRIPTION
Another requirement of IBM's security advisor architects:
Do not store flows to object store which are neither tagged "ingress" or "egress".