### PR TITLE
ui: display the node/edge ID in the metadata panel

### DIFF
--- a/statics/css/skydive.css
+++ b/statics/css/skydive.css
@@ -157,6 +157,14 @@ label {
   stroke: #fff;
 }
 
+.panel .description {
+  float: right;
+  font-style: italic;
+  font-weight: normal;
+  padding-right: 10px;
+  font-size: 12px;
+}
+
 .panel .btn, .button-holder .btn {
   border-radius: 24px;
   padding: 10px 20px;

--- a/statics/js/components/panel.js
+++ b/statics/js/components/panel.js
@@ -9,6 +9,11 @@ Vue.component('panel', {
       required: true,
     },
 
+    description: {
+      type: String,
+      required: false,
+    },
+
     collapsed: {
       type: Boolean,
       default: true,
@@ -24,6 +29,7 @@ Vue.component('panel', {
           <span class="pull-right">\
             <i class="glyphicon glyphicon-chevron-left rotate" :class="{\'down\': props.active}"></i>\
           </span>\
+          <span v-if="description" class="description">{{ description }}</span>\
         </h1>\
         <div slot="collapse-body">\
           <div ref="body">\

--- a/statics/js/components/topology.js
+++ b/statics/js/components/topology.js
@@ -192,7 +192,7 @@ var TopologyComponent = {
         </tabs>\
         <panel id="node-metadata" v-if="currentNodeMetadata"\
                :collapsed="false"\
-               title="Metadata">\
+               title="Metadata" :description="\'ID: \'+currentNode.id">\
           <template slot="actions">\
             <button v-if="currentNode.isGroupOwner()"\
                     title="Expand/Collapse Node"\
@@ -208,7 +208,7 @@ var TopologyComponent = {
           </object-detail>\
         </panel>\
         <panel id="edge-metadata" v-if="currentEdge"\
-               title="Metadata">\
+               title="Metadata" :description="\'ID: \'+currentEdge.id">\
           <object-detail :object="currentEdgeMetadata"></object-detail>\
         </panel>\
         <panel id="docker-metadata" v-if="currentNodeDocker"\


### PR DESCRIPTION
skip skydive-go-fmt
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-scale-tests
skip skydive-unit-tests
skip skydive-compile-tests
skip skydive-k8s-tests
skip skydive-ppc64le-tests
skip skydive-functional-hw-tests