### PR TITLE
netns: fix unregistering of multiply registered paths

### DIFF
--- a/topology/probes/netns/netns.go
+++ b/topology/probes/netns/netns.go
@@ -223,7 +223,6 @@ func (u *ProbeHandler) Unregister(path string) {
 		return
 	}
 
-	delete(u.pathToNetNS, path)
 	nsString := ns.String()
 	probe, ok := u.nsNetLinkProbes[nsString]
 	if !ok {
@@ -253,6 +252,7 @@ func (u *ProbeHandler) Unregister(path string) {
 	}
 
 	delete(u.nsNetLinkProbes, nsString)
+	delete(u.pathToNetNS, path)
 }
 
 func (u *ProbeHandler) initializeRunPath(path string) {


### PR DESCRIPTION
skip skydive-go-fmt
skip skydive-functional-tests-backend-orientdb
skip skydive-scale-tests
skip skydive-cdd-overview-tests
skip skydive-unit-tests
skip skydive-compile-tests
skip skydive-k8s-tests
skip skydive-ppc64le-tests
skip skydive-functional-hw-tests