### PR TITLE
exporters/core: Fixes for StoreS3: Serialize access, fix queueing

### DIFF
--- a/contrib/exporters/core/store_s3.go
+++ b/contrib/exporters/core/store_s3.go
@@ -105,7 +105,9 @@ func (s *StoreS3) StoreFlows(in map[Tag][]interface{}) error {
 
 	endTime := time.Now()
 
-	s.flows = in
+	for t, incomingTagFlows := range in {
+		s.flows[t] = append(s.flows[t], incomingTagFlows...)
+	}
 
 	// check which flows needs to be flushed to the object store
 	flushedTags := make(map[Tag]bool)

--- a/contrib/exporters/core/store_s3.go
+++ b/contrib/exporters/core/store_s3.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spf13/viper"
@@ -53,6 +54,7 @@ type StoreS3 struct {
 	flows             map[Tag][]interface{}
 	lastFlushTime     map[Tag]time.Time
 	flushTimers       map[Tag]*time.Timer
+	flowsMutex        sync.Mutex
 }
 
 // SetPipeline setup
@@ -98,6 +100,9 @@ func (s *StoreS3) DeleteObject(objectKey *string) error {
 
 // StoreFlows store flows in memory, before being written to the object store
 func (s *StoreS3) StoreFlows(in map[Tag][]interface{}) error {
+	s.flowsMutex.Lock()
+	defer s.flowsMutex.Unlock()
+
 	endTime := time.Now()
 
 	s.flows = in


### PR DESCRIPTION
Two small changes:

1. Serialize access to StoreFlows: we encountered panics (slice out of bounds) due to multiple goroutines modifying `s.flows` concurrently.
2. Appending incoming flows to current state (queue) instead of replacing current state.

Basically here we restore previous behaviour that was modified in commit cf3489644e051f048138ac504f2ce758978f19d6 .

@hunchback please review.

Note that there are ideas of how to improve this whole area of the code (in the future) - create a proper batching and queuing layers (maybe open source libraries already exist?) instead of slices and timers per tag.
