### PR TITLE
K8s cross links

### DIFF
--- a/topology/probes/k8s/container.go
+++ b/topology/probes/k8s/container.go
@@ -144,7 +144,9 @@ func newContainerProbe(client interface{}, g *graph.Graph) Subprobe {
 }
 
 func newPodContainerLinker(g *graph.Graph) probe.Probe {
-	return newResourceLinker(g, GetSubprobesMap(Manager), "pod", MetadataFields("Namespace", "Name"), "container", MetadataFields("Namespace", "Pod"), topology.OwnershipMetadata())
+	podIndexer := newResourceIndexer(g, Manager, "pod", MetadataFields("Namespace", "Name"))
+	containerIndexer := newResourceIndexer(g, Manager, "container", MetadataFields("Namespace", "Pod"))
+	return newResourceLinker(g, podIndexer, containerIndexer, topology.OwnershipMetadata())
 }
 
 func newDockerIndexer(g *graph.Graph) *graph.MetadataIndexer {

--- a/topology/probes/k8s/container.go
+++ b/topology/probes/k8s/container.go
@@ -174,7 +174,7 @@ func newContainerDockerLinker(g *graph.Graph) probe.Probe {
 	dockerIndexer := newDockerIndexer(g)
 	dockerIndexer.Start()
 
-	ml := graph.NewMetadataIndexerLinker(g, containerIndexer, dockerIndexer, NewEdgeMetadata(Manager, "association"))
+	ml := graph.NewMetadataIndexerLinker(g, containerIndexer, dockerIndexer, NewEdgeMetadata(Manager, "container"))
 
 	linker := &Linker{
 		ResourceLinker: ml.ResourceLinker,

--- a/topology/probes/k8s/node.go
+++ b/topology/probes/k8s/node.go
@@ -78,5 +78,7 @@ func newHostNodeLinker(g *graph.Graph) probe.Probe {
 }
 
 func newNodePodLinker(g *graph.Graph) probe.Probe {
-	return newResourceLinker(g, GetSubprobesMap(Manager), "node", MetadataFields("Name"), "pod", MetadataFields("Node"), NewEdgeMetadata(Manager, "association"))
+	nodeIndexer := newResourceIndexer(g, Manager, "node", MetadataFields("Name"))
+	podIndexer := newResourceIndexer(g, Manager, "pod", MetadataFields("Node"))
+	return newResourceLinker(g, nodeIndexer, podIndexer, NewEdgeMetadata(Manager, "association"))
 }

--- a/topology/probes/k8s/node.go
+++ b/topology/probes/k8s/node.go
@@ -67,7 +67,7 @@ func newHostNodeLinker(g *graph.Graph) probe.Probe {
 	nodeIndexer := graph.NewMetadataIndexer(g, nodeProbe, graph.Metadata{"Type": "node"}, MetadataField("Name"))
 	nodeIndexer.Start()
 
-	ml := graph.NewMetadataIndexerLinker(g, hostIndexer, nodeIndexer, NewEdgeMetadata(Manager, "association"))
+	ml := graph.NewMetadataIndexerLinker(g, hostIndexer, nodeIndexer, NewEdgeMetadata(Manager, "node"))
 
 	linker := &Linker{
 		ResourceLinker: ml.ResourceLinker,
@@ -80,5 +80,5 @@ func newHostNodeLinker(g *graph.Graph) probe.Probe {
 func newNodePodLinker(g *graph.Graph) probe.Probe {
 	nodeIndexer := newResourceIndexer(g, Manager, "node", MetadataFields("Name"))
 	podIndexer := newResourceIndexer(g, Manager, "pod", MetadataFields("Node"))
-	return newResourceLinker(g, nodeIndexer, podIndexer, NewEdgeMetadata(Manager, "association"))
+	return newResourceLinker(g, nodeIndexer, podIndexer, NewEdgeMetadata(Manager, "node"))
 }


### PR DESCRIPTION
Provide cross links (which associate between k8s node to physical node) a meaningful RelationType:
- k8s.container --> docker
- k8s.node --> host

To test enable in skydive.yml:

```
analyzer:
  topology:
    probes:
    - k8s
agent:
  topology:
    probes: 
    - docker
```

And run allinone:

```
sudo $(which skydive) -c skydive.yml allinone 
```

Now verify that when pressing on cross links you see the correct RelationType

![image](https://user-images.githubusercontent.com/2760739/55079362-ac794c80-50a4-11e9-84da-9926805e0d18.png)
