### PR TITLE
ebpf: do not use shell pipefail option

### DIFF
--- a/probe/ebpf/Makefile
+++ b/probe/ebpf/Makefile
@@ -1,4 +1,3 @@
-SHELL=/bin/sh -o pipefail
 LLC ?= llc
 CLANG ?= clang
 DOCKER_FILE ?= Dockerfile

--- a/scripts/ci/cleanup.sh
+++ b/scripts/ci/cleanup.sh
@@ -61,6 +61,7 @@ EOF
   systemctl restart elasticsearch
   systemctl restart orientdb
   systemctl restart lxd
+  systemctl restart vpp
 
   for vm in dev_dev vagrant_analyzer1 vagrant_agent1 devstack_devstack
   do


### PR DESCRIPTION
skip skydive-go-fmt
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-scale-tests
skip skydive-cdd-overview-tests
skip skydive-unit-tests
skip skydive-compile-tests
skip skydive-k8s-tests
skip skydive-ppc64le-tests