### PR TITLE
secadvisor: refactor resolver code

### DIFF
--- a/contrib/exporters/secadvisor/mod/resolve_cache.go
+++ b/contrib/exporters/secadvisor/mod/resolve_cache.go
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2019 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package mod
+
+import (
+	"time"
+
+	cache "github.com/pmylund/go-cache"
+
+	"github.com/skydive-project/skydive/common"
+	"github.com/skydive-project/skydive/logging"
+)
+
+// Resolver resolves values for the transformer
+type Resolver interface {
+	IPToName(ipString, nodeTID string) (string, error)
+	TIDToType(nodeTID string) (string, error)
+}
+
+type resolveCache struct {
+	resolver  Resolver
+	nameCache *cache.Cache
+	typeCache *cache.Cache
+}
+
+// NewResolveCache creates a new name resolver
+func NewResolveCache(resolver Resolver) Resolver {
+	return &resolveCache{
+		resolver:  resolver,
+		nameCache: cache.New(5*time.Minute, 10*time.Minute),
+		typeCache: cache.New(5*time.Minute, 10*time.Minute),
+	}
+}
+
+// IPToName resolve ip address to name
+func (rc *resolveCache) IPToName(ipString, nodeTID string) (string, error) {
+	name, ok := rc.nameCache.Get(ipString)
+
+	if !ok {
+		var err error
+		name, err = rc.resolver.IPToName(ipString, nodeTID)
+		if err != nil {
+			if err != common.ErrNotFound {
+				logging.GetLogger().Warningf("Failed to query container name for IP '%s': %s", ipString, err)
+			}
+			return "", err
+		}
+
+		rc.nameCache.Set(ipString, name, cache.DefaultExpiration)
+	}
+
+	return name.(string), nil
+}
+
+// TIDToType resolve tid to type
+func (rc *resolveCache) TIDToType(nodeTID string) (string, error) {
+	nodeType, ok := rc.typeCache.Get(nodeTID)
+	if !ok {
+		var err error
+		nodeType, err = rc.resolver.TIDToType(nodeTID)
+
+		if err != nil {
+			if err != common.ErrNotFound {
+				logging.GetLogger().Warningf("Failed to query node type for TID '%s': %s", nodeTID, err)
+			}
+			return "", err
+		}
+
+		rc.typeCache.Set(nodeTID, nodeType, cache.DefaultExpiration)
+	}
+
+	return nodeType.(string), nil
+}

--- a/contrib/exporters/secadvisor/mod/resolve_fallback.go
+++ b/contrib/exporters/secadvisor/mod/resolve_fallback.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2019 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package mod
+
+type resolveFallback struct {
+	resolver Resolver
+}
+
+// NewResolveFallback creates a new name resolver
+func NewResolveFallback(resolver Resolver) Resolver {
+	return &resolveFallback{
+		resolver: resolver,
+	}
+}
+
+// IPToName resolve ip address to name
+func (rc *resolveFallback) IPToName(ipString, nodeTID string) (string, error) {
+	if ipString == "" {
+		return "", nil
+	}
+
+	name, err := rc.resolver.IPToName(ipString, nodeTID)
+	if err != nil {
+		return ipString, nil
+	}
+
+	return name, nil
+}
+
+// TIDToType resolve tid to type
+func (rc *resolveFallback) TIDToType(nodeTID string) (string, error) {
+	if nodeTID == "" {
+		return "", nil
+	}
+
+	nodeType, _ := rc.resolver.TIDToType(nodeTID)
+	return nodeType, nil
+}

--- a/contrib/exporters/secadvisor/mod/resolve_multi.go
+++ b/contrib/exporters/secadvisor/mod/resolve_multi.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2019 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package mod
+
+import (
+	"github.com/skydive-project/skydive/common"
+)
+
+type resolveMulti struct {
+	resolvers []Resolver
+}
+
+// NewResolveMulti creates a new name resolver
+func NewResolveMulti(resolvers ...Resolver) Resolver {
+	return &resolveMulti{
+		resolvers: resolvers,
+	}
+}
+
+// IPToName resolve ip address to name
+func (rm *resolveMulti) IPToName(ipString, nodeTID string) (string, error) {
+	for _, r := range rm.resolvers {
+		if name, err := r.IPToName(ipString, nodeTID); err == nil {
+			return name, nil
+		}
+	}
+
+	return "", common.ErrNotFound
+}
+
+// TIDToType resolve tid to type
+func (rm *resolveMulti) TIDToType(nodeTID string) (string, error) {
+	for _, r := range rm.resolvers {
+		if ty, err := r.TIDToType(nodeTID); err == nil {
+			return ty, nil
+		}
+	}
+
+	return "", common.ErrNotFound
+}

--- a/contrib/exporters/secadvisor/mod/resolve_runc.go
+++ b/contrib/exporters/secadvisor/mod/resolve_runc.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2019 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package mod
+
+import (
+	"github.com/spf13/viper"
+
+	"github.com/skydive-project/skydive/api/client"
+	"github.com/skydive-project/skydive/contrib/exporters/core"
+	g "github.com/skydive-project/skydive/gremlin"
+)
+
+// NewResolveRunc creates a new name resolver
+func NewResolveRunc(cfg *viper.Viper) Resolver {
+	gremlinClient := client.NewGremlinQueryHelper(core.CfgAuthOpts(cfg))
+	return &resolveRunc{
+		gremlinClient: gremlinClient,
+	}
+}
+
+type resolveRunc struct {
+	gremlinClient *client.GremlinQueryHelper
+}
+
+// IPToName resolve ip to name
+func (r *resolveRunc) IPToName(ipString, nodeTID string) (string, error) {
+	node, err := r.gremlinClient.GetNode(g.G.V().Has("TID", nodeTID).Out("Runc.Hosts.IP", ipString))
+	if err != nil {
+		return "", err
+	}
+
+	name, err := node.GetFieldString("Runc.Hosts.Hostname")
+	if err != nil {
+		return "", err
+	}
+
+	return "0_0_" + name + "_0", nil
+}
+
+// TIDToType resolve tid to type
+func (r *resolveRunc) TIDToType(nodeTID string) (string, error) {
+	node, err := r.gremlinClient.GetNode(g.G.V().Has("TID", nodeTID))
+	if err != nil {
+		return "", err
+	}
+
+	return node.GetFieldString("Type")
+}


### PR DESCRIPTION
the refactor of resolver is functional natural but will enable to easy support adding of additional resolution methods beyond runC such that we may have:
- runc (current secadvisor)
- docker (legacy secadvisor)
- k8s (future secadvisor)
- generic (which uses configuration) 

@KalmanMeth / @dubek / @eranra - kindly review