### PR TITLE
ebpf : introduce a constant flow polling rate from the kernel

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -104,7 +104,7 @@ func init() {
 	cfg.SetDefault("agent.flow.pcapsocket.bind_address", "127.0.0.1")
 	cfg.SetDefault("agent.flow.pcapsocket.min_port", 8100)
 	cfg.SetDefault("agent.flow.pcapsocket.max_port", 8132)
-	cfg.SetDefault("agent.flow.ebpf.kernel_scan_interval", 10)
+	cfg.SetDefault("agent.flow.ebpf.polling_rate", 16000)
 	cfg.SetDefault("agent.flow.sflow.bind_address", "127.0.0.1")
 	cfg.SetDefault("agent.flow.sflow.port_min", 6345)
 	cfg.SetDefault("agent.flow.sflow.port_max", 6355)

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -281,9 +281,8 @@ agent:
       # port_max: 6375
 
     ebpf:
-      # Period in seconds representing the delay between two successive scans 
-      # of the kernel table in ebpf mode for new flow updates. Default interval is 10 seconds
-      # kernel_scan_interval: 10
+      # Rate of flows to poll per second from the kernel
+      # polling_rate: 16000
 
   capture:
     # Period in second to get capture stats from the probe. Note this


### PR DESCRIPTION
Avoid to burst load the kernel every tick
Default flow polling rate : 16000 flow per second