### PR TITLE
security advisor changes + tests

### DIFF
--- a/contrib/ansible/devmode.yml
+++ b/contrib/ansible/devmode.yml
@@ -8,4 +8,5 @@
   roles:
   - role: elasticsearch
   - role: orientdb
+  - role: objectstore
   - role: skydive_dev

--- a/contrib/ansible/roles/objectstore/tasks/main.yml
+++ b/contrib/ansible/roles/objectstore/tasks/main.yml
@@ -1,0 +1,66 @@
+---
+- name: Set facts
+  set_fact:
+    minio_path: "/usr/local/bin/minio"
+    minio_client_path: "/usr/local/bin/minioc"
+    minio_data_path: "/opt/minio/data"
+    minio_systemd_service_path: "/etc/systemd/system/minio.service"
+    minio_service_confiugration_path: "/etc/default/minio"
+    minio_endpoint: "http://127.0.0.1:9000"
+    minio_cluster_name: "local"
+    minio_access_key: "user"
+    minio_secret_key: "password"
+    bucket_name: "bucket"
+
+- name: Download minio
+  get_url:
+    url: https://dl.minio.io/server/minio/release/linux-amd64/minio
+    dest: "{{ minio_path }}"
+    mode: 0775
+
+- name: Download minio client
+  get_url:
+    url: https://dl.minio.io/client/mc/release/linux-amd64/mc
+    dest: "{{ minio_client_path }}"
+    mode: 0775
+
+- name: Download minio systemd service
+  get_url:
+    url: https://raw.githubusercontent.com/minio/minio-service/master/linux-systemd/minio.service
+    dest: "{{ minio_systemd_service_path }}"
+
+- name: Remove user/group from minio service definition
+  replace:
+    path: "{{ minio_systemd_service_path }}"
+    regexp: 'User=minio-user\nGroup=minio-user\n'
+    replace: ''
+    backup: no
+
+- name: Create minio service configuration file
+  blockinfile:
+    path: "{{ minio_service_confiugration_path }}"
+    create: yes
+    block: |
+      # Volume to be used for Minio server.
+      MINIO_VOLUMES="{{ minio_data_path }}"
+      # Access Key of the server.
+      MINIO_ACCESS_KEY={{ minio_access_key }}
+      # Secret key of the server.
+      MINIO_SECRET_KEY={{ minio_secret_key }}
+
+- name: Create minio data directory
+  file:
+    path: "{{ minio_data_path }}"
+    state: directory
+    mode: 0755
+
+- name: Start minio service
+  systemd:
+    name: minio
+    state: started
+
+- name: Configure minio client
+  shell: "{{ minio_client_path }} config host add {{ minio_cluster_name }} {{ minio_endpoint }} {{ minio_access_key }} {{ minio_secret_key }} {{ minio_data_path }} --api S3v4"
+
+- name: Create bucket
+  shell: "{{ minio_client_path }} mb {{ minio_cluster_name }}/{{ bucket_name }}"

--- a/contrib/objectstore/main.go
+++ b/contrib/objectstore/main.go
@@ -18,17 +18,13 @@
 package main
 
 import (
-	"net/url"
 	"os"
 	"os/signal"
 	"syscall"
 
-	"github.com/skydive-project/skydive/common"
 	"github.com/skydive-project/skydive/config"
 	"github.com/skydive-project/skydive/contrib/objectstore/subscriber"
-	shttp "github.com/skydive-project/skydive/http"
 	"github.com/skydive-project/skydive/logging"
-	"github.com/skydive-project/skydive/websocket"
 )
 
 const defaultConfigurationFile = "/etc/skydive/skydive-objectstore.yml"
@@ -44,65 +40,17 @@ func main() {
 		os.Exit(1)
 	}
 
-	cfg := config.GetConfig()
-
-	endpoint := cfg.GetString("endpoint")
-	region := cfg.GetString("region")
-	bucket := cfg.GetString("bucket")
-	accessKey := cfg.GetString("access_key")
-	secretKey := cfg.GetString("secret_key")
-	apiKey := cfg.GetString("api_key")
-	iamEndpoint := cfg.GetString("iam_endpoint")
-	objectPrefix := cfg.GetString("object_prefix")
-	subscriberURLString := cfg.GetString("subscriber_url")
-	subscriberUsername := cfg.GetString("subscriber_username")
-	subscriberPassword := cfg.GetString("subscriber_password")
-	maxFlowsPerObject := cfg.GetInt("max_flows_per_object")
-	maxSecondsPerObject := cfg.GetInt("max_seconds_per_object")
-	maxSecondsPerStream := cfg.GetInt("max_seconds_per_stream")
-	maxFlowArraySize := cfg.GetInt("max_flow_array_size")
-	flowTransformerName := cfg.GetString("flow_transformer")
-	flowClassifier, err := subscriber.NewFlowClassifier(cfg.GetStringSlice("cluster_net_masks"))
+	s, err := subscriber.NewSubscriberFromConfig(config.GetConfig())
 	if err != nil {
-		logging.GetLogger().Errorf("Cannot initialize flow classifier: %s", err.Error())
+		logging.GetLogger().Errorf(err.Error())
 		os.Exit(1)
 	}
 
-	flowTransformer, err := subscriber.NewFlowTransformer(flowTransformerName)
-	if err != nil {
-		logging.GetLogger().Errorf("Failed to initialize flow transformer: %s", err.Error())
-		os.Exit(1)
-	}
-
-	objectStoreClient := subscriber.NewClient(endpoint, region, accessKey, secretKey, apiKey, iamEndpoint)
-
-	authOpts := &shttp.AuthenticationOpts{
-		Username: subscriberUsername,
-		Password: subscriberPassword,
-	}
-
-	subscriberURL, err := url.Parse(subscriberURLString)
-	if err != nil {
-		logging.GetLogger().Errorf("Failed to parse subscriber URL: %s", err.Error())
-		os.Exit(1)
-	}
-
-	wsClient, err := config.NewWSClient(common.AnalyzerService, subscriberURL, websocket.ClientOpts{AuthOpts: authOpts})
-	if err != nil {
-		logging.GetLogger().Errorf("Failed to create websocket client: %s", err)
-		os.Exit(1)
-	}
-	structClient := wsClient.UpgradeToStructSpeaker()
-
-	s := subscriber.New(objectStoreClient, bucket, objectPrefix, maxFlowArraySize, maxFlowsPerObject, maxSecondsPerObject, maxSecondsPerStream, flowTransformer, flowClassifier)
-
-	// subscribe to the flow updates
-	structClient.AddStructMessageHandler(s, []string{"flow"})
-	structClient.Start()
+	s.Start()
 
 	ch := make(chan os.Signal)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 	<-ch
 
-	structClient.Stop()
+	s.Stop()
 }

--- a/contrib/objectstore/skydive-objectstore.yml.default
+++ b/contrib/objectstore/skydive-objectstore.yml.default
@@ -1,20 +1,28 @@
-# endpoint: http://127.0.0.1:9000
-# region: local
-# bucket: bucket
-# access_key: user
-# secret_key: password
-# api_key: key
-# iam_endpoint: https://iam.cloud.ibm.com/identity/token
-# object_prefix: logs
-# subscriber_url: wss://127.0.0.1:8082/ws/subscriber/flow
-# subscriber_username:
-# subscriber_password:
-# max_flows_per_object: 6000
-# max_seconds_per_object: 60
-# max_seconds_per_stream: 86400
-# max_flow_array_size: 100000
-# flow_transformer: security-advisor
-# cluster_net_masks:
-  # - 10.0.0.0/8
-  # - 172.16.0.0/12
-  # - 192.168.0.0/16
+analyzers:
+  # - 127.0.0.1:8082
+objectstore:
+  # endpoint: http://127.0.0.1:9000
+  # region: local
+  # bucket: bucket
+  # access_key: user
+  # secret_key: password
+  # api_key: key
+  # iam_endpoint: https://iam.cloud.ibm.com/identity/token
+  # object_prefix: logs
+  # subscriber_url: wss://127.0.0.1:8082/ws/subscriber/flow
+  # subscriber_username:
+  # subscriber_password:
+  # max_flows_per_object: 6000
+  # max_seconds_per_object: 60
+  # max_seconds_per_stream: 86400
+  # max_flow_array_size: 100000
+  # flow_transformer: security-advisor
+  # cluster_net_masks:
+    # - 10.0.0.0/8
+    # - 172.16.0.0/12
+    # - 192.168.0.0/16
+  # excluded_tags:
+    # - internal
+    # - other
+  # security_advisor:
+    # exclude_started_flows: true

--- a/contrib/objectstore/subscriber/flowclassifier.go
+++ b/contrib/objectstore/subscriber/flowclassifier.go
@@ -26,29 +26,29 @@ import (
 	"github.com/skydive-project/skydive/logging"
 )
 
-// FlowClassifier classifies flows to different tags (strings)
-type FlowClassifier interface {
+// flowClassifier classifies flows to different tags (strings)
+type flowClassifier interface {
 	// GetFlowTag returns the tag of the given flow
-	GetFlowTag(fl *flow.Flow) Tag
+	GetFlowTag(fl *flow.Flow) tag
 }
 
-// Tag represents the flow classification
-type Tag string
+// tag represents the flow classification
+type tag string
 
 const (
-	tagOther    Tag = "other"
-	tagEgress   Tag = "egress"
-	tagIngress  Tag = "ingress"
-	tagInternal Tag = "internal"
+	tagOther    tag = "other"
+	tagEgress   tag = "egress"
+	tagIngress  tag = "ingress"
+	tagInternal tag = "internal"
 )
 
-// FlowDirectionClassifier classifies flows by their direction (ingress, egress, etc)
-type FlowDirectionClassifier struct {
+// flowDirectionClassifier classifies flows by their direction (ingress, egress, etc)
+type flowDirectionClassifier struct {
 	clusterNetMasks []*net.IPNet
 }
 
 // GetFlowTag tag flows based on src and dst IP ranges
-func (fc *FlowDirectionClassifier) GetFlowTag(fl *flow.Flow) Tag {
+func (fc *flowDirectionClassifier) GetFlowTag(fl *flow.Flow) tag {
 	if fl == nil || fl.Network == nil {
 		return tagOther
 	}
@@ -75,7 +75,7 @@ func (fc *FlowDirectionClassifier) GetFlowTag(fl *flow.Flow) Tag {
 }
 
 // isClusterIP check if IP is in defined subnet
-func (fc *FlowDirectionClassifier) isClusterIP(ip string) (bool, error) {
+func (fc *flowDirectionClassifier) isClusterIP(ip string) (bool, error) {
 	var err error
 	clusterIP := false
 	netIP := net.ParseIP(ip)
@@ -94,8 +94,8 @@ func (fc *FlowDirectionClassifier) isClusterIP(ip string) (bool, error) {
 	return false, nil
 }
 
-// NewFlowClassifier returns a new FlowDirectionClassifier, based on the given cluster net masks
-func NewFlowClassifier(clusterNetMasks []string) (*FlowDirectionClassifier, error) {
+// newFlowClassifier returns a new FlowDirectionClassifier, based on the given cluster net masks
+func newFlowClassifier(clusterNetMasks []string) (*flowDirectionClassifier, error) {
 	parsedNetMasks := make([]*net.IPNet, 0, len(clusterNetMasks))
 	for _, netMask := range clusterNetMasks {
 		_, sa, err := net.ParseCIDR(netMask)
@@ -104,5 +104,5 @@ func NewFlowClassifier(clusterNetMasks []string) (*FlowDirectionClassifier, erro
 		}
 		parsedNetMasks = append(parsedNetMasks, sa)
 	}
-	return &FlowDirectionClassifier{clusterNetMasks: parsedNetMasks}, nil
+	return &flowDirectionClassifier{clusterNetMasks: parsedNetMasks}, nil
 }

--- a/contrib/objectstore/subscriber/flowtransformer.go
+++ b/contrib/objectstore/subscriber/flowtransformer.go
@@ -20,20 +20,21 @@ package subscriber
 import (
 	"fmt"
 
+	"github.com/skydive-project/skydive/api/client"
 	"github.com/skydive-project/skydive/flow"
 )
 
-// FlowTransformer allows generic transformations of a flow
-type FlowTransformer interface {
+// flowTransformer allows generic transformations of a flow
+type flowTransformer interface {
 	// Transform transforms a flow before being stored
-	Transform(flow *flow.Flow, tag Tag) interface{}
+	Transform(f *flow.Flow) interface{}
 }
 
-// NewFlowTransformer creates a new flow transformer based on a name string
-func NewFlowTransformer(flowTransformerName string) (FlowTransformer, error) {
+// newFlowTransformer creates a new flow transformer based on a name string
+func newFlowTransformer(flowTransformerName string, gremlinClient *client.GremlinQueryHelper) (flowTransformer, error) {
 	switch flowTransformerName {
 	case "security-advisor":
-		return NewSecurityAdvisorFlowTransformer(), nil
+		return newSecurityAdvisorFlowTransformer(gremlinClient), nil
 	case "":
 		return nil, nil
 	default:

--- a/contrib/objectstore/subscriber/objectstore.go
+++ b/contrib/objectstore/subscriber/objectstore.go
@@ -42,26 +42,27 @@ type stream struct {
 	SeqNumber int
 }
 
-// Subscriber describes a Flows subscriber writing to an object storage service
-type Subscriber struct {
+// Storage allows writing flows to an object storage service
+type Storage struct {
 	bucket            string
 	objectPrefix      string
-	currentStream     map[Tag]stream
+	currentStream     map[tag]stream
 	maxFlowsPerObject int
 	maxFlowArraySize  int
 	maxStreamDuration time.Duration
 	maxObjectDuration time.Duration
-	objectStoreClient Client
-	flowTransformer   FlowTransformer
-	flowClassifier    FlowClassifier
-	flows             map[Tag][]interface{}
+	client            objectStoreClient
+	flowTransformer   flowTransformer
+	flowClassifier    flowClassifier
+	excludedTags      map[tag]bool
+	flows             map[tag][]interface{}
 	flowsMutex        sync.Mutex
-	lastFlushTime     map[Tag]time.Time
-	flushTimers       map[Tag]*time.Timer
+	lastFlushTime     map[tag]time.Time
+	flushTimers       map[tag]*time.Timer
 }
 
 // OnStructMessage is triggered when WS server sends us a message.
-func (s *Subscriber) OnStructMessage(c ws.Speaker, msg *ws.StructMessage) {
+func (s *Storage) OnStructMessage(c ws.Speaker, msg *ws.StructMessage) {
 	switch msg.Type {
 	case "store":
 		var flows []*flow.Flow
@@ -77,8 +78,44 @@ func (s *Subscriber) OnStructMessage(c ws.Speaker, msg *ws.StructMessage) {
 	}
 }
 
+// ListObjects lists all stored objects
+func (s *Storage) ListObjects() ([]*string, error) {
+	objectKeys, err := s.client.ListObjects(s.bucket, s.objectPrefix)
+	if err != nil {
+		logging.GetLogger().Error("Failed to list objects: ", err)
+		return nil, err
+	}
+
+	return objectKeys, nil
+}
+
+// ReadObjectFlows reads flows from object
+func (s *Storage) ReadObjectFlows(objectKey *string, objectFlows interface{}) error {
+	objectBytes, err := s.client.ReadObject(s.bucket, *objectKey)
+	if err != nil {
+		logging.GetLogger().Error("Failed to read object: ", err)
+		return err
+	}
+
+	if err = json.Unmarshal(objectBytes, objectFlows); err != nil {
+		logging.GetLogger().Error("Failed to JSON-decode object: ", err)
+		return err
+	}
+
+	return nil
+}
+
+// DeleteObject deletes an object
+func (s *Storage) DeleteObject(objectKey *string) error {
+	if err := s.client.DeleteObject(s.bucket, *objectKey); err != nil {
+		logging.GetLogger().Error("Failed to delete object: ", err)
+		return err
+	}
+	return nil
+}
+
 // StoreFlows store flows in memory, before being written to the object store
-func (s *Subscriber) StoreFlows(flows []*flow.Flow) error {
+func (s *Storage) StoreFlows(flows []*flow.Flow) error {
 	endTime := time.Now()
 
 	s.flowsMutex.Lock()
@@ -88,10 +125,13 @@ func (s *Subscriber) StoreFlows(flows []*flow.Flow) error {
 	if flows != nil {
 		for _, fl := range flows {
 			flowTag := s.flowClassifier.GetFlowTag(fl)
+			if _, ok := s.excludedTags[flowTag]; ok {
+				continue
+			}
 
 			var transformedFlow interface{}
 			if s.flowTransformer != nil {
-				transformedFlow = s.flowTransformer.Transform(fl, flowTag)
+				transformedFlow = s.flowTransformer.Transform(fl)
 			} else {
 				transformedFlow = fl
 			}
@@ -102,66 +142,70 @@ func (s *Subscriber) StoreFlows(flows []*flow.Flow) error {
 	}
 
 	// check which flows needs to be flushed to the object store
-	flushedTags := make(map[Tag]bool)
-	tagsToTimerReset := make(map[Tag]bool)
-	for tag := range s.flows {
-		if _, ok := s.lastFlushTime[tag]; !ok {
-			s.lastFlushTime[tag] = endTime
-			tagsToTimerReset[tag] = true
+	flushedTags := make(map[tag]bool)
+	tagsToTimerReset := make(map[tag]bool)
+	for t := range s.flows {
+		if _, ok := s.lastFlushTime[t]; !ok {
+			s.lastFlushTime[t] = endTime
+			tagsToTimerReset[t] = true
 		}
 		for {
-			flowsLength := len(s.flows[tag])
+			flowsLength := len(s.flows[t])
 			if flowsLength == 0 {
 				break
 			}
-			if flowsLength < s.maxFlowsPerObject && time.Since(s.lastFlushTime[tag]) < s.maxObjectDuration {
+			if flowsLength < s.maxFlowsPerObject && time.Since(s.lastFlushTime[t]) < s.maxObjectDuration {
 				break
 			}
 
-			if s.flushFlowsToObject(tag, endTime) != nil {
+			if s.flushFlowsToObject(t, endTime) != nil {
 				break
 			}
 
-			flushedTags[tag] = true
-			tagsToTimerReset[tag] = true
+			flushedTags[t] = true
+			tagsToTimerReset[t] = true
 		}
 
 		// check if need to trim flow array
-		overflowCount := len(s.flows["tag"]) - s.maxFlowArraySize
+		overflowCount := len(s.flows[t]) - s.maxFlowArraySize
 		if overflowCount > 0 {
-			logging.GetLogger().Warningf("Flow array for tag '%s' overflowed maximum size. Discarding %d flows", string(tag), overflowCount)
-			s.flows["tag"] = s.flows["tag"][overflowCount:]
+			logging.GetLogger().Warningf("Flow array for tag '%s' overflowed maximum size. Discarding %d flows", string(t), overflowCount)
+			s.flows[t] = s.flows[t][overflowCount:]
 		}
 	}
 
-	for tag := range flushedTags {
+	for t := range flushedTags {
 		// copy slice to free up memory of already flushed flows
-		newArray := make([]interface{}, 0, len(s.flows[tag]))
-		copy(newArray, s.flows[tag])
-		s.flows[tag] = newArray
+		newArray := make([]interface{}, 0, len(s.flows[t]))
+		copy(newArray, s.flows[t])
+		s.flows[t] = newArray
 	}
 
-	for tag := range tagsToTimerReset {
+	for t := range tagsToTimerReset {
 		// stop old flush timers
-		oldTimer, ok := s.flushTimers[tag]
+		oldTimer, ok := s.flushTimers[t]
 		if ok {
 			oldTimer.Stop()
 		}
 	}
 
 	// set a timer for next flush
-	for tag := range tagsToTimerReset {
-		s.flushTimers[tag] = time.AfterFunc(s.maxObjectDuration-time.Since(endTime), func() { s.StoreFlows(nil) })
+	if s.maxObjectDuration > 0 {
+		for t := range tagsToTimerReset {
+			s.flushTimers[t] = time.AfterFunc(s.maxObjectDuration-time.Since(endTime), func() {
+				s.StoreFlows(nil)
+			})
 
-		// a single timer will cover all of the flushed tags
-		break
+			// a single timer will cover all of the flushed tags
+			break
+		}
 	}
 
 	return nil
 }
 
-func (s *Subscriber) flushFlowsToObject(tag Tag, endTime time.Time) error {
-	flows := s.flows[tag]
+func (s *Storage) flushFlowsToObject(t tag, endTime time.Time) error {
+	flows := s.flows[t]
 	if len(flows) == 0 {
 		return nil
 	}
@@ -176,7 +220,7 @@ func (s *Subscriber) flushFlowsToObject(tag Tag, endTime time.Time) error {
 		return err
 	}
 
-	startTime := s.lastFlushTime[tag]
+	startTime := s.lastFlushTime[t]
 	startTimeString := strconv.FormatInt(startTime.UTC().UnixNano()/int64(time.Millisecond), 10)
 	endTimeString := strconv.FormatInt(endTime.UTC().UnixNano()/int64(time.Millisecond), 10)
 
@@ -192,13 +236,13 @@ func (s *Subscriber) flushFlowsToObject(tag Tag, endTime time.Time) error {
 	w.Write(flowsBytes)
 	w.Close()
 
-	currentStream := s.currentStream[tag]
+	currentStream := s.currentStream[t]
 	if endTime.Sub(currentStream.ID) >= s.maxStreamDuration {
 		currentStream = stream{ID: endTime}
 	}
 
-	objectKey := strings.Join([]string{s.objectPrefix, string(tag), currentStream.ID.UTC().Format("20060102T150405Z"), fmt.Sprintf("%08d.gz", currentStream.SeqNumber)}, "/")
-	err = s.objectStoreClient.WriteObject(s.bucket, objectKey, string(b.Bytes()), "application/json", "gzip", metadata)
+	objectKey := strings.Join([]string{s.objectPrefix, string(t), currentStream.ID.UTC().Format("20060102T150405Z"), fmt.Sprintf("%08d.gz", currentStream.SeqNumber)}, "/")
+	err = s.client.WriteObject(s.bucket, objectKey, string(b.Bytes()), "application/json", "gzip", metadata)
 
 	if err != nil {
 		logging.GetLogger().Error("Failed to write object: ", err)
@@ -206,30 +250,36 @@ func (s *Subscriber) flushFlowsToObject(tag Tag, endTime time.Time) error {
 	}
 
 	// flush was successful, update state
-	s.lastFlushTime[tag] = endTime
+	s.lastFlushTime[t] = endTime
 	currentStream.SeqNumber++
-	s.currentStream[tag] = currentStream
-	s.flows[tag] = s.flows[tag][len(flows):]
+	s.currentStream[t] = currentStream
+	s.flows[t] = s.flows[t][len(flows):]
 
 	return nil
 }
 
-// New returns a new flows subscriber writing to an object storage service
-func New(objectStoreClient Client, bucket, objectPrefix string, maxFlowArraySize, maxFlowsPerObject, maxSecondsPerObject, maxSecondsPerStream int, flowTransformer FlowTransformer, flowClassifier FlowClassifier) *Subscriber {
-	s := &Subscriber{
+// newStorage returns a new storage interface for storing flows to object store
+func newStorage(client objectStoreClient, bucket, objectPrefix string, maxFlowArraySize, maxFlowsPerObject, maxSecondsPerObject, maxSecondsPerStream int, flowTransformer flowTransformer, flowClassifier flowClassifier, excludedTags []string) *Storage {
+	s := &Storage{
 		bucket:            bucket,
 		objectPrefix:      objectPrefix,
 		maxFlowsPerObject: maxFlowsPerObject,
 		maxFlowArraySize:  maxFlowArraySize,
 		maxObjectDuration: time.Second * time.Duration(maxSecondsPerObject),
 		maxStreamDuration: time.Second * time.Duration(maxSecondsPerStream),
-		objectStoreClient: objectStoreClient,
+		client:            client,
 		flowTransformer:   flowTransformer,
 		flowClassifier:    flowClassifier,
-		currentStream:     make(map[Tag]stream),
-		flows:             make(map[Tag][]interface{}),
-		lastFlushTime:     make(map[Tag]time.Time),
-		flushTimers:       make(map[Tag]*time.Timer),
+		excludedTags:      make(map[tag]bool),
+		currentStream:     make(map[tag]stream),
+		flows:             make(map[tag][]interface{}),
+		lastFlushTime:     make(map[tag]time.Time),
+		flushTimers:       make(map[tag]*time.Timer),
 	}
+
+	for _, t := range excludedTags {
+		s.excludedTags[tag(t)] = true
+	}
+
 	return s
 }

--- a/contrib/objectstore/subscriber/secadvisor_test.go
+++ b/contrib/objectstore/subscriber/secadvisor_test.go
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2019 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package subscriber
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/pmylund/go-cache"
+
+	"github.com/skydive-project/skydive/common"
+	"github.com/skydive-project/skydive/flow"
+)
+
+type fakeGraphClient struct {
+	containerNameError     error
+	nodeTypeError          error
+	nodeTypeCallCount      int
+	containerNameCallCount int
+}
+
+func (c *fakeGraphClient) getContainerName(ipString, nodeTID string) (string, error) {
+	c.containerNameCallCount++
+	return "container" + ipString, c.containerNameError
+}
+
+func (c *fakeGraphClient) getNodeType(nodeTID string) (string, error) {
+	c.nodeTypeCallCount++
+	return "type" + nodeTID, c.nodeTypeError
+}
+
+func getTestSecurityAdvisorTransformer() (*securityAdvisorFlowTransformer, *fakeGraphClient) {
+	fakeClient := &fakeGraphClient{}
+	return &securityAdvisorFlowTransformer{
+		flowUpdateCount: cache.New(10*time.Minute, 10*time.Minute),
+		graphClient:     fakeClient,
+		containerName:   cache.New(5*time.Minute, 10*time.Minute),
+		nodeType:        cache.New(5*time.Minute, 10*time.Minute),
+	}, fakeClient
+}
+
+func testTransform(ft *securityAdvisorFlowTransformer, f *flow.Flow) *SecurityAdvisorFlow {
+	res := ft.Transform(f)
+	if res == nil {
+		return nil
+	}
+	return res.(*SecurityAdvisorFlow)
+}
+
+func Test_Transform_UpdateCount(t *testing.T) {
+	ft, _ := getTestSecurityAdvisorTransformer()
+	f1 := &flow.Flow{UUID: "1", FinishType: flow.FlowFinishType_TCP_FIN}
+
+	assertEqual(t, int64(0), testTransform(ft, f1).UpdateCount)
+	f1.FinishType = flow.FlowFinishType_NOT_FINISHED
+	assertEqual(t, int64(1), testTransform(ft, f1).UpdateCount)
+
+	f2 := &flow.Flow{UUID: "2", FinishType: flow.FlowFinishType_TCP_FIN}
+	assertEqual(t, int64(0), testTransform(ft, f2).UpdateCount)
+	f2.FinishType = flow.FlowFinishType_NOT_FINISHED
+	assertEqual(t, int64(2), testTransform(ft, f1).UpdateCount)
+
+	f1.FinishType = flow.FlowFinishType_TIMEOUT
+	assertEqual(t, int64(3), testTransform(ft, f1).UpdateCount)
+	assertEqual(t, int64(0), testTransform(ft, f1).UpdateCount)
+
+	f2.FinishType = flow.FlowFinishType_TCP_FIN
+	assertEqual(t, int64(1), testTransform(ft, f2).UpdateCount)
+	assertEqual(t, int64(2), testTransform(ft, f2).UpdateCount)
+}
+
+func Test_Transform_Status(t *testing.T) {
+	ft, _ := getTestSecurityAdvisorTransformer()
+	f := &flow.Flow{}
+
+	assertEqual(t, "STARTED", testTransform(ft, f).Status)
+	assertEqual(t, "UPDATED", testTransform(ft, f).Status)
+
+	f.FinishType = flow.FlowFinishType_TCP_FIN
+	assertEqual(t, "ENDED", testTransform(ft, f).Status)
+
+	f.FinishType = flow.FlowFinishType_NOT_FINISHED
+	assertEqual(t, "UPDATED", testTransform(ft, f).Status)
+	f.FinishType = flow.FlowFinishType_TCP_RST
+	assertEqual(t, "ENDED", testTransform(ft, f).Status)
+
+	f.FinishType = flow.FlowFinishType_NOT_FINISHED
+	assertEqual(t, "UPDATED", testTransform(ft, f).Status)
+	f.FinishType = flow.FlowFinishType_TIMEOUT
+	assertEqual(t, "ENDED", testTransform(ft, f).Status)
+}
+
+func Test_Transform_FinishType(t *testing.T) {
+	ft, _ := getTestSecurityAdvisorTransformer()
+	f := &flow.Flow{}
+
+	assertEqual(t, "", testTransform(ft, f).FinishType)
+	assertEqual(t, "", testTransform(ft, f).FinishType)
+
+	f.FinishType = flow.FlowFinishType_TCP_FIN
+	assertEqual(t, "SYN_FIN", testTransform(ft, f).FinishType)
+
+	f.FinishType = flow.FlowFinishType_NOT_FINISHED
+	assertEqual(t, "", testTransform(ft, f).FinishType)
+	f.FinishType = flow.FlowFinishType_TCP_RST
+	assertEqual(t, "SYN_RST", testTransform(ft, f).FinishType)
+
+	f.FinishType = flow.FlowFinishType_NOT_FINISHED
+	assertEqual(t, "", testTransform(ft, f).FinishType)
+	f.FinishType = flow.FlowFinishType_TIMEOUT
+	assertEqual(t, "Timeout", testTransform(ft, f).FinishType)
+}
+
+func Test_Transform_Network(t *testing.T) {
+	ft, fakeClient := getTestSecurityAdvisorTransformer()
+	network := &flow.FlowLayer{
+		Protocol: flow.FlowProtocol_IPV4,
+		A:        "aValue",
+		B:        "bValue",
+	}
+	f := &flow.Flow{Network: network}
+	transformedNetwork := testTransform(ft, f).Network
+	assertEqual(t, flow.FlowProtocol_IPV4.String(), transformedNetwork.Protocol)
+	assertEqual(t, "aValue", transformedNetwork.A)
+	assertEqual(t, "bValue", transformedNetwork.B)
+	assertEqual(t, "0_0_containeraValue_0", transformedNetwork.AName)
+	assertEqual(t, "0_0_containerbValue_0", transformedNetwork.BName)
+	assertEqual(t, 2, fakeClient.containerNameCallCount)
+
+	transformedNetwork = testTransform(ft, f).Network
+	assertEqual(t, "0_0_containeraValue_0", transformedNetwork.AName)
+	assertEqual(t, "0_0_containerbValue_0", transformedNetwork.BName)
+	assertEqual(t, 2, fakeClient.containerNameCallCount)
+
+	fakeClient.containerNameError = errors.New("myerror")
+	network.A = "a2Value"
+	transformedNetwork = testTransform(ft, f).Network
+	assertEqual(t, "", transformedNetwork.AName)
+	assertEqual(t, 3, fakeClient.containerNameCallCount)
+
+	transformedNetwork = testTransform(ft, f).Network
+	assertEqual(t, "", transformedNetwork.AName)
+	assertEqual(t, 4, fakeClient.containerNameCallCount)
+
+	fakeClient.containerNameError = common.ErrNotFound
+	transformedNetwork = testTransform(ft, f).Network
+	assertEqual(t, "", transformedNetwork.AName)
+	assertEqual(t, 5, fakeClient.containerNameCallCount)
+
+	transformedNetwork = testTransform(ft, f).Network
+	assertEqual(t, "", transformedNetwork.AName)
+	assertEqual(t, 5, fakeClient.containerNameCallCount)
+}
+
+func Test_Transform_Transport(t *testing.T) {
+	ft, _ := getTestSecurityAdvisorTransformer()
+	transport := &flow.TransportLayer{
+		Protocol: flow.FlowProtocol_IPV4,
+		A:        10,
+		B:        20,
+	}
+	f := &flow.Flow{Transport: transport}
+	transformedNetwork := testTransform(ft, f).Transport
+	assertEqual(t, flow.FlowProtocol_IPV4.String(), transformedNetwork.Protocol)
+	assertEqual(t, "10", transformedNetwork.A)
+	assertEqual(t, "20", transformedNetwork.B)
+}
+
+func Test_Transform_NodeType(t *testing.T) {
+	ft, fakeClient := getTestSecurityAdvisorTransformer()
+	f := &flow.Flow{NodeTID: "tid"}
+	assertEqual(t, "typetid", testTransform(ft, f).NodeType)
+	assertEqual(t, 1, fakeClient.nodeTypeCallCount)
+
+	assertEqual(t, "typetid", testTransform(ft, f).NodeType)
+	assertEqual(t, 1, fakeClient.nodeTypeCallCount)
+
+	fakeClient.nodeTypeError = errors.New("myerror")
+	f.NodeTID = "tid2"
+	assertEqual(t, "", testTransform(ft, f).NodeType)
+	assertEqual(t, 2, fakeClient.nodeTypeCallCount)
+
+	assertEqual(t, "", testTransform(ft, f).NodeType)
+	assertEqual(t, 3, fakeClient.nodeTypeCallCount)
+
+	fakeClient.nodeTypeError = common.ErrNotFound
+	assertEqual(t, "", testTransform(ft, f).NodeType)
+	assertEqual(t, 4, fakeClient.nodeTypeCallCount)
+
+	assertEqual(t, "", testTransform(ft, f).NodeType)
+	assertEqual(t, 4, fakeClient.nodeTypeCallCount)
+}
+
+func Test_Transform_ExcludeStartedFlows(t *testing.T) {
+	ft, _ := getTestSecurityAdvisorTransformer()
+	ft.excludeStartedFlows = true
+	f := &flow.Flow{}
+
+	assertEqual(t, nil, ft.Transform(f))
+	assertEqual(t, "UPDATED", testTransform(ft, f).Status)
+}

--- a/contrib/objectstore/subscriber/subscriber.go
+++ b/contrib/objectstore/subscriber/subscriber.go
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2019 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package subscriber
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/spf13/viper"
+
+	"github.com/skydive-project/skydive/api/client"
+	"github.com/skydive-project/skydive/common"
+	"github.com/skydive-project/skydive/config"
+	shttp "github.com/skydive-project/skydive/http"
+	"github.com/skydive-project/skydive/websocket"
+)
+
+// Subscriber represents a flow subscriber writing to object store
+type Subscriber struct {
+	structClient *websocket.StructSpeaker
+	storage      *Storage
+}
+
+// NewSubscriberFromConfig returns a new flow subscriber writing to object store
+func NewSubscriberFromConfig(cfg *viper.Viper) (*Subscriber, error) {
+	cfgPrefix := "objectstore."
+
+	endpoint := cfg.GetString(cfgPrefix + "endpoint")
+	region := cfg.GetString(cfgPrefix + "region")
+	bucket := cfg.GetString(cfgPrefix + "bucket")
+	accessKey := cfg.GetString(cfgPrefix + "access_key")
+	secretKey := cfg.GetString(cfgPrefix + "secret_key")
+	apiKey := cfg.GetString(cfgPrefix + "api_key")
+	iamEndpoint := cfg.GetString(cfgPrefix + "iam_endpoint")
+	objectPrefix := cfg.GetString(cfgPrefix + "object_prefix")
+	subscriberURLString := cfg.GetString(cfgPrefix + "subscriber_url")
+	subscriberUsername := cfg.GetString(cfgPrefix + "subscriber_username")
+	subscriberPassword := cfg.GetString(cfgPrefix + "subscriber_password")
+	maxFlowsPerObject := cfg.GetInt(cfgPrefix + "max_flows_per_object")
+	maxSecondsPerObject := cfg.GetInt(cfgPrefix + "max_seconds_per_object")
+	maxSecondsPerStream := cfg.GetInt(cfgPrefix + "max_seconds_per_stream")
+	maxFlowArraySize := cfg.GetInt(cfgPrefix + "max_flow_array_size")
+	flowTransformerName := cfg.GetString(cfgPrefix + "flow_transformer")
+	flowClassifier, err := newFlowClassifier(cfg.GetStringSlice(cfgPrefix + "cluster_net_masks"))
+	if err != nil {
+		return nil, fmt.Errorf("Cannot initialize flow classifier: %s", err.Error())
+	}
+	excludedTags := cfg.GetStringSlice(cfgPrefix + "excluded_tags")
+
+	objectStoreClient := newClient(endpoint, region, accessKey, secretKey, apiKey, iamEndpoint)
+
+	authOpts := &shttp.AuthenticationOpts{
+		Username: subscriberUsername,
+		Password: subscriberPassword,
+	}
+
+	gremlinClient := client.NewGremlinQueryHelper(authOpts)
+	flowTransformer, err := newFlowTransformer(flowTransformerName, gremlinClient)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to initialize flow transformer: %s", err.Error())
+	}
+
+	subscriberURL, err := url.Parse(subscriberURLString)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse subscriber URL: %s", err.Error())
+	}
+
+	wsClient, err := config.NewWSClient(common.AnalyzerService, subscriberURL, websocket.ClientOpts{AuthOpts: authOpts})
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create websocket client: %s", err)
+	}
+	structClient := wsClient.UpgradeToStructSpeaker()
+
+	s := newStorage(objectStoreClient, bucket, objectPrefix, maxFlowArraySize, maxFlowsPerObject, maxSecondsPerObject, maxSecondsPerStream, flowTransformer, flowClassifier, excludedTags)
+
+	// subscribe to the flow updates
+	structClient.AddStructMessageHandler(s, []string{"flow"})
+
+	return &Subscriber{structClient: structClient, storage: s}, nil
+}
+
+// Start starts the object store flow subscriber
+func (s *Subscriber) Start() {
+	s.structClient.Start()
+}
+
+// Stop stops the object store flow subscriber
+func (s *Subscriber) Stop() {
+	s.structClient.Stop()
+}
+
+// GetStorage returns the backing storage client
+func (s *Subscriber) GetStorage() *Storage {
+	return s.storage
+}

--- a/scripts/ci/ansible/deploy.yml
+++ b/scripts/ci/ansible/deploy.yml
@@ -104,7 +104,7 @@
   roles:
     - role: skydive_dev
 
-- name: Install orientdb and elasticsearch
+- name: Install orientdb, elasticsearch and objectstore
   hosts: slaves
   tags:
     - master
@@ -113,6 +113,7 @@
   roles:
    - role: orientdb
    - role: elasticsearch
+   - role: objectstore
 
 - name: Register Jenkins slaves
   hosts: jenkins_master

--- a/scripts/ci/cleanup.sh
+++ b/scripts/ci/cleanup.sh
@@ -57,11 +57,19 @@ DROP DATABASE remote:localhost/Skydive root root plocal
 EOF
   /opt/orientdb/bin/console.sh /tmp/commands.txt
 
+  # clean objectstore
+  minioc rm -r --force local/bucket
+  minioc rb local/bucket
+
   systemctl restart openvswitch
   systemctl restart elasticsearch
   systemctl restart orientdb
+  systemctl restart minio
   systemctl restart lxd
   systemctl restart vpp
+
+  # create objectstorage bucket
+  minioc mb local/bucket
 
   for vm in dev_dev vagrant_analyzer1 vagrant_agent1 devstack_devstack
   do

--- a/tests/secadvisor_test.go
+++ b/tests/secadvisor_test.go
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2019 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package tests
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/skydive-project/skydive/config"
+	"github.com/skydive-project/skydive/contrib/objectstore/subscriber"
+	g "github.com/skydive-project/skydive/gremlin"
+)
+
+const securityAdvisorConfigTemplate = `---
+objectstore:
+  endpoint: http://127.0.0.1:9000
+  region: local
+  bucket: bucket
+  access_key: user
+  secret_key: password
+  subscriber_url: ws://%s/ws/subscriber/flow
+  max_flows_per_object: 6000
+  max_seconds_per_object: 0
+  max_seconds_per_stream: 86400
+  max_flow_array_size: 100000
+  flow_transformer: security-advisor
+`
+
+func initSecurityAdvisorConfig(cfg *viper.Viper) error {
+	analyzers := config.GetStringSlice("analyzers")
+	if len(analyzers) == 0 {
+		return errors.New("Missing analyzers config")
+	}
+
+	f, err := ioutil.TempFile("", "skydive_agent")
+	if err != nil {
+		return fmt.Errorf("failed to create configuration file: %s", err.Error())
+	}
+	if _, err = f.Write([]byte(fmt.Sprintf(securityAdvisorConfigTemplate, analyzers[0]))); err != nil {
+		return fmt.Errorf("failed to write configuration file: %s", err.Error())
+	}
+	if err = f.Close(); err != nil {
+		return fmt.Errorf("failed to close configuration file: %s", err.Error())
+	}
+
+	configFile, err := os.Open(f.Name())
+	if err != nil {
+		return fmt.Errorf("failed to open configuration file: %s", err.Error())
+	}
+	cfg.SetConfigType("yaml")
+	if err := cfg.MergeConfig(configFile); err != nil {
+		return fmt.Errorf("failed to update configuration: %s", err.Error())
+	}
+	return nil
+}
+
+func securityAdvisorSetup(c *TestContext) error {
+	cfg := viper.New()
+	if err := initSecurityAdvisorConfig(cfg); err != nil {
+		return fmt.Errorf("Failed to init security advisor configuration: %s", err.Error())
+	}
+
+	s, err := subscriber.NewSubscriberFromConfig(cfg)
+	if err != nil {
+		return err
+	}
+
+	s.Start()
+	c.data["subscriber"] = s
+	return err
+}
+
+func securityAdvisorTearDown(c *TestContext) error {
+	rawS, ok := c.data["subscriber"]
+	if ok {
+		s := rawS.(*subscriber.Subscriber)
+		s.Stop()
+
+		storage := s.GetStorage()
+		objectKeys, err := storage.ListObjects()
+		if err != nil {
+			return err
+		}
+
+		for _, objectKey := range objectKeys {
+			if err = storage.DeleteObject(objectKey); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func Test_SecurityAdvisor(t *testing.T) {
+	test := &Test{
+		setupFunction: securityAdvisorSetup,
+
+		setupCmds: []Cmd{
+			{"podman run -d --name secadvtest --ip=10.88.0.49 --hostname=myhost nginx", false},
+		},
+
+		injections: []TestInjection{{
+			from:  g.G.V().Has("Name", "cni0"),
+			toIP:  "10.88.0.49",
+			count: 1,
+		}},
+
+		tearDownCmds: []Cmd{
+			{"podman kill secadvtest", false},
+			{"podman rm secadvtest", false},
+		},
+
+		captures: []TestCapture{
+			{gremlin: g.G.V().Has("Name", "cni0")},
+		},
+
+		mode: OneShot,
+
+		checks: []CheckFunction{func(c *CheckContext) error {
+			storage := c.data["subscriber"].(*subscriber.Subscriber).GetStorage()
+
+			objectKeys, err := storage.ListObjects()
+			if err != nil {
+				return fmt.Errorf("Failed to list objects: %s", err.Error())
+			}
+
+			flows := make([]*subscriber.SecurityAdvisorFlow, 0)
+			for _, objectKey := range objectKeys {
+				var objectFlows []*subscriber.SecurityAdvisorFlow
+				if err := storage.ReadObjectFlows(objectKey, &objectFlows); err != nil {
+					return fmt.Errorf("Failed to read object flows: %s", err.Error())
+				}
+
+				flows = append(flows, objectFlows...)
+			}
+
+			found := false
+			for _, fl := range flows {
+				if fl.Network != nil && fl.Network.B == "10.88.0.49" {
+					if fl.NodeType != "bridge" {
+						return fmt.Errorf("Expected 'bridge' NodeType, but got: %s", fl.NodeType)
+					}
+
+					if fl.Network.BName != "0_0_myhost_0" {
+						return fmt.Errorf("Expected '0_0_myhost_0' B_Name, but got: %s", fl.Network.BName)
+					}
+
+					found = true
+				}
+			}
+
+			if !found {
+				return errors.New("No flows found with destination 10.88.0.49")
+			}
+
+			return nil
+		}},
+
+		tearDownFunction: securityAdvisorTearDown,
+	}
+
+	RunTest(t, test)
+}


### PR DESCRIPTION
This PR replaces #1703.
It adds NodeType and A_Name, B_Name fields to the security advisor flow, with extensive unit testing.
Unlike #1703, this PR also includes a functional test.