### PR TITLE
istio: check existence of gateways declared by a virtualservice

### DIFF
--- a/topology/probes/istio/verifiers.go
+++ b/topology/probes/istio/verifiers.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2018 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package istio
+
+import (
+	"github.com/skydive-project/skydive/graffiti/graph"
+	"github.com/skydive-project/skydive/probe"
+)
+
+type verifierHandler func(g *graph.Graph) *resourceVerifier
+
+type resourceVerifier struct {
+	graph.DefaultGraphListener
+	g                *graph.Graph
+	verifier         func(*graph.Graph)
+	listenerHandlers []graph.ListenerHandler
+}
+
+func (rv *resourceVerifier) OnNodeAdded(node *graph.Node) {
+	rv.verifier(rv.g)
+}
+
+func (rv *resourceVerifier) OnNodeUpdated(node *graph.Node) {
+	rv.verifier(rv.g)
+}
+
+func (rv *resourceVerifier) OnNodeDeleted(node *graph.Node) {
+	rv.verifier(rv.g)
+}
+
+func (rv *resourceVerifier) Start() {
+	for _, lh := range rv.listenerHandlers {
+		lh.AddEventListener(rv)
+	}
+}
+
+func (rv *resourceVerifier) Stop() {
+	for _, lh := range rv.listenerHandlers {
+		lh.RemoveEventListener(rv)
+	}
+}
+
+func newResourceVerifier(g *graph.Graph, lh []graph.ListenerHandler, verifier func(*graph.Graph)) *resourceVerifier {
+	return &resourceVerifier{
+		g:                g,
+		listenerHandlers: lh,
+		verifier:         verifier,
+	}
+}
+
+func initResourceVerifiers(handlers []verifierHandler, g *graph.Graph) []probe.Probe {
+	verifiers := []probe.Probe{}
+	for _, h := range handlers {
+		verifiers = append(verifiers, h(g))
+	}
+	return verifiers
+}

--- a/topology/probes/k8s/k8s.go
+++ b/topology/probes/k8s/k8s.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/skydive-project/skydive/config"
 	"github.com/skydive-project/skydive/graffiti/graph"
+	"github.com/skydive-project/skydive/probe"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -106,7 +107,9 @@ func NewK8sProbe(g *graph.Graph) (*Probe, error) {
 
 	linkers := InitLinkers(linkerHandlers, g)
 
-	probe := NewProbe(g, Manager, subprobes[Manager], linkers)
+	verifiers := []probe.Probe{}
+
+	probe := NewProbe(g, Manager, subprobes[Manager], linkers, verifiers)
 
 	probe.AppendClusterLinkers(
 		"namespace",

--- a/topology/probes/k8s/probe.go
+++ b/topology/probes/k8s/probe.go
@@ -81,6 +81,7 @@ type Probe struct {
 	manager   string
 	subprobes map[string]Subprobe
 	linkers   []probe.Probe
+	verifiers []probe.Probe
 }
 
 // Subprobe describes a probe for a specific Kubernetes resource
@@ -110,6 +111,10 @@ func (p *Probe) Start() {
 	for _, subprobe := range p.subprobes {
 		subprobe.Start()
 	}
+
+	for _, verifier := range p.verifiers {
+		verifier.Start()
+	}
 }
 
 // Stop k8s probe
@@ -120,6 +125,10 @@ func (p *Probe) Stop() {
 
 	for _, subprobe := range p.subprobes {
 		subprobe.Stop()
+	}
+
+	for _, verifier := range p.verifiers {
+		verifier.Stop()
 	}
 }
 
@@ -138,7 +147,7 @@ func (p *Probe) AppendNamespaceLinkers(types ...string) {
 }
 
 // NewProbe creates the probe for tracking k8s events
-func NewProbe(g *graph.Graph, manager string, subprobes map[string]Subprobe, linkers []probe.Probe) *Probe {
+func NewProbe(g *graph.Graph, manager string, subprobes map[string]Subprobe, linkers []probe.Probe, verifiers []probe.Probe) *Probe {
 	names := []string{}
 	for k := range subprobes {
 		names = append(names, k)
@@ -149,6 +158,7 @@ func NewProbe(g *graph.Graph, manager string, subprobes map[string]Subprobe, lin
 		manager:   manager,
 		subprobes: subprobes,
 		linkers:   linkers,
+		verifiers: verifiers,
 	}
 }
 


### PR DESCRIPTION
This PR adds first sanity check for Istio configuration resources. In this check, if a virtualservice declares a gateway which doesn't exist, an error will appear in this virtualservice metadata.
As part of the implementation, k8s subprobes creation mechanism has been generalized.
To check the changes, one can create a virtualservice and the corresponding gateway with `kubect create -f tests/istio/gateway-virtualservice.yaml` and observe the "OK" state of the virtualservice. After that, one can delete the gateway by `kubectl delete gateways skydive-test-gateway-virtualservice` (refresh the page) and observe the "ERROR" state of the virtualservice.