### PR TITLE
docker: compile/crosscompile - bump gosu to 1.11

### DIFF
--- a/contrib/docker/Dockerfile.compile
+++ b/contrib/docker/Dockerfile.compile
@@ -28,7 +28,7 @@ RUN PROTOC_VER=3.5.1; \
 RUN mkdir -p /root/go/bin && chmod a+wrx /root/go/bin
 
 RUN arch="$(dpkg --print-architecture)" \
-    && wget --no-verbose -O /gosu "https://github.com/tianon/gosu/releases/download/1.10/gosu-${arch##*-}" \
+    && wget --no-verbose -O /gosu "https://github.com/tianon/gosu/releases/download/1.11/gosu-${arch##*-}" \
     && chmod a+x /gosu
 
 ENV UID=$UID

--- a/contrib/docker/Dockerfile.crosscompile
+++ b/contrib/docker/Dockerfile.crosscompile
@@ -36,7 +36,7 @@ RUN PROTOC_VER=3.5.1; \
 RUN mkdir -p /root/go/bin && chmod a+wrx /root/go/bin
 
 RUN arch="$(dpkg --print-architecture)" \
-    && wget --no-verbose -O /gosu "https://github.com/tianon/gosu/releases/download/1.10/gosu-${arch##*-}" \
+    && wget --no-verbose -O /gosu "https://github.com/tianon/gosu/releases/download/1.11/gosu-${arch##*-}" \
     && chmod a+x /gosu
 
 ENV UID=$UID


### PR DESCRIPTION
skip skydive-go-fmt
skip skydive-unit-tests
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-functional-hw-tests
skip skydive-compile-tests
skip skydive-k8s-tests
skip skydive-cdd-overview-tests
skip skydive-scale-tests