### PR TITLE
flow: move RTT to Metric in order to keep track of it.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,6 +241,8 @@ flow/flow.pb.go: flow/flow.proto filters/filters.proto
 		-e 's/ICMPType\(.*\),omitempty\(.*\)/ICMPType\1\2/' \
 		-e 's/int64\(.*\),omitempty\(.*\)/int64\1\2/' \
 		-i $@
+	# add omitempty to RTT as it is not always filled
+	sed -e 's/json:"RTT"/json:"RTT,omitempty"/' -i $@
 	# do not export LastRawPackets used internally
 	sed -e 's/json:"LastRawPackets,omitempty"/json:"-"/g' -i $@
 	# add flowState to flow generated struct

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -59,10 +59,9 @@ const (
 // flowState is used internally to track states within the flow table.
 // it is added to the generated Flow struct by Makefile
 type flowState struct {
-	lastMetric       *FlowMetric
-	link1stPacket    int64
-	network1stPacket int64
-	updateVersion    int64
+	lastMetric    *FlowMetric
+	rtt1stPacket  int64
+	updateVersion int64
 }
 
 // Packet describes one packet
@@ -578,6 +577,10 @@ func (f *Flow) Update(packet *Packet, opts Opts) {
 			f.updateMetricsWithNetworkLayer(packet, 0)
 		}
 	}
+
+	f.updateRTT(packet)
+
+	// depends on options
 	if f.TCPMetric != nil {
 		f.updateTCPMetrics(packet)
 	}
@@ -619,6 +622,52 @@ func getLinkLayerLength(packet *layers.Ethernet) int64 {
 	return 14 + int64(len(packet.Payload))
 }
 
+func (f *Flow) updateRTT(packet *Packet) {
+	icmpLayer := packet.Layer(layers.LayerTypeICMPv4)
+	if icmp, ok := icmpLayer.(*layers.ICMPv4); ok {
+		switch icmp.TypeCode.Type() {
+		case layers.ICMPv4TypeEchoRequest:
+			if f.XXX_state.rtt1stPacket == 0 {
+				f.XXX_state.rtt1stPacket = packet.GoPacket.Metadata().Timestamp.UnixNano()
+			}
+		case layers.ICMPv4TypeEchoReply:
+			if f.XXX_state.rtt1stPacket != 0 {
+				f.Metric.RTT = packet.GoPacket.Metadata().Timestamp.UnixNano() - f.XXX_state.rtt1stPacket
+				f.XXX_state.rtt1stPacket = 0
+			}
+		}
+
+		return
+	}
+
+	icmpLayer = packet.Layer(layers.LayerTypeICMPv6)
+	if icmp, ok := icmpLayer.(*layers.ICMPv6); ok {
+		switch icmp.TypeCode.Type() {
+		case layers.ICMPv6TypeEchoRequest:
+			if f.XXX_state.rtt1stPacket == 0 {
+				f.XXX_state.rtt1stPacket = packet.GoPacket.Metadata().Timestamp.UnixNano()
+			}
+		case layers.ICMPv6TypeEchoReply:
+			if f.XXX_state.rtt1stPacket != 0 {
+				f.Metric.RTT = packet.GoPacket.Metadata().Timestamp.UnixNano() - f.XXX_state.rtt1stPacket
+				f.XXX_state.rtt1stPacket = 0
+			}
+		}
+
+		return
+	}
+
+	tcpLayer := packet.Layer(layers.LayerTypeTCP)
+	if tcpPacket, ok := tcpLayer.(*layers.TCP); ok {
+		if tcpPacket.SYN && f.XXX_state.rtt1stPacket == 0 {
+			f.XXX_state.rtt1stPacket = packet.GoPacket.Metadata().Timestamp.UnixNano()
+		} else if f.XXX_state.rtt1stPacket != 0 && (tcpPacket.SYN && tcpPacket.ACK) || tcpPacket.RST {
+			f.Metric.RTT = packet.GoPacket.Metadata().Timestamp.UnixNano() - f.XXX_state.rtt1stPacket
+			f.XXX_state.rtt1stPacket = 0
+		}
+	}
+}
+
 func (f *Flow) updateMetricsWithLinkLayer(packet *Packet) bool {
 	ethernetPacket := getLinkLayer(packet)
 	if ethernetPacket == nil || f.Link == nil {
@@ -636,14 +685,6 @@ func (f *Flow) updateMetricsWithLinkLayer(packet *Packet) bool {
 	} else {
 		f.Metric.BAPackets++
 		f.Metric.BABytes += length
-	}
-
-	if f.XXX_state.link1stPacket == 0 {
-		f.XXX_state.link1stPacket = packet.GoPacket.Metadata().Timestamp.UnixNano()
-	} else {
-		if (f.RTT == 0) && (f.Link.A == ethernetPacket.DstMAC.String()) {
-			f.RTT = packet.GoPacket.Metadata().Timestamp.UnixNano() - f.XXX_state.link1stPacket
-		}
 	}
 
 	return true
@@ -715,14 +756,6 @@ func (f *Flow) updateMetricsWithNetworkLayer(packet *Packet, length int64) error
 			f.Metric.BABytes += length
 		}
 
-		// update RTT
-		if f.XXX_state.network1stPacket == 0 {
-			f.XXX_state.network1stPacket = packet.GoPacket.Metadata().Timestamp.UnixNano()
-		} else {
-			if (f.RTT == 0) && (f.Network.A == ipv4Packet.DstIP.String()) {
-				f.RTT = packet.GoPacket.Metadata().Timestamp.UnixNano() - f.XXX_state.network1stPacket
-			}
-		}
 		return nil
 	}
 	ipv6Layer := packet.Layer(layers.LayerTypeIPv6)
@@ -738,14 +771,6 @@ func (f *Flow) updateMetricsWithNetworkLayer(packet *Packet, length int64) error
 			f.Metric.BABytes += length
 		}
 
-		// update RTT
-		if f.XXX_state.network1stPacket == 0 {
-			f.XXX_state.network1stPacket = packet.GoPacket.Metadata().Timestamp.UnixNano()
-		} else {
-			if (f.RTT == 0) && (f.Network.A == ipv6Packet.DstIP.String()) {
-				f.RTT = packet.GoPacket.Metadata().Timestamp.UnixNano() - f.XXX_state.network1stPacket
-			}
-		}
 		return nil
 	}
 
@@ -758,6 +783,7 @@ func (f *Flow) updateTCPMetrics(packet *Packet) error {
 	if f.Network == nil || f.Transport == nil || f.Transport.Protocol != FlowProtocol_TCP {
 		return nil
 	}
+
 	var metadata *gopacket.PacketMetadata
 	if metadata = packet.GoPacket.Metadata(); metadata == nil {
 		return nil
@@ -803,16 +829,12 @@ func (f *Flow) updateTCPMetrics(packet *Packet) error {
 
 	switch {
 	case tcpPacket.SYN:
-		if f.Network.A == srcIP {
-			if f.TCPMetric.ABSynStart == 0 {
-				f.TCPMetric.ABSynStart = captureTime
-				f.TCPMetric.ABSynTTL = timeToLive
-			}
-		} else {
-			if f.TCPMetric.BASynStart == 0 {
-				f.TCPMetric.BASynStart = captureTime
-				f.TCPMetric.BASynTTL = timeToLive
-			}
+		if f.Network.A == srcIP && f.TCPMetric.ABSynStart == 0 {
+			f.TCPMetric.ABSynStart = captureTime
+			f.TCPMetric.ABSynTTL = timeToLive
+		} else if f.TCPMetric.BASynStart == 0 {
+			f.TCPMetric.BASynStart = captureTime
+			f.TCPMetric.BASynTTL = timeToLive
 		}
 	case tcpPacket.FIN:
 		if f.Network.A == srcIP {
@@ -849,8 +871,7 @@ func (f *Flow) newTransportLayer(packet *Packet, opts Opts) error {
 
 		if transportPacket.FIN {
 			f.FinishType = FlowFinishType_TCP_FIN
-		}
-		if transportPacket.RST {
+		} else if transportPacket.RST {
 			f.FinishType = FlowFinishType_TCP_RST
 		}
 	} else if layer := packet.Layer(layers.LayerTypeUDP); layer != nil {
@@ -1298,8 +1319,6 @@ func (f *Flow) GetFieldInt64(field string) (_ int64, err error) {
 		return f.Last, nil
 	case "Start":
 		return f.Start, nil
-	case "RTT":
-		return f.RTT, nil
 	}
 
 	fields := strings.Split(field, ".")

--- a/flow/flow.proto
+++ b/flow/flow.proto
@@ -89,6 +89,7 @@ message FlowMetric {
   int64 BABytes = 5;
   int64 Start = 6;
   int64 Last = 7;
+  int64 RTT = 8;
 }
 
 message RawPacket {
@@ -165,7 +166,6 @@ message Flow {
 
   int64 Start = 10;
   int64 Last = 11;
-  int64 RTT = 14;
 
 /* Flow Tracking IDentifier, from 1st packet bytes
    flow.TrackingID could be used to identify an unique flow whatever it has

--- a/flow/flow_test.go
+++ b/flow/flow_test.go
@@ -56,6 +56,7 @@ func TestFlowMetric(t *testing.T) {
 		ABBytes:   344,
 		BAPackets: 3,
 		BABytes:   206,
+		RTT:       33000,
 		Start:     m.Start,
 		Last:      m.Last,
 	}
@@ -85,6 +86,7 @@ func TestFlowTruncatedMetric(t *testing.T) {
 		ABBytes:   1066,
 		BAPackets: 1,
 		BABytes:   1066,
+		RTT:       13104000,
 		Start:     m.Start,
 		Last:      m.Last,
 	}
@@ -106,8 +108,8 @@ func TestFlowSimpleIPv4(t *testing.T) {
 	if flows[0].LayersPath != "Ethernet/IPv4/TCP" {
 		t.Errorf("Flow LayersPath must be Ethernet/IPv4/TCP got : %s", flows[0].LayersPath)
 	}
-	if flows[0].RTT != 33000 {
-		t.Errorf("Flow RTT must be 33000 got : %v", flows[0].RTT)
+	if flows[0].Metric.RTT != 33000 {
+		t.Errorf("Flow RTT must be 33000 got : %v", flows[0].Metric.RTT)
 	}
 }
 
@@ -119,8 +121,8 @@ func TestFlowSimpleIPv6(t *testing.T) {
 	if flows[0].LayersPath != "Ethernet/IPv6/TCP" {
 		t.Errorf("Flow LayersPath must be Ethernet/IPv6/TCP got : %s", flows[0].LayersPath)
 	}
-	if flows[0].RTT != 28000 {
-		t.Errorf("Flow RTT must be 28000 got : %v", flows[0].RTT)
+	if flows[0].Metric.RTT != 28000 {
+		t.Errorf("Flow RTT must be 28000 got : %v", flows[0].Metric.RTT)
 	}
 }
 

--- a/flow/metrics.go
+++ b/flow/metrics.go
@@ -82,6 +82,8 @@ func (fm *FlowMetric) GetFieldInt64(field string) (int64, error) {
 		return fm.BAPackets, nil
 	case "BABytes":
 		return fm.BABytes, nil
+	case "RTT":
+		return fm.RTT, nil
 	}
 	return 0, common.ErrFieldNotFound
 }

--- a/flow/storage/orientdb/orientdb.go
+++ b/flow/storage/orientdb/orientdb.go
@@ -82,6 +82,7 @@ type metricDoc struct {
 	ABBytes   int64
 	BAPackets int64
 	BABytes   int64
+	RTT       int64
 	Start     int64
 	Last      int64
 }
@@ -121,6 +122,7 @@ func metricToDoc(rid string, m *flow.FlowMetric) *metricDoc {
 		ABPackets: m.ABPackets,
 		BABytes:   m.BABytes,
 		BAPackets: m.BAPackets,
+		RTT:       m.RTT,
 		Start:     m.Start,
 		Last:      m.Last,
 	}
@@ -132,6 +134,7 @@ func (m *metricDoc) metric() *flow.FlowMetric {
 		ABPackets: m.ABPackets,
 		BABytes:   m.BABytes,
 		BAPackets: m.BAPackets,
+		RTT:       m.RTT,
 		Start:     m.Start,
 		Last:      m.Last,
 	}
@@ -303,7 +306,7 @@ func (c *Storage) SearchRawPackets(fsq filters.SearchQuery, packetFilter *filter
 // SearchMetrics searches flow metrics matching filters in the database
 func (c *Storage) SearchMetrics(fsq filters.SearchQuery, metricFilter *filters.Filter) (map[string][]common.Metric, error) {
 	filter := fsq.Filter
-	sql := "SELECT ABBytes, ABPackets, BABytes, BAPackets, Start, Last, Flow.UUID FROM FlowMetric"
+	sql := "SELECT ABBytes, ABPackets, BABytes, BAPackets, RTT, Start, Last, Flow.UUID FROM FlowMetric"
 	sql += " WHERE " + orient.FilterToExpression(metricFilter, nil)
 	if conditional := orient.FilterToExpression(filter, func(s string) string { return "Flow." + s }); conditional != "" {
 		sql += " AND " + conditional
@@ -389,6 +392,7 @@ func New(backend string) (*Storage, error) {
 				{Name: "ABPackets", Type: "INTEGER", Mandatory: true, NotNull: true},
 				{Name: "BABytes", Type: "INTEGER", Mandatory: true, NotNull: true},
 				{Name: "BAPackets", Type: "INTEGER", Mandatory: true, NotNull: true},
+				{Name: "RTT", Type: "INTEGER", Mandatory: false, NotNull: true},
 				{Name: "Start", Type: "LONG", Mandatory: true, NotNull: true},
 				{Name: "Last", Type: "LONG", Mandatory: true, NotNull: true},
 			},

--- a/flow/table.go
+++ b/flow/table.go
@@ -247,6 +247,7 @@ func (ft *Table) updateMetric(f *Flow, start, last int64) {
 	f.LastUpdateMetric.ABBytes = f.Metric.ABBytes
 	f.LastUpdateMetric.BAPackets = f.Metric.BAPackets
 	f.LastUpdateMetric.BABytes = f.Metric.BABytes
+	f.LastUpdateMetric.RTT = f.Metric.RTT
 
 	// subtract previous values to get the diff so that we store the
 	// amount of data between two updates
@@ -435,8 +436,11 @@ func (ft *Table) processFlowOP(op *Operation) {
 				BARstStart: updateTCPFlagTime(fl.TCPMetric.BARstStart, op.Flow.TCPMetric.BARstStart),
 			}
 		}
-		if fl.RTT == 0 && fl.Metric.ABPackets > 0 && fl.Metric.BAPackets > 0 {
-			fl.RTT = fl.Last - fl.Start
+
+		// TODO(safchain) remove this should be provided by the sender
+		// with a good time resolution
+		if fl.Metric.RTT == 0 && fl.Metric.ABPackets > 0 && fl.Metric.BAPackets > 0 {
+			fl.Metric.RTT = fl.Last - fl.Start
 		}
 	}
 }

--- a/gremlin/query.go
+++ b/gremlin/query.go
@@ -132,6 +132,11 @@ func (q QueryString) Count() QueryString {
 	return q.newQueryString("Count")
 }
 
+// Values append a Vaies() operation to query
+func (q QueryString) Values(key string) QueryString {
+	return q.newQueryString("Values", key)
+}
+
 // Dedup append a Dedup() operation to query
 func (q QueryString) Dedup() QueryString {
 	return q.newQueryString("Dedup")

--- a/statics/js/components/flow-table.js
+++ b/statics/js/components/flow-table.js
@@ -445,7 +445,7 @@ Vue.component('flow-table', {
           show: false,
         },
         {
-          name: ['RTT'],
+          name: ['Metric.RTT'],
           label: 'RTT ms',
           show: true,
         },
@@ -543,7 +543,8 @@ Vue.component('flow-table', {
     transform: function(key, value) {
       var dt;
       switch (key) {
-        case "RTT":
+        case "LastUpdateMetric.RTT":
+        case "Metric.RTT":
           return value / 1000000 + " ms";
         case "Start":
         case "Last":
@@ -711,7 +712,8 @@ Vue.component('flow-table', {
         }
         if (value !== null) {
           switch (path) {
-            case "RTT":
+            case "LastUpdateMetric.RTT":
+            case "Metric.RTT":
               value /= 1000000; // ms
           }
           return value;

--- a/statics/js/components/graph-layout.js
+++ b/statics/js/components/graph-layout.js
@@ -94,7 +94,7 @@ var LinkLabelLatency = Vue.extend({
 
     updateLatency: function(link, a, b) {
       link.latencyTimestamp = Math.max(a.Last, b.Last);
-      link.latency = Math.abs(a.RTT - b.RTT) / 1000000;
+      link.latency = Math.abs(a.Metric.RTT - b.Metric.RTT) / 1000000;
     },
 
     flowQuery: function(nodeTID, trackingID, limit) {
@@ -102,7 +102,7 @@ var LinkLabelLatency = Vue.extend({
       if (typeof trackingID !== 'undefined') {
         has += `"TrackingID", ${trackingID}`;
       }
-      has += `"RTT", NE(0)`;
+      has += `"Metric.RTT", NE(0)`;
       let query = `G.Flows().Has(${has}).Sort().Limit(${limit})`;
       return this.$topologyQuery(query)
     },

--- a/tests/flow_test.go
+++ b/tests/flow_test.go
@@ -662,6 +662,11 @@ func TestFlowMetrics(t *testing.T) {
 				return fmt.Errorf("Wrong number of flow, should have none, got : %v", metric)
 			}
 
+			metric, err = getFirstFlowMetric(gremlin.Has("Metric.RTT", g.Gt(0)))
+			if err != nil || metric == nil {
+				return fmt.Errorf("Wrong number of flow, should have none, got : %v", metric)
+			}
+
 			return nil
 		}},
 	}


### PR DESCRIPTION
This patch moves the RTT value to the Metric struct
in order to keep multiple version of it in the datastore.
The goal is to be able to get its value with only one
packet injection. For example create a long ICMP packet
injection with the same ID.

It is also improve the algorithm to rely on protocols
to get the 2 first packets. It avoid to calculate
the RTT in the middle of the flow.