### PR TITLE
ci: bump go to 1.12.5 to enable arm64

### DIFF
--- a/packetinjector/forge.go
+++ b/packetinjector/forge.go
@@ -186,10 +186,10 @@ func NewForgedPacketGenerator(pp *PacketInjectionParams, srcNode *graph.Node) (*
 
 	return &ForgedPacketGenerator{
 		PacketInjectionParams: pp,
-		srcIP:     srcIP,
-		dstIP:     dstIP,
-		srcMAC:    srcMAC,
-		dstMAC:    dstMAC,
-		layerType: layerType,
+		srcIP:                 srcIP,
+		dstIP:                 dstIP,
+		srcMAC:                srcMAC,
+		dstMAC:                dstMAC,
+		layerType:             layerType,
 	}, nil
 }

--- a/scripts/ci/create-docker-image.sh
+++ b/scripts/ci/create-docker-image.sh
@@ -5,8 +5,7 @@ set -x
 set -e
 
 # Arches are the docker arch names
-: ${ARCHES:=amd64 ppc64le s390x}
-# arm64 waiting on  golang 1.11 (https://github.com/skydive-project/skydive/pull/1188#discussion_r204336060)
+: ${ARCHES:=amd64 arm64 ppc64le s390x}
 : ${DOCKER_IMAGE:=skydive/skydive}
 : ${DOCKER_IMAGE_SNAPSHOT:=skydive/snapshots}
 : ${DOCKER_USERNAME:=skydiveproject}

--- a/scripts/ci/install-go.sh
+++ b/scripts/ci/install-go.sh
@@ -14,7 +14,7 @@ curl -sL -o ~/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master
 chmod +x ~/bin/gimme
 
 # before changing this be sure that it will not break the RHEL packaging
-eval "$(gimme 1.10.3)"
+eval "$(gimme 1.11.10)"
 
 export GOPATH=$WORKSPACE
 export PATH=$PATH:$GOPATH/bin

--- a/tests/flow_ebpf_test.go
+++ b/tests/flow_ebpf_test.go
@@ -151,7 +151,7 @@ func TestFlowsVLANEBPF(t *testing.T) {
 func TestFlowsGREEBPF(t *testing.T) {
 	test := testFlowTunnel(t, "br-greebpf", "gre", false, "192.168.0.1", "192.168.0.2",
 		"172.16.0.1", "172.16.0.2", "192.168.0.0/24")
-	for i, _ := range test.captures {
+	for i := range test.captures {
 		test.captures[i].kind = "ebpf"
 	}
 	RunTest(t, test)

--- a/tests/openflow_test.go
+++ b/tests/openflow_test.go
@@ -318,11 +318,11 @@ func testOVSRule(t *testing.T, kind, rule string, checkRule func(node *graph.Nod
 
 	test := &Test{
 		setupCmds: []Cmd{
-			Cmd{"ovs-vsctl add-br br-test", true},
-			Cmd{"ovs-ofctl del-flows br-test", true},
-			Cmd{"ovs-vsctl set bridge br-test protocols=OpenFlow10,OpenFlow14", true},
-			Cmd{"ovs-vsctl set-controller br-test ptcp:16633", true},
-			Cmd{fmt.Sprintf("ovs-ofctl add-%s br-test %s", kind, rule), true},
+			{"ovs-vsctl add-br br-test", true},
+			{"ovs-ofctl del-flows br-test", true},
+			{"ovs-vsctl set bridge br-test protocols=OpenFlow10,OpenFlow14", true},
+			{"ovs-vsctl set-controller br-test ptcp:16633", true},
+			{fmt.Sprintf("ovs-ofctl add-%s br-test %s", kind, rule), true},
 		},
 
 		tearDownCmds: []Cmd{

--- a/websocket/message.go
+++ b/websocket/message.go
@@ -390,7 +390,7 @@ func (s *StructSpeaker) OnMessage(c Speaker, m Message) {
 
 func newStructSpeaker(c Speaker) *StructSpeaker {
 	s := &StructSpeaker{
-		Speaker: c,
+		Speaker:                      c,
 		structSpeakerEventDispatcher: newStructSpeakerEventDispatcher(),
 		nsSubscribed:                 make(map[string]bool),
 		replyChan:                    make(map[string]chan *StructMessage),
@@ -494,7 +494,7 @@ func (s *StructServer) OnDisconnected(c Speaker) {
 // NewStructServer returns a new StructServer
 func NewStructServer(server *Server) *StructServer {
 	s := &StructServer{
-		Server: server,
+		Server:                           server,
 		structSpeakerPoolEventDispatcher: newStructSpeakerPoolEventDispatcher(server),
 	}
 


### PR DESCRIPTION
Apologies in advance for using your CI as a primary test environment.

I've no idea on how to test that changing the version won't break RHEL packaging either.