### PR TITLE
minikube: upgrade to v1.1.1

### DIFF
--- a/scripts/ci/install-minikube.sh
+++ b/scripts/ci/install-minikube.sh
@@ -6,10 +6,10 @@ OS=linux
 ARCH=amd64
 TARGET_DIR=/usr/bin
 
-MINIKUBE_VERSION="v0.28.2"
+MINIKUBE_VERSION="v1.1.1"
 MINIKUBE_URL="https://github.com/kubernetes/minikube/releases/download/$MINIKUBE_VERSION/minikube-$OS-$ARCH"
 
-K8S_VERSION="v1.10.0"
+K8S_VERSION="v1.14.3"
 KUBECTL_URL="https://storage.googleapis.com/kubernetes-release/release/$K8S_VERSION/bin/$OS/$ARCH/kubectl"
 
 [ -z "$WITH_CALICO" ] && WITH_CALICO=false
@@ -101,10 +101,10 @@ start() {
 
         local args="--kubernetes-version $K8S_VERSION --memory 4096"
         if [ "$MINIKUBE_DRIVER" == "none" ]; then
-                args="$args --vm-driver=none --bootstrapper=localkube"
+                args="$args --vm-driver=none"
                 local driver=$(sudo docker info --format '{{print .CgroupDriver}}')
                 if [ -n "$driver" ]; then
-                        args="$args --extra-config=kubelet.CgroupDriver=$driver"
+                        args="$args --extra-config=kubelet.cgroup-driver=$driver"
                 fi
         fi
 


### PR DESCRIPTION
can be tested by:

```
$ scripts/ci/minikube-install.sh stop
$ scripts/ci/minikube-install.sh uninstall
$ scripts/ci/minikube-install.sh install
$ scripts/ci/minikube-install.sh start
```

then check:

```
$ kubectl get pods --all-namespaces
NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE
kube-system   coredns-fb8b8dccf-tztxq            1/1     Running   0          7m9s
kube-system   coredns-fb8b8dccf-whhtj            1/1     Running   0          7m9s
kube-system   etcd-minikube                      1/1     Running   0          6m8s
kube-system   kube-addon-manager-minikube        1/1     Running   0          7m20s
kube-system   kube-apiserver-minikube            1/1     Running   0          6m24s
kube-system   kube-controller-manager-minikube   1/1     Running   0          5m57s
kube-system   kube-proxy-n697v                   1/1     Running   0          7m10s
kube-system   kube-scheduler-minikube            1/1     Running   0          6m1s
kube-system   storage-provisioner                1/1     Running   0          7m8s
```

skip skydive-go-fmt
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-unit-tests
skip skydive-compile-tests
skip skydive-ppc64le-tests
skip skydive-functional-hw-tests
