### PR TITLE
ansible: do not install yum-plugin-copr on fedora

### DIFF
--- a/contrib/ansible/roles/skydive_dev/tasks/centos.yml
+++ b/contrib/ansible/roles/skydive_dev/tasks/centos.yml
@@ -12,3 +12,8 @@
 - package:
     name: centos-release-openstack-queens
     state: present
+
+- name: "Install copr yum plugin"
+  package:
+    name: yum-plugin-copr
+    state: present

--- a/contrib/ansible/roles/skydive_dev/tasks/fedora.yml
+++ b/contrib/ansible/roles/skydive_dev/tasks/fedora.yml
@@ -5,3 +5,8 @@
 
 - name: "Updating packages"
   shell: "dnf update -y"
+
+- name: "Install copr dnf plugin"
+  package:
+    name: dnf-plugins-core
+    state: present

--- a/contrib/ansible/roles/skydive_dev/tasks/lxd.yml
+++ b/contrib/ansible/roles/skydive_dev/tasks/lxd.yml
@@ -3,10 +3,6 @@
     policy: targeted
     state: permissive
 
-- package:
-    name: yum-plugin-copr
-    state: present
-
 - shell: yum -y copr enable ganto/lxc3
 
 - package:

--- a/contrib/ansible/roles/skydive_dev/tasks/vpp.yml
+++ b/contrib/ansible/roles/skydive_dev/tasks/vpp.yml
@@ -1,18 +1,22 @@
 ---
+- shell: dnf -y copr enable nucleo/frr
+  when: ansible_distribution == "Fedora"
+
 - copy:
-      dest: "/etc/yum.repos.d/fdio-release.repo"
-      content: |
-        [fdio_release]
-        name=fdio_release
-        baseurl=https://packagecloud.io/fdio/release/el/7/$basearch
-        repo_gpgcheck=1
-        gpgcheck=0
-        enabled=1
-        gpgkey=https://packagecloud.io/fdio/release/gpgkey
-        sslverify=1
-        sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-        metadata_expire=300
-    
+    dest: "/etc/yum.repos.d/fdio-release.repo"
+    content: |
+      [fdio_release]
+      name=fdio_release
+      baseurl=https://packagecloud.io/fdio/release/el/7/$basearch
+      repo_gpgcheck=1
+      gpgcheck=0
+      enabled=1
+      gpgkey=https://packagecloud.io/fdio/release/gpgkey
+      sslverify=1
+      sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+      metadata_expire=300
+  when: ansible_distribution != "Fedora"
+
 - package:
     name: "{{ item }}"
     state: present


### PR DESCRIPTION
skip skydive-go-fmt
skip skydive-unit-tests
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-functional-hw-tests
skip skydive-compile-tests
skip skydive-k8s-tests
skip skydive-cdd-overview-tests
skip skydive-scale-tests