### PR TITLE
build: fix docker image build, remove ppa

### DIFF
--- a/contrib/docker/Dockerfile.compile
+++ b/contrib/docker/Dockerfile.compile
@@ -10,7 +10,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -y update \
     && apt-get -y install software-properties-common \
-    && add-apt-repository -y ppa:ubuntu-toolchain-r/ppa \
     && apt-get -y update \
     && apt-get -y install git make flex bison wget unzip golang libpcap0.8-dev npm \
          clang llvm zlib1g-dev liblzma-dev libc++-dev libc-dev linux-libc-dev libxml2-dev libvirt-dev \

--- a/contrib/docker/Dockerfile.crosscompile
+++ b/contrib/docker/Dockerfile.crosscompile
@@ -12,7 +12,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -y update \
     && apt-get -y install software-properties-common \
-    && add-apt-repository -y ppa:ubuntu-toolchain-r/ppa \
     && dpkg --add-architecture $DEBARCH \
     && echo "deb [arch=$DEBARCH] http://ports.ubuntu.com/ubuntu-ports bionic main universe" >> /etc/apt/sources.list \
     && echo "deb [arch=$DEBARCH] http://ports.ubuntu.com/ubuntu-ports bionic-updates main universe" >> /etc/apt/sources.list \


### PR DESCRIPTION
skip skydive-compile-tests
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-go-fmt
skip skydive-k8s-tests
skip skydive-scale-tests
skip skydive-selenium-tests
skip skydive-unit-tests
skip skydive-cdd-overview-tests
skip skydive-ppc64-tests
skydive-functional-hw-tests
