### PR TITLE
gremlin: Properly escape query arguments

### DIFF
--- a/gremlin/query_test.go
+++ b/gremlin/query_test.go
@@ -26,7 +26,31 @@ func TestQueryBuilder(t *testing.T) {
 	const key, val = "Type", "host"
 	expected := fmt.Sprintf(`G.V().Has("%s", Regex("%s"), "%s", Regex("%s.*"), "%s", Regex(".*%s")).Flows().Sort()`,
 		key, val, key, val, key, val)
-	actual := G.V().Has(Quote(key), Regex(val), Quote(key), Regex("%s.*", val), Quote(key), Regex(".*%s", val)).Flows().Sort()
+	actual := G.V().Has(Quote(key), Regex(val), Quote(key), Regex(val+".*"), Quote(key), Regex(".*"+val)).Flows().Sort()
+	if actual.String() != expected {
+		t.Errorf("Wrong query,\nexpected: \"%s\",\nactual: \"%s\"", expected, actual)
+	}
+}
+
+func TestQueryWithPercentSign(t *testing.T) {
+	actual := G.V().Has("foo", "%p")
+	expected := `G.V().Has("foo", "%p")`
+	if actual.String() != expected {
+		t.Errorf("Wrong query,\nexpected: \"%s\",\nactual: \"%s\"", expected, actual)
+	}
+}
+
+func TestQueryWithDoubleQuotes(t *testing.T) {
+	actual := G.V().Has("foo", `"`)
+	expected := `G.V().Has("foo", "\"")`
+	if actual.String() != expected {
+		t.Errorf("Wrong query,\nexpected: \"%s\",\nactual: \"%s\"", expected, actual)
+	}
+}
+
+func TestRegexWithPercentSignAndDoubleQuotes(t *testing.T) {
+	actual := G.V().Has("foo", Regex(`my-%s-"-regex`))
+	expected := `G.V().Has("foo", Regex("my-%s-\"-regex"))`
 	if actual.String() != expected {
 		t.Errorf("Wrong query,\nexpected: \"%s\",\nactual: \"%s\"", expected, actual)
 	}

--- a/gremlin/value.go
+++ b/gremlin/value.go
@@ -18,6 +18,7 @@
 package gremlin
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 )
@@ -52,14 +53,18 @@ func (v ValueString) String() string {
 const DESC = ValueString("DESC")
 
 // Quote used to quote string values as needed by query
-func Quote(format string, a ...interface{}) ValueString {
-	s := fmt.Sprintf(format, a...)
-	return ValueString(fmt.Sprintf(`"%s"`, s))
+func Quote(s string) ValueString {
+	escaped, err := json.Marshal(s)
+	if err != nil {
+		// According to the encoding/json source code, json.Marshal will never return
+		// error if the input type is a string; so this case is currently unlikely.
+		return ValueString(fmt.Sprintf("Unexpected error when quoting string: %v", err))
+	}
+	return ValueString(string(escaped))
 }
 
 // Regex used for constructing a regexp expression string
-func Regex(format string, a ...interface{}) ValueString {
-	s := fmt.Sprintf(format, a...)
+func Regex(s string) ValueString {
 	return ValueString(fmt.Sprintf("Regex(%s)", Quote(s)))
 }
 

--- a/tests/istio_test.go
+++ b/tests/istio_test.go
@@ -218,7 +218,7 @@ func TestBookInfoScenario(t *testing.T) {
 					return err
 				}
 
-				podProductpage, err := checkNodeCreation(t, c, k8s.Manager, "pod", g.Regex("%s-.*", "productpage"))
+				podProductpage, err := checkNodeCreation(t, c, k8s.Manager, "pod", g.Regex("productpage-.*"))
 				if err != nil {
 					return err
 				}

--- a/tests/k8s_test.go
+++ b/tests/k8s_test.go
@@ -342,7 +342,7 @@ func TestHelloNodeScenario(t *testing.T) {
 					return err
 				}
 
-				replicaset, err := checkNodeCreation(t, c, k8s.Manager, "replicaset", g.Regex("%s-.*", "hello-node"))
+				replicaset, err := checkNodeCreation(t, c, k8s.Manager, "replicaset", g.Regex("hello-node-.*"))
 				if err != nil {
 					return err
 				}
@@ -352,7 +352,7 @@ func TestHelloNodeScenario(t *testing.T) {
 					return err
 				}
 
-				pod, err := checkNodeCreation(t, c, k8s.Manager, "pod", g.Regex("%s-.*", "hello-node"))
+				pod, err := checkNodeCreation(t, c, k8s.Manager, "pod", g.Regex("hello-node-.*"))
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
When constructing the Gremlin query string, double quotes were not
escaped, and therefore using a double quote char inside a query argument
would break the query.  This fix uses json.Marshal to quote a string, so
special chars like quote, newline, and tab will be backslash-quoted
inside the resulting Gremlin query string.

Moreover, quoting was done by passing the input as the format string to
fmt.Sprintf, which causes "format string injection" issues (these cannot
cause segfaults like in C, but still not very nice). It seems that this
functionality is not used at all, but also broke query arguments that
have the `%` char in them.

Note that this changes the public function signatures of `gremlin.Quote` and `gremlin.Regex` - it seems they are not used outside this package but please take extra look.

This fix now allows the following queries:

    G.V().Has("foo", "%p") // --> `G.V().Has("foo", "%p")`
    G.V().Has("foo", `"`) // --> `G.V().Has("foo", "\\"")`

The commit adds unit tests for these cases:

    $ go test -v
    === RUN   TestQueryBuilder
    --- PASS: TestQueryBuilder (0.00s)
    === RUN   TestQueryWithPercentSign
    --- PASS: TestQueryWithPercentSign (0.00s)
    === RUN   TestQueryWithDoubleQuotes
    --- PASS: TestQueryWithDoubleQuotes (0.00s)
    === RUN   TestRegexWithPercentSignAndDoubleQuotes
    --- PASS: TestRegexWithPercentSignAndDoubleQuotes (0.00s)
    PASS
    ok      github.com/skydive-project/skydive/gremlin      0.007s