### PR TITLE
Make test debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -489,7 +489,7 @@ endif
 
 .PHONY: test.functionals.run
 test.functionals.run:
-	cd tests && sudo -E ./functionals ${VERBOSE_TESTS_FLAGS} -test.run ${TEST_PATTERN} -test.timeout ${TIMEOUT} ${ARGS} ${EXTRA_ARGS}
+	cd tests && sudo -E ./functionals ${VERBOSE_TESTS_FLAGS} -test.run "${TEST_PATTERN}" -test.timeout ${TIMEOUT} ${ARGS} ${EXTRA_ARGS}
 
 .PHONY: tests.functionals.all
 test.functionals.all: test.functionals.compile
@@ -497,11 +497,7 @@ test.functionals.all: test.functionals.compile
 
 .PHONY: test.functionals.batch
 test.functionals.batch: test.functionals.compile
-ifneq ($(TEST_PATTERN),)
-	set -e ; $(MAKE) ARGS="${ARGS} -test.run ${TEST_PATTERN}" test.functionals.run EXTRA_ARGS="${EXTRA_ARGS}"
-else
-	set -e ; $(MAKE) ARGS="${ARGS} " test.functionals.run EXTRA_ARGS="${EXTRA_ARGS}"
-endif
+	set -e ; $(MAKE) ARGS="${ARGS} " test.functionals.run EXTRA_ARGS="${EXTRA_ARGS}" TEST_PATTERN="${TEST_PATTERN}"
 
 .PHONY: test.functionals
 test.functionals: test.functionals.compile
@@ -511,7 +507,7 @@ test.functionals: test.functionals.compile
 
 .PHONY: functional
 functional:
-	$(MAKE) test.functionals VERBOSE=true TIMEOUT=10m ARGS='-standalone -analyzer.topology.backend elasticsearch -analyzer.flow.backend elasticsearch' TEST_PATTERN=${TEST_PATTERN}
+	$(MAKE) test.functionals VERBOSE=true TIMEOUT=10m ARGS='-standalone -analyzer.topology.backend elasticsearch -analyzer.flow.backend elasticsearch' TEST_PATTERN="${TEST_PATTERN}"
 
 .PHONY: test
 test: govendor genlocalfiles

--- a/scripts/ci/jobs/jobs.yml
+++ b/scripts/ci/jobs/jobs.yml
@@ -796,7 +796,7 @@
     builders:
       - skydive-cleanup
       - skydive-test:
-          test: BACKEND=elasticsearch WITH_EBPF=true WITH_VPP=true TEST_PATTERN='\(EBPF\|SRIOV\|VPP\|Libvirt\)' TAGS="$TAGS libvirt_tests sriov_tests" scripts/ci/run-functional-tests.sh
+          test: BACKEND=elasticsearch WITH_EBPF=true WITH_VPP=true TEST_PATTERN='(EBPF|SRIOV|VPP|Libvirt)' TAGS="$TAGS libvirt_tests sriov_tests" scripts/ci/run-functional-tests.sh
     publishers:
       - junit:
           results: tests.xml

--- a/scripts/ci/run-istio-tests.sh
+++ b/scripts/ci/run-istio-tests.sh
@@ -29,6 +29,6 @@ network_setup
 istio_setup
 WITH_K8S=true
 WITH_ISTIO=true
-TEST_PATTERN='\(Istio\|K8s\)'
+TEST_PATTERN='(Istio|K8s)'
 tests_run
 exit $RETCODE


### PR DESCRIPTION
One commit enables to set TEST_PATTERN  for the test.functiomals.run target to be tested by:

```
make TEST_PATTERN=abc test.functionals.run 
```

The 2nd commit enables running tests under debugger (after installing delve) by:

```
make DEBUG=true test.functionals.run
```