### PR TITLE
contrib/openshift, charts: Mount OpenShift dirs in agent pod

### DIFF
--- a/contrib/helm/templates/deployment-agents.yaml
+++ b/contrib/helm/templates/deployment-agents.yaml
@@ -13,7 +13,7 @@ spec:
       annotations:
         productName: {{ .Chart.Name }}
         productID: 8e6bdbcba44f46939c3d1c54447386b2
-        productVersion: {{ .Chart.Version }} 
+        productVersion: {{ .Chart.Version }}
       labels:
         app: {{ template "fullname" . }}
         chart: "{{ .Chart.Name }}"
@@ -24,7 +24,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       securityContext:
-        runAsNonRoot: false        
+        runAsNonRoot: false
       affinity:
         {{- include "nodeaffinity" . | indent 6 }}
       tolerations:
@@ -34,7 +34,7 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.image.secretName }}
       {{- end }}
-      {{- end }}      
+      {{- end }}
       containers:
       - name: skydive-agent
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/contrib/helm/templates/deployment-agents.yaml
+++ b/contrib/helm/templates/deployment-agents.yaml
@@ -100,6 +100,10 @@ spec:
           mountPath: /var/data/kubelet
         - name: lib-kubelet
           mountPath: /var/lib/kubelet
+        - name: data-openshiftvolumes
+          mountPath: /var/data/openshiftvolumes
+        - name: lib-origin
+          mountPath: /var/lib/origin
       volumes:
       - name: docker
         hostPath:
@@ -125,3 +129,9 @@ spec:
       - name: lib-kubelet
         hostPath:
           path: /var/lib/kubelet
+      - name: data-openshiftvolumes
+        hostPath:
+          path: /var/data/openshiftvolumes
+      - name: lib-origin
+        hostPath:
+          path: /var/lib/origin

--- a/contrib/openshift/skydive-template.yaml
+++ b/contrib/openshift/skydive-template.yaml
@@ -186,6 +186,10 @@ objects:
             name: runc-ctrs
           - mountPath: /run/containerd/runc
             name: containerd-runc
+          - mountPath: /var/data/openshiftvolumes
+            name: data-openshiftvolumes
+          - mountPath: /var/lib/origin
+            name: lib-origin
         dnsPolicy: ClusterFirst
         hostNetwork: true
         hostPID: true
@@ -210,6 +214,12 @@ objects:
         - hostPath:
             path: /run/openvswitch/db.sock
           name: ovsdb
+        - hostPath:
+            path: /var/data/openshiftvolumes
+          name: data-openshiftvolumes
+        - hostPath:
+            path: /var/lib/origin
+          name: lib-origin
 - apiVersion: v1
   kind: Route
   metadata:
@@ -232,7 +242,7 @@ parameters:
   name: SKYDIVE_LOGGING_LEVEL
   required: true
   value: INFO
-- description: Topology probes for anaylyser, default is empty. Add 'k8s' to add k8s/openshift objects to skydive
+- description: Topology probes for analyzer, default is empty. Add 'k8s' to add k8s/openshift objects to skydive
   displayName: Analyzer topology probes
   name: SKYDIVE_ANALYZER_TOPOLOGY_PROBES
   required: false


### PR DESCRIPTION
OpenShift seems to store state files about containers under `/var/lib/origin` and `/var/data/openshiftvolumes` . In order for the Skydive agent Runc probe to successfully extract container information on OpenShift, it should have access to these directories.

Without this we got the following errors in `parseHosts` (unfortunately in `DEBUG` level) at the beginning of the agent log when running in OpenShift 3.11:

```
2019-09-05T08:02:21.232Z        INFO    agent/agent.go:41 glob..func1   kube-wdc04-crac1766060dcf4354816f6b171eae7a7b-w1.cloud.ibm: Skydive Agent _2019-09-02T05:45:19 starting...
...
2019-09-05T08:02:21.251Z        ERROR   runc/runc.go:346 (*ProbeHandler).initializeFolder       kube-wdc04-crac1766060dcf4354816f6b171eae7a7b-w1.cloud.ibm: no such file or directory
2019-09-05T08:02:21.252Z        ERROR   runc/runc.go:346 (*ProbeHandler).initializeFolder       kube-wdc04-crac1766060dcf4354816f6b171eae7a7b-w1.cloud.ibm: no such file or directory
2019-09-05T08:02:21.253Z        DEBUG   runc/runc.go:261 (*ProbeHandler).registerContainer      kube-wdc04-crac1766060dcf4354816f6b171eae7a7b-w1.cloud.ibm: Register runc container 0ce1bbc1db5ab0260c5df542b1fd69d54eef6458074ad957e7e891d03e226736 and PID 20213
2019-09-05T08:02:21.267Z        DEBUG   runc/runc.go:195 (*ProbeHandler).parseHosts     kube-wdc04-crac1766060dcf4354816f6b171eae7a7b-w1.cloud.ibm: open /var/lib/origin/openshift.local.volumes/pods/4f422727-9db1-11e9-8074-deb42b7790a3/etc-hosts: no such file or directory
2019-09-05T08:02:21.268Z        ERROR   runc/runc.go:346 (*ProbeHandler).initializeFolder       kube-wdc04-crac1766060dcf4354816f6b171eae7a7b-w1.cloud.ibm: no such file or directory
2019-09-05T08:02:21.270Z        DEBUG   runc/runc.go:261 (*ProbeHandler).registerContainer      kube-wdc04-crac1766060dcf4354816f6b171eae7a7b-w1.cloud.ibm: Register runc container 126901b72747848fe8f83d55a5ddf2a3c132e080c0bec3c85f44278953ed1414 and PID 18367
2019-09-05T08:02:21.270Z        DEBUG   netns/netns.go:135 (*ProbeHandler).Register     kube-wdc04-crac1766060dcf4354816f6b171eae7a7b-w1.cloud.ibm: Register network namespace: /proc/18367/ns/net
2019-09-05T08:02:21.270Z        DEBUG   netns/netns.go:174 (*ProbeHandler).Register     kube-wdc04-crac1766060dcf4354816f6b171eae7a7b-w1.cloud.ibm: Network namespace added: 3,4026532639
2019-09-05T08:02:21.270Z        DEBUG   netns/netns.go:192 (*ProbeHandler).Register     kube-wdc04-crac1766060dcf4354816f6b171eae7a7b-w1.cloud.ibm: Registering namespace: 3,4026532639
2019-09-05T08:02:21.272Z        DEBUG   runc/runc.go:195 (*ProbeHandler).parseHosts     kube-wdc04-crac1766060dcf4354816f6b171eae7a7b-w1.cloud.ibm: open /var/lib/origin/openshift.local.volumes/pods/d8f766b8-cedb-11e9-b9ab-72f2130a622b/etc-hosts: no such file or directory
```

Mounting `/var/lib/origin` and `/var/data/openshiftvolumes` solved these (though a few `no such file or directroy` errors remain, see #1976).