### PR TITLE
Add option to disable certificate validation

### DIFF
--- a/contrib/ansible/roles/skydive_analyzer/defaults/main.yml
+++ b/contrib/ansible/roles/skydive_analyzer/defaults/main.yml
@@ -36,3 +36,5 @@ skydive_auth_os_user_role: admin
 skydive_deployment_test: yes
 
 skydive_iptables_rules: false
+
+validate_certs: true

--- a/contrib/ansible/roles/skydive_analyzer/tasks/keystone.yml
+++ b/contrib/ansible/roles/skydive_analyzer/tasks/keystone.yml
@@ -46,6 +46,7 @@
         domain_id: "{{ skydive_auth_os_domain_id }}"
         enabled: True
         state: present
+        validate_certs: "{{ validate_certs }}"
 
     - name: Create a Skydive keystone API user
       environment:
@@ -63,6 +64,7 @@
         domain: "{{ skydive_auth_os_domain_name }}"
         default_project: "{{ skydive_auth_os_tenant_name }}"
         state: present
+        validate_certs: "{{ validate_certs }}"
 
     - name: Set skydive Keystone API user role
       environment:
@@ -79,6 +81,7 @@
         role: "{{ skydive_auth_os_user_role }}"
         project: "{{ skydive_auth_os_tenant_name }}"
         state: present
+        validate_certs: "{{ validate_certs }}"
 
     - name: Create a Skydive keystone service user
       environment:
@@ -96,6 +99,7 @@
         domain: "{{ skydive_os_service_domain_name }}"
         default_project: "{{ skydive_os_service_tenant_name }}"
         state: present
+        validate_certs: "{{ validate_certs }}"
 
     - name: Set skydive Keystone service user role
       environment:
@@ -112,3 +116,4 @@
         role: "{{ skydive_os_service_user_role }}"
         project: "{{ skydive_os_service_tenant_name }}"
         state: present
+        validate_certs: "{{ validate_certs }}"


### PR DESCRIPTION
When deploying in a lab environment with self-signed certificates, playbook fails. This PR adds an option to disable certificate validation.