### PR TITLE
contrib/exporters/core: Populate the X-Websocket-Namespace header

### DIFF
--- a/contrib/exporters/core/subscriber.go
+++ b/contrib/exporters/core/subscriber.go
@@ -19,6 +19,7 @@ package core
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
@@ -29,6 +30,7 @@ import (
 	"github.com/skydive-project/skydive/common"
 	"github.com/skydive-project/skydive/config"
 	shttp "github.com/skydive-project/skydive/http"
+	"github.com/skydive-project/skydive/logging"
 	"github.com/skydive-project/skydive/websocket"
 )
 
@@ -55,7 +57,12 @@ func NewSubscriber(pipeline *Pipeline, cfg *viper.Viper) (*websocket.StructSpeak
 		namespace = namespace + "/" + captureID
 	}
 
-	wsClient, err := config.NewWSClient(common.AnalyzerService, subscriberURL, websocket.ClientOpts{AuthOpts: CfgAuthOpts(cfg)})
+	logging.GetLogger().Infof("Subscribing to %s with namespace '%s'", subscriberURL, namespace)
+	clientOpts := websocket.ClientOpts{
+		AuthOpts: CfgAuthOpts(cfg),
+		Headers:  http.Header{"X-Websocket-Namespace": []string{namespace}},
+	}
+	wsClient, err := config.NewWSClient(common.AnalyzerService, subscriberURL, clientOpts)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create websocket client: %s", err)
 	}


### PR DESCRIPTION
contrib/exporters/core: Populate the X-Websocket-Namespace header



Following changes in the Skydive flow server to publish flows by capture
ID, the exporter subscription didn't receive any websocket messages it didn't
supply any namespace during connection (and therefore got a default
WildcardNamespace = `"*"`).  The flow server looks for subscribers
literally according to their requested namespace (and didn't take `"*"`
into account).

This fix makes the exporter websocket subscriber populate the
`X-Websocket-Namespace` HTTP header (on the websocket connection) with
the namespace `flow` or the namespace `flow/<CAPTURE_ID>` (if configured
to subscribe to a specific capture ID).

I think this was broken in commit da7e47bb785ec594b6ecfd38096c18aa40387f31 , but I'm actually fixing the client (flow exporter) here to declare the required namespace.

@hunchback please review; @safchain please check this is inline with your original intention when adding namespace handling in the flow server.

----

### Before the fix

Exporter log:

```
2019-09-08T09:52:08.901Z        INFO    websocket/client.go:507 (*Client).Connect       : Connecting to ws://127.0.0.1:8082/ws/subscriber/flow
2019-09-08T09:52:08.902Z        INFO    websocket/client.go:531 (*Client).Connect       : Connected to ws://127.0.0.1:8082/ws/subscriber/flow
```

Skydive analyzer log:

```
2019-09-08T09:50:31.930Z        INFO    websocket/server.go:117 (*Server).newIncomingClient     : New WebSocket Connection from 127.0.0.1:33594 : URI path /ws/subscriber/flow
2019-09-08T09:50:31.931Z        INFO    server/flow_subscriber_endpoint.go:81 (*FlowSubscriberEndpoint).OnConnected     : New flow subscriber using namespaces: [*]
```
 
Notice that the namespace the server sees is `"*"` (this is `websocket.WildcardNamespace`).

----

### After the fix

Exporter log:

```
2019-09-08T11:52:27.040Z        INFO    core/subscriber.go:60 NewSubscriber     : Subscribing to ws://127.0.0.1:8082/ws/subscriber/flow with namespace 'flow'
2019-09-08T11:52:27.041Z        INFO    websocket/client.go:507 (*Client).Connect       : Connecting to ws://127.0.0.1:8082/ws/subscriber/flow
2019-09-08T11:52:27.042Z        INFO    websocket/client.go:531 (*Client).Connect       : Connected to ws://127.0.0.1:8082/ws/subscriber/flow
```

Skydive analyzer log:

```
2019-09-08T11:52:27.042Z        INFO    websocket/server.go:117 (*Server).newIncomingClient    : New WebSocket Connection from 127.0.0.1:38760 : URI path /ws/subscriber/flow
2019-09-08T11:52:27.042Z        INFO    server/flow_subscriber_endpoint.go:83 (*FlowSubscriberEndpoint).OnConnected     : New flow subscriber using namespaces: [flow]
```
