### PR TITLE
[WIP] docker/runc: emit warnings (not error) in case does not exist

### DIFF
--- a/topology/probes/docker/docker.go
+++ b/topology/probes/docker/docker.go
@@ -192,7 +192,8 @@ func (probe *Probe) connect() error {
 	defer probe.client.Close()
 
 	if _, err := probe.client.ServerVersion(context.Background()); err != nil {
-		logging.GetLogger().Errorf("Failed to connect to Docker daemon: %s", err)
+		// in case docker does not exist we emit warnings not and errors
+		logging.GetLogger().Warningf("Failed to connect to Docker daemon: %s", err)
 		return err
 	}
 

--- a/topology/probes/runc/runc.go
+++ b/topology/probes/runc/runc.go
@@ -453,7 +453,8 @@ func (probe *Probe) start() {
 				}
 			}
 		case err := <-probe.watcher.Errors:
-			logging.GetLogger().Errorf("Error while watching runc state folder: %s", err)
+			// in case runC does not exist we emit a warnings not an errors
+			logging.GetLogger().Warningf("Error while watching runc state folder: %s", err)
 		case <-ticker.C:
 		}
 	}


### PR DESCRIPTION
Mute logs (warning instead of errors) when docker or runC probes are created back capabilities are missing from host.

To test create a system which is missing either runc or docker and then run:

```
export SKYDIVE_AGENT_TOPOLOGY_PROBES="runc docker"
sudo -E $(which skydive) allinone
```

And verify that repeated log messages are a warning every 1s