### PR TITLE
contrib/k8s: fix cluster role

### DIFF
--- a/contrib/kubernetes/README.md
+++ b/contrib/kubernetes/README.md
@@ -45,3 +45,9 @@ Change etcd port from 12379/12380 to 22379/22380:
 ```
 cat skydive.yaml | sed -e s/12379/22379/ -e s/12380/22380/ | kubectl apply -f -
 ```
+
+Deploy to namespace `mynamespace` instead of `default`:
+
+```
+cat skydive.yaml | sed -e "s/namespace: default/namespace: mynamespace/" | kubectl apply -n mynamespace -f -
+```

--- a/contrib/kubernetes/skydive.yaml
+++ b/contrib/kubernetes/skydive.yaml
@@ -6,11 +6,11 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: skydive-default-view
+  name: skydive-cluster-role
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: view
+  name: cluster-admin
 subjects:
   - kind: ServiceAccount
     name: skydive-service-account


### PR DESCRIPTION
To test:

```
kubectl create namespace mynamespace
cat skydive.yaml | sed -e "s/namespace: default/namespace: mynamespace/" | kubectl delete -n mynamespace -f -
```