### PR TITLE
ansible: bump golang to 1.10 for role skydive_dev

### DIFF
--- a/contrib/ansible/roles/skydive_dev/tasks/gimme.yml
+++ b/contrib/ansible/roles/skydive_dev/tasks/gimme.yml
@@ -9,7 +9,7 @@
 - name: run gimme in bash profile
   lineinfile:
     path: /home/vagrant/.bash_profile
-    line: 'eval "$(gimme 1.9.1)"'
+    line: 'eval "$(gimme 1.10.8)"'
 
 - name: set GOPATH
   lineinfile:
@@ -17,6 +17,6 @@
     line: 'export GOPATH=/home/vagrant/go'
 
 - name: run gimme once
-  command: /usr/local/bin/gimme 1.9.1
+  command: /usr/local/bin/gimme 1.10.8
   become: yes
   become_user: vagrant


### PR DESCRIPTION
skip skydive-go-fmt
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-scale-tests
skip skydive-cdd-overview-tests
skip skydive-unit-tests
skip skydive-compile-tests
skip skydive-k8s-tests
skip skydive-functional-hw-tests