### PR TITLE
ebpf reenable FNV hashing

### DIFF
--- a/probe/ebpf/flow_network.c
+++ b/probe/ebpf/flow_network.c
@@ -70,7 +70,10 @@
 		case IPPROTO_SCTP:
 		case IPPROTO_UDP:
 		case IPPROTO_TCP:
-			fill_transport(skb, transproto, offset, len, flow, ordered_src < ordered_dst, ordered_src == ordered_dst);
+		{
+			struct net_keys net_keys = { .swap = ordered_src < ordered_dst, .equal = ordered_src < ordered_dst };
+			fill_transport(skb, transproto, offset, len, flow, net_keys);
+		}
 			break;
 		case IPPROTO_ICMP:
 			fill_icmpv4(skb, offset, flow);


### PR DESCRIPTION
skip skydive-cdd-overview-tests skip skydive-coverage skip skydive-devstack-tests skip skydive-helm-tests skip skydive-kolla-tests skip skydive-skydive-release skip skydive-create-binaries skip skydive-compile-tests skip skydive-functional-tests-backend-elasticsearch skip skydive-functional-tests-backend-orientdb skip skydive-go-fmt skip skydive-k8s-tests skip skydive-packaging-tests skip skydive-python-tests skip skydive-scale-tests skip skydive-selenium-tests skip skydive-unit-tests skip skydive-ppc64le-tests run vagrant-tests
