### PR TITLE
istio: add protocol field to virtualservice-pod edge metadata

### DIFF
--- a/statics/js/components/graph-layout.js
+++ b/statics/js/components/graph-layout.js
@@ -1506,11 +1506,11 @@ TopologyGraphLayout.prototype = {
 	}
       }
 
-      if (link.metadata.hasOwnProperty('weight')) {
+      if (link.metadata.hasOwnProperty('Weight')) {
         this.linkLabelData[link.id] = {
 	  id: "link-label-" + link.id,
 	  link: link,
-	  text: `${link.metadata.weight}%`,
+	  text: `${link.metadata.Weight}%`,
 	};
       }
     }

--- a/tests/istio/virtualservice-pod.yaml
+++ b/tests/istio/virtualservice-pod.yaml
@@ -10,15 +10,33 @@ spec:
     - destination:
         host: reviews.prod.svc.cluster.local
         subset: v1
-      weight: 40
+      weight: 90
+    - destination:
+        host: reviews.prod.svc.cluster.local
+        subset: v2
+      weight: 10
 ---
 apiVersion: v1
 kind: Pod
 metadata:
-  name: skydive-test-virtualservice-pod
+  name: podv1
   labels:
     app: reviews.prod.svc.cluster.local
     version: v1
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: podv2
+  labels:
+    app: reviews.prod.svc.cluster.local
+    version: v2
 spec:
   containers:
   - name: nginx

--- a/tests/istio_test.go
+++ b/tests/istio_test.go
@@ -65,11 +65,18 @@ func TestIstioVirtualServicePodScenario(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				pod, err := checkNodeCreation(t, c, k8s.Manager, "pod", name)
+				podv1, err := checkNodeCreation(t, c, k8s.Manager, "pod", "podv1")
 				if err != nil {
 					return err
 				}
-				if err = checkEdge(t, c, virtualservice, pod, "virtualservice"); err != nil {
+				podv2, err := checkNodeCreation(t, c, k8s.Manager, "pod", "podv2")
+				if err != nil {
+					return err
+				}
+				if err = checkEdge(t, c, virtualservice, podv1, "virtualservice", "Protocol", "HTTP", "Weight", 90); err != nil {
+					return err
+				}
+				if err = checkEdge(t, c, virtualservice, podv2, "virtualservice", "Protocol", "HTTP", "Weight", 10); err != nil {
 					return err
 				}
 				return nil
@@ -202,7 +209,7 @@ func TestBookInfoScenario(t *testing.T) {
 
 				// check edges exist
 
-				if err = checkEdge(t, c, vs, podProductpage, "virtualservice"); err != nil {
+				if err = checkEdge(t, c, vs, podProductpage, "virtualservice", "Protocol", "HTTP"); err != nil {
 					return err
 				}
 


### PR DESCRIPTION
This PR adds 'Protocol' field to virtualservice-pod edge metadata. 
The relevant tests, `TestIstioVirtualServicePodScenario` and `TestBookInfoScenario`, have been extended, such that now they check this property (the amount of traffic routed to each pod by the virtualservice, which was added to the edge metadata in a previous PR, is now being checked as well).