### PR TITLE
docker: install missing cross compile dependencies

### DIFF
--- a/contrib/docker/Dockerfile.crosscompile
+++ b/contrib/docker/Dockerfile.crosscompile
@@ -18,10 +18,15 @@ RUN apt-get -y update \
     && apt-get -y update; \
     apt-get -y install git make flex bison wget unzip golang npm \
                    zlib1g-dev:$DEBARCH \
+                   zlib1g:$DEBARCH \
                    liblzma-dev:$DEBARCH \
+                   liblzma:$DEBARCH \
                    libc++-dev:$DEBARCH \
+                   libc++:$DEBARCH \
                    libc-dev:$DEBARCH \
+                   libc:$DEBARCH \
                    libpcap0.8-dev:$DEBARCH \
+                   libpcap0.8:$DEBARCH \
                    linux-libc-dev:$DEBARCH \
                    gcc-${TARGET_ARCH}-linux-gnu \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
skip skydive-go-fmt
skip skydive-unit-tests
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-functional-hw-tests
skip skydive-compile-tests
skip skydive-k8s-tests
skip skydive-cdd-overview-tests
skip skydive-scale-tests
