### PR TITLE
istio: add destinationrule-serviceentry links

### DIFF
--- a/tests/istio/destinationrule-serviceentry.yaml
+++ b/tests/istio/destinationrule-serviceentry.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: skydive-test-destinationrule-serviceentry
+spec:
+  hosts:
+  - example.unix.local
+  location: MESH_EXTERNAL
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+  resolution: STATIC
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: skydive-test-destinationrule-serviceentry
+spec:
+  host: example.unix.local

--- a/tests/istio_test.go
+++ b/tests/istio_test.go
@@ -104,6 +104,32 @@ func TestIstioDestinationRuleServiceScenario(t *testing.T) {
 	)
 }
 
+func TestIstioDestinationRuleServiceEntryScenario(t *testing.T) {
+	file := "destinationrule-serviceentry"
+	name := objName + "-" + file
+	testRunner(
+		t,
+		setupFromConfigFile(istio.Manager, file),
+		tearDownFromConfigFile(istio.Manager, file),
+		[]CheckFunction{
+			func(c *CheckContext) error {
+				destinationrule, err := checkNodeCreation(t, c, istio.Manager, "destinationrule", name)
+				if err != nil {
+					return err
+				}
+				serviceentry, err := checkNodeCreation(t, c, istio.Manager, "serviceentry", name)
+				if err != nil {
+					return err
+				}
+				if err = checkEdge(t, c, destinationrule, serviceentry, "destinationrule"); err != nil {
+					return err
+				}
+				return nil
+			},
+		},
+	)
+}
+
 func TestIstioGatewayVirtualServiceScenario(t *testing.T) {
 	file := "gateway-virtualservice"
 	name := objName + "-" + file

--- a/topology/probes/istio/istio.go
+++ b/topology/probes/istio/istio.go
@@ -65,6 +65,7 @@ func NewIstioProbe(g *graph.Graph) (*k8s.Probe, error) {
 	linkerHandlers := []k8s.LinkHandler{
 		newVirtualServicePodLinker,
 		newDestinationRuleServiceLinker,
+		newDestinationRuleServiceEntryLinker,
 		newGatewayVirtualServiceLinker,
 	}
 


### PR DESCRIPTION
This PR adds links between serviceEntries and destinationRules.
Can be checked with `TestIstioDestinationRuleServiceEntryScenario`.