### PR TITLE
istio: add a circuit breaker field to destinationrules metadata

### DIFF
--- a/tests/istio_test.go
+++ b/tests/istio_test.go
@@ -29,7 +29,22 @@ import (
 
 /* -- test creation of single resource -- */
 func TestIstioDestinationRuleNode(t *testing.T) {
-	testNodeCreationFromConfig(t, istio.Manager, "destinationrule", objName+"-destinationrule")
+	file := "destinationrule"
+	name := objName + "-" + file
+	testRunner(
+		t,
+		setupFromConfigFile(istio.Manager, file),
+		tearDownFromConfigFile(istio.Manager, file),
+		[]CheckFunction{
+			func(c *CheckContext) error {
+				_, err := checkNodeCreation(t, c, istio.Manager, "destinationrule", name, "TrafficPolicy", false, "HostName", "c")
+				if err != nil {
+					return err
+				}
+				return nil
+			},
+		},
+	)
 }
 
 func TestIstioGatewayNode(t *testing.T) {

--- a/topology/probes/istio/destinationrule.go
+++ b/topology/probes/istio/destinationrule.go
@@ -34,7 +34,10 @@ type destinationRuleHandler struct {
 func (h *destinationRuleHandler) Map(obj interface{}) (graph.Identifier, graph.Metadata) {
 	dr := obj.(*kiali.DestinationRule)
 	m := k8s.NewMetadataFields(&dr.ObjectMeta)
-	return graph.Identifier(dr.GetUID()), k8s.NewMetadata(Manager, "destinationrule", m, dr, dr.Name)
+	metadata := k8s.NewMetadata(Manager, "destinationrule", m, dr, dr.Name)
+	metadata.SetField("TrafficPolicy", dr.Spec["trafficPolicy"] != nil)
+	metadata.SetField("HostName", dr.Spec["host"])
+	return graph.Identifier(dr.GetUID()), metadata
 }
 
 // Dump k8s resource
@@ -45,10 +48,6 @@ func (h *destinationRuleHandler) Dump(obj interface{}) string {
 
 func newDestinationRuleProbe(client interface{}, g *graph.Graph) k8s.Subprobe {
 	return k8s.NewResourceCache(client.(*kiali.IstioClient).GetIstioNetworkingApi(), &kiali.DestinationRule{}, "destinationrules", g, &destinationRuleHandler{})
-}
-
-type destinationRuleSpec struct {
-	App string `mapstructure:"host"`
 }
 
 func destinationRuleServiceAreLinked(a, b interface{}) bool {


### PR DESCRIPTION
This PR adds a circuit breaker field to destinationrules metadata.