### PR TITLE
AWS Accept/Reject Action field in exporter report for VPC logs

### DIFF
--- a/contrib/exporters/core/acc_rej_action.go
+++ b/contrib/exporters/core/acc_rej_action.go
@@ -15,18 +15,21 @@
  *
  */
 
-package main
+package core
 
 import (
-	"github.com/skydive-project/skydive/contrib/exporters/core"
-	vpc "github.com/skydive-project/skydive/contrib/exporters/vpclogs/mod"
+	"github.com/spf13/viper"
 )
 
-func main() {
-	core.Main("/etc/skydive/vpclogs.yml")
+type actionerNone struct {
 }
 
-func init() {
-	core.TransformerHandlers.Register("vpclogs", vpc.NewTransform, false)
-	core.ActionHandlers.Register("aws", vpc.NewAction, false)
+// NewAccRejNone create a new Accept/Reject process that will do nothing
+func NewActionerNone(cfg *viper.Viper) (interface{}, error) {
+	return &actionerNone{}, nil
+}
+
+// Action for type accRejNone does nothing
+func (t actionerNone) Action(f interface{}) interface{} {
+	return f
 }

--- a/contrib/exporters/vpclogs/mod/acc_rej_action.go
+++ b/contrib/exporters/vpclogs/mod/acc_rej_action.go
@@ -1,0 +1,338 @@
+/*
+ * Copyright (C) 2019 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/*
+ * This code is to support the "action" feature of aws in the vpc flow logs.
+ * For each flow, specify whether it was Accepted or Rejected.
+ * The assumption is that we have 2 points where the flows are captured: one on each side of a firewall.
+ * If a flow appears on only one side of the firewall, we declare it as Rejected.
+ * If the flow appears on both sides of the firewall, we declare it as Accepted.
+ * When a flow is blocked mid-stream, we need to accurately report the number of bytes and packets that were Accepted.
+ *
+ * The algorith to implement the feature is as follows.
+ * For each accepted flow, we should see the flow logs at both points of capture.
+ * For each rejected flow, we should see the flow logs at only one of the points of capture.
+ * For each round of reported flows, match up the pairs of accepted flows using their common Tracking ID.
+ * Measurements on the 2 interfaces may happen independently of one another.
+ * Since a flow may change from Accepted to Rejected mid-stream, we should be careful to report as Accepted 
+ * only those bytes and packets that have already been confirmed at both capture points.
+ * We therefore report the lesser of the numbers (bytes, packets, time) recorded in the 2 measurements of the same flow.
+ */
+
+package mod
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/viper"
+
+	"github.com/skydive-project/skydive/common"
+	"github.com/skydive-project/skydive/flow"
+	"github.com/skydive-project/skydive/logging"
+	"github.com/skydive-project/skydive/contrib/exporters/core"
+)
+
+type flowInfoStatus int32
+
+const (
+	flowInfoNoState     flowInfoStatus = 0
+	flowInfoOneEntry    flowInfoStatus = 1 // startup state
+	flowInfoTwoEntries  flowInfoStatus = 2 // startup state
+	flowInfoOldFlow     flowInfoStatus = 3 // standard state
+	flowInfoOneEntryDup flowInfoStatus = 4 // error state
+	flowInfoThreeFlows  flowInfoStatus = 5 // error state
+	flowInfoTimedOut    flowInfoStatus = 6 // error state
+	flowInfoRejected    flowInfoStatus = 7 // error state
+)
+
+// time for cleanup of old connections
+const timeoutPeriodCleanup = 20
+
+type singleFlowInfo struct {
+	UUID string
+	flow *VpclogsFlow // most recent Flow seen for this UUID
+	saw  bool         // true if this UUID was seen in most recent interation
+}
+
+type combinedFlowInfo struct {
+	status         flowInfoStatus
+	prevStatus     flowInfoStatus
+	metricReported *flow.FlowMetric
+	flow1          singleFlowInfo
+	flow2          singleFlowInfo
+}
+
+type Action struct {
+	// table of saved flows
+	state             map[string]*combinedFlowInfo
+	timeOfLastCleanup int64
+	tid1              string
+	tid2              string
+}
+
+// NewAction - creates data structures needed for vpc Accept/Reject based on measurements flows at 2 points
+func NewAction(cfg *viper.Viper) (interface{}, error) {
+	state := make(map[string]*combinedFlowInfo)
+	tid1 := cfg.GetString(core.CfgRoot + "action.tid1")
+	if tid1 == "" {
+		logging.GetLogger().Errorf("tid1 not defined")
+		return nil, fmt.Errorf("Failed to detect tid1")
+	}
+	tid2 := cfg.GetString(core.CfgRoot + "action.tid2")
+	if tid2 == "" {
+		logging.GetLogger().Errorf("tid2 not defined")
+		return nil, fmt.Errorf("Failed to detect tid2")
+	}
+	logging.GetLogger().Infof("tid1 = %s", tid1)
+	logging.GetLogger().Infof("tid2 = %s", tid2)
+	now := time.Now()
+	secs := now.Unix()
+	accRej := &Action{
+		state:             state,
+		timeOfLastCleanup: secs,
+		tid1:              tid1,
+		tid2:              tid2,
+	}
+	return accRej, nil
+}
+
+// init - initialize internal data structure for this round
+func (t *Action) init() {
+	// reset the entries in the table for this round
+	for _, ars := range t.state {
+		ars.flow1.saw = false
+		ars.flow2.saw = false
+		ars.prevStatus = ars.status
+		if ars.status == flowInfoTwoEntries {
+			ars.status = flowInfoOldFlow
+		}
+	}
+}
+
+// updateInfo - go over all the flows and fill in our internal data structure with relevant info
+func (t *Action) updateInfo(fl interface{}) {
+	fl1 := fl.([]interface{})
+	for _, i := range fl1 {
+		f := i.(*VpclogsFlow)
+		// only consider flows that match the specified TIDs
+		if f.TID != t.tid1  && f.TID != t.tid2 {
+			logging.GetLogger().Errorf("TIDs don't match: tid1 = %s, tid2 = %s, flowInfo = %s", t.tid1, t.tid2, f)
+			return
+		}
+		TrackingID := f.TrackingID
+		flowInfState, ok := t.state[TrackingID]
+		newFlowInfo := singleFlowInfo {
+			flow: f,
+			UUID: f.UUID,
+			saw:  true,
+		}
+		if !ok {
+			// this flow is not yet in our table
+			t.state[TrackingID] = &combinedFlowInfo{
+				status: flowInfoOneEntry,
+				flow1:  newFlowInfo,
+			}
+			continue
+		} else if flowInfState.status == flowInfoOneEntry {
+			if flowInfState.flow1.UUID != f.UUID {
+				flowInfState.flow2 = newFlowInfo
+				flowInfState.status = flowInfoTwoEntries
+			} else {
+				// got duplicate from same flow; need to indicate reject
+				// or accumulate the stats until next time
+				flowInfState.status = flowInfoOneEntryDup
+				if f.Last > flowInfState.flow1.flow.Last {
+					flowInfState.flow1.flow = f
+				}
+				flowInfState.flow1.saw = true
+			}
+		} else { // normal case; we have info from 2 flows
+			if flowInfState.flow1.UUID == f.UUID {
+				if f.Last > flowInfState.flow1.flow.Last {
+					flowInfState.flow1.flow = f
+				}
+				flowInfState.flow1.saw = true
+			} else if flowInfState.flow2.UUID == f.UUID {
+				if f.Last > flowInfState.flow2.flow.Last {
+					flowInfState.flow2.flow = f
+				}
+				flowInfState.flow2.saw = true
+			} else {
+				// this is a third flow with the same TrackingID;
+				logging.GetLogger().Errorf("third flow with same tracking id; f = %s, flow1 = %s, flow2 = %s", f, flowInfState.flow1, flowInfState.flow2)
+				flowInfState.status = flowInfoThreeFlows
+			}
+		}
+	}
+}
+
+func prepareCombinedMetric(M1, M2 *flow.FlowMetric) *flow.FlowMetric {
+	// take byte and packet count as minimum of the 2 reports
+	return &flow.FlowMetric{
+		ABPackets: common.MinInt64(M1.ABPackets, M2.ABPackets),
+		BAPackets: common.MinInt64(M1.BAPackets, M2.BAPackets),
+		ABBytes:   common.MinInt64(M1.ABBytes, M2.ABBytes),
+		BABytes:   common.MinInt64(M1.BABytes, M2.BABytes),
+		Last:      common.MinInt64(M1.Last, M2.Last),
+		Start:     M1.Start,
+	}
+}
+
+// combineFlows - helper function to combine 2 seen flows into one, based on common minimums
+func (t *Action) combineFlows(f *combinedFlowInfo) *VpclogsFlow {
+	if f.status == flowInfoThreeFlows { // error status; return no combined flow
+		return nil
+	}
+	logging.GetLogger().Debugf("combineFlows: flow1 = %s", f.flow1.flow)
+	logging.GetLogger().Debugf("combineFlows: flow2 = %s", f.flow2.flow)
+	// perform shallow copy of flow and then update some fields
+	newF := *f.flow1.flow
+	// verify we received flows from each of the 2 specified interfaces
+	tidOK := true
+	if f.flow1.flow.TID != t.tid1 {
+		if f.flow1.flow.TID != t.tid2 || f.flow2.flow.TID != t.tid1 {
+			tidOK = false;
+		}
+	} else if f.flow2.flow.TID != t.tid2 {
+		tidOK = false
+	}
+	if !tidOK {
+		logging.GetLogger().Errorf("TIDs don't match: tid1 = %s, tid2 = %s, flowInfo = %s", t.tid1, t.tid2, f)
+		newF.SetAction("REJECT")
+		f.status = flowInfoRejected
+		return &newF
+	}
+	newMetricReported := prepareCombinedMetric(f.flow1.flow.Metric, f.flow2.flow.Metric)
+
+	// if we are at the end of the flow, set Last time to latest of the times measured
+	if f.flow1.flow.FinishType == "ENDED" && f.flow2.flow.FinishType == "ENDED" {
+		newMetricReported.Last = common.MaxInt64(f.flow1.flow.Metric.Last, f.flow2.flow.Metric.Last)
+	}
+
+	var newLastUpdateMetric *flow.FlowMetric = new(flow.FlowMetric)
+	// compute LastUpdateMetric based on previous metricReported and current newMetricReported
+	if f.status == flowInfoOldFlow {
+		newLastUpdateMetric.ABPackets = newMetricReported.ABPackets - f.metricReported.ABPackets
+		newLastUpdateMetric.ABBytes = newMetricReported.ABBytes - f.metricReported.ABBytes
+		newLastUpdateMetric.BAPackets = newMetricReported.BAPackets - f.metricReported.BAPackets
+		newLastUpdateMetric.BABytes = newMetricReported.BABytes - f.metricReported.BABytes
+		newLastUpdateMetric.Start = f.metricReported.Last
+	} else {
+		// this is the first report for the flow
+		newLastUpdateMetric = prepareCombinedMetric(f.flow1.flow.LastUpdateMetric, f.flow2.flow.LastUpdateMetric)
+		newLastUpdateMetric.Start = newMetricReported.Start
+	}
+	newLastUpdateMetric.Last = newMetricReported.Last
+
+	newF.Metric = newMetricReported
+	newF.LastUpdateMetric = newLastUpdateMetric
+
+	// What should we do with UpdateCount? In the meantime, we have the value from flow1.flow
+	newF.SetAction("ACCEPT")
+	f.metricReported = newMetricReported
+	logging.GetLogger().Debugf("combineFlows: %s\n\n", newF)
+	return &newF
+}
+
+// specialHandling - called when we did not see 2 copies of a flow during this iteration; figure out if we need to Reject
+func (t *Action) specialHandling(f *combinedFlowInfo) *VpclogsFlow {
+	// almost all exception cases are Rejected. Do special handling only for cases that are not Rejected
+	if f.status == flowInfoOneEntry {
+		if f.prevStatus == flowInfoNoState { // give it another iteration
+			return nil
+		}
+	} else if f.status == flowInfoOldFlow {
+		if !f.flow1.saw && !f.flow2.saw { // this might be OK
+			// if the flow is indicated as ENDED, then mark it for deletion
+			if f.flow1.flow.FinishType == "ENDED" || f.flow2.flow.FinishType == "ENDED" { // flow was finished
+				f.status = flowInfoTimedOut
+			}
+			return nil
+		} else if f.flow1.flow.Metric.Last > f.metricReported.Last && f.flow2.flow.Metric.Last > f.metricReported.Last {
+			// only one flow was received this iteration; report left-over bytes from previous report
+			return t.combineFlows(f)
+		}
+	}
+	// all other cases are marked as Rejected
+	var f2 *VpclogsFlow
+	f2 = f.flow1.flow
+	f2.SetAction("REJECT")
+	f.status = flowInfoRejected
+	logging.GetLogger().Debugf("rejectFlow: %s\n\n", f2)
+	return f2
+}
+
+// cleanupOldEntries - delete old entries from table; allocate a new table and preserve only the live connections
+func (t *Action) cleanupOldEntries() {
+	// allocate a new status buffer
+	stateNew := make(map[string]*combinedFlowInfo)
+	logging.GetLogger().Debugf("Action cleanupOldEntries, len of old state table: %d", len(t.state))
+	for _, f := range t.state {
+		if f.status == flowInfoRejected {
+			continue
+		}
+		if f.status == flowInfoThreeFlows { // let this flow be re-initialized on the next iteration
+			continue
+		}
+		if f.flow1.flow.FinishType == "ENDED" && f.flow2.flow.FinishType == "ENDED" { // flow was finished
+			continue
+		}
+		if f.status == flowInfoOneEntry && f.prevStatus == flowInfoOneEntry {
+			continue
+		}
+		if f.status == flowInfoTimedOut {
+			continue
+		}
+		TrackingID := f.flow1.flow.TrackingID
+		stateNew[TrackingID], _ = t.state[TrackingID]
+	}
+	t.state = stateNew
+	logging.GetLogger().Debugf("Action cleanupOldEntries, len of new state table: %d", len(t.state))
+	now := time.Now()
+	t.timeOfLastCleanup = now.Unix()
+}
+
+// Action - combines flows from 2 measurement points to determine whether a flow was Accepted or Rejected
+func (t *Action) Action(fl interface{}) interface{} {
+	t.init()
+	t.updateInfo(fl)
+
+	// go over the table and prepare the items that need to be reported
+	// flows that were seen twice are Accepted; flows seen once need special handling for accounting purposes
+	var newFl []interface{}
+	var f2 *VpclogsFlow
+	for _, f := range t.state {
+		if f.flow1.saw && f.flow2.saw {
+			f2 = t.combineFlows(f)
+		} else {
+			f2 = t.specialHandling(f)
+		}
+		// if flow is valid but did not appear in most recent round, report nothing
+		if f2 != nil {
+			newFl = append(newFl, f2)
+		}
+	}
+	// delete old Rejected entries every so often
+	now := time.Now()
+	secs := now.Unix()
+	secs2 := t.timeOfLastCleanup + timeoutPeriodCleanup
+	if secs > secs2 {
+		t.cleanupOldEntries()
+	}
+	return newFl
+}

--- a/contrib/exporters/vpclogs/mod/action_test.go
+++ b/contrib/exporters/vpclogs/mod/action_test.go
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2019 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package mod
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/skydive-project/skydive/common"
+	"github.com/skydive-project/skydive/config"
+	"github.com/skydive-project/skydive/flow"
+)
+
+func myPrint(a interface{}) {
+	out, _ := json.Marshal(a)
+	fmt.Println(string(out))
+}
+
+const testConfig = `---
+pipeline:
+  action:
+    type: aws
+    tid1: fake_tid_1
+    tid2: fake_tid_2
+`
+
+func initConfig(conf string) error {
+	f, _ := ioutil.TempFile("", "action_test")
+	b := []byte(conf)
+	f.Write(b)
+	f.Close()
+	err := config.InitConfig("file", []string{f.Name()})
+	return err
+}
+
+func assertEqual(t *testing.T, expected, actual interface{}) {
+	if expected != actual {
+		msg := "Equal assertion failed"
+		_, file, no, ok := runtime.Caller(1)
+		if ok {
+			msg += fmt.Sprintf(" on %s:%d", file, no)
+		}
+		t.Fatalf("%s: (expected: %v, actual: %v)", msg, expected, actual)
+	}
+}
+
+func assertEqualInt64(t *testing.T, expected, actual int64) {
+	if expected != actual {
+		msg := "Equal assertion failed"
+		_, file, no, ok := runtime.Caller(1)
+		if ok {
+			msg += fmt.Sprintf(" on %s:%d", file, no)
+		}
+		t.Fatalf("%s: (expected: %v, actual: %v)", msg, expected, actual)
+	}
+}
+
+type fakeActioner interface {
+	// Action determines the Accept/Reject action and combines common flows
+	Action(f interface{}) interface{}
+}
+
+func getBasicFlow() *VpclogsFlow {
+	t, _ := time.Parse(time.RFC3339, "2019-01-01T10:20:30Z")
+	start := common.UnixMillis(t)
+	return &VpclogsFlow{
+		UUID:       "66724f5d-718f-47a2-93a7-c807cd54241e",
+		LayersPath: "Ethernet/IPv4/TCP",
+		Network: &VpclogsFlowLayer{
+			Protocol: "IPv4",
+			A:        "192.168.0.5",
+			B:        "173.194.40.147",
+		},
+		Transport: &VpclogsFlowLayer{
+			Protocol: "TCP",
+			A:        "47838",
+			B:        "80",
+		},
+		Metric: &flow.FlowMetric{
+			ABPackets: 6,
+			ABBytes:   516,
+			BAPackets: 4,
+			BABytes:   760,
+		},
+		LastUpdateMetric: &flow.FlowMetric{
+			ABPackets: 2,
+			ABBytes:   200,
+			BAPackets: 3,
+			BABytes:   300,
+		},
+		Start: start,
+		Last:  start,
+	}
+}
+
+func getFlowArrayLive(iter int) interface{} {
+	iteration := int64(iter)
+	flow1 := getBasicFlow()
+	flow1.TrackingID = "flow1-id"
+	flow1.Metric.ABPackets += iteration * 2
+	flow1.Metric.ABBytes += iteration * 200
+	flow1.Metric.BAPackets += iteration * 3
+	flow1.Metric.BABytes += iteration * 300
+	flow1.Last = flow1.Start + iteration*300
+	flow1.UUID = "UUID1"
+	flow1.TID = "fake_tid_1"
+
+	flow2 := getBasicFlow()
+	flow2.TrackingID = "flow2-id"
+	flow2.Metric.ABPackets += iteration * 2
+	flow2.Metric.ABBytes += iteration * 200
+	flow2.Metric.BAPackets += iteration * 3
+	flow2.Metric.BABytes += iteration * 300
+	flow2.Last = flow2.Start + iteration*300
+	flow2.UUID = "UUID2"
+	flow2.TID = "fake_tid_1"
+
+	flow3 := getBasicFlow()
+	flow3.TrackingID = "flow3-id"
+	flow3.Metric.ABPackets += iteration * 2
+	flow3.Metric.ABBytes += iteration * 200
+	flow3.Metric.BAPackets += iteration * 3
+	flow3.Metric.BABytes += iteration * 300
+	flow3.Last = flow3.Start + iteration*300
+	flow3.UUID = "UUID3"
+	flow3.TID = "fake_tid_2"
+
+	flow4 := getBasicFlow()
+	flow4.TrackingID = "flow2-id"
+	flow4.Metric.ABPackets += iteration*2 - 1
+	flow4.Metric.ABBytes += iteration*200 - 100
+	flow4.Metric.BAPackets += iteration*3 + 1
+	flow4.Metric.BABytes += iteration*300 + 100
+	flow4.Last = flow4.Start + iteration*300 - 20
+	flow4.UUID = "UUID4"
+	flow4.TID = "fake_tid_2"
+
+	flow5 := getBasicFlow()
+	flow5.TrackingID = "flow1-id"
+	flow5.Metric.ABPackets += iteration*2 + 1
+	flow5.Metric.ABBytes += iteration*200 + 100
+	flow5.Metric.BAPackets += iteration*3 - 1
+	flow5.Metric.BABytes += iteration*300 - 100
+	flow5.Last = flow5.Start + iteration*300 + 20
+	flow5.UUID = "UUID5"
+	flow5.TID = "fake_tid_2"
+
+	var ff []interface{}
+	ff = append(ff, flow1)
+	ff = append(ff, flow2)
+	ff = append(ff, flow3)
+	ff = append(ff, flow4)
+	ff = append(ff, flow5)
+	return ff
+}
+
+func checkStats(t *testing.T, fArray1 interface{}, fArray2 interface{}) {
+	f1 := fArray1.([]interface{})
+	f2 := fArray2.([]interface{})
+	var i, j int
+	for _, k := range f2 {
+		f := k.(*VpclogsFlow)
+		if f.TrackingID == "flow3-id" {
+			assertEqual(t, "REJECT", f.Action)
+			continue
+		} else if f.TrackingID == "flow1-id" {
+			i = 0
+			j = 4
+		} else if f.TrackingID == "flow2-id" {
+			i = 1
+			j = 3
+		}
+		f1a := f1[i].(*VpclogsFlow)
+		f1b := f1[j].(*VpclogsFlow)
+		assertEqualInt64(t, common.MinInt64(f1a.Metric.ABPackets, f1b.Metric.ABPackets), f.Metric.ABPackets)
+		assertEqualInt64(t, common.MinInt64(f1a.Metric.BAPackets, f1b.Metric.BAPackets), f.Metric.BAPackets)
+		assertEqualInt64(t, common.MinInt64(f1a.Metric.ABBytes, f1b.Metric.ABBytes), f.Metric.ABBytes)
+		assertEqualInt64(t, common.MinInt64(f1a.Metric.BABytes, f1b.Metric.BABytes), f.Metric.BABytes)
+		assertEqual(t, "ACCEPT", f.Action)
+	}
+}
+
+func TestActionAcceptMetric(t *testing.T) {
+	initConfig(testConfig)
+	cfg := config.GetConfig().Viper
+	action, _ := NewAction(cfg)
+	action1 := action.(fakeActioner)
+	for i := 0; i < 4; i++ {
+		f1 := getFlowArrayLive(i)
+		f2 := action1.Action(f1)
+		checkStats(t, f1, f2)
+		// we expect flow3-id to not show up on the first iteration
+		// we expect flow3-id to show up as Rejected from second iteration and onwards
+		f2b := f2.([]interface{})
+		if i == 0 {
+			assertEqual(t, 2, len(f2b))
+		} else {
+			assertEqual(t, 3, len(f2b))
+		}
+	}
+}

--- a/contrib/exporters/vpclogs/mod/transform.go
+++ b/contrib/exporters/vpclogs/mod/transform.go
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2019 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package mod
+
+import (
+	"strconv"
+	"time"
+
+	cache "github.com/pmylund/go-cache"
+
+	"github.com/spf13/viper"
+
+	"github.com/skydive-project/skydive/flow"
+	"github.com/skydive-project/skydive/logging"
+	"github.com/skydive-project/skydive/contrib/exporters/core"
+	sa "github.com/skydive-project/skydive/contrib/exporters/secadvisor/mod"
+)
+
+// NewTransform creates a new flow transformer based on a name string
+func NewTransform(cfg *viper.Viper) (interface{}, error) {
+	excludeStartedFlows := cfg.GetBool(core.CfgRoot + "transform.secadvisor.exclude_started_flows")
+
+	runcResolver := sa.NewResolveRunc(cfg)
+	resolver := sa.NewResolveMulti(runcResolver)
+	resolver = sa.NewResolveFallback(resolver)
+	resolver = sa.NewResolveCache(resolver)
+
+	return &vpclogsFlowTransformer{
+		resolver:             resolver,
+		flowUpdateCountCache: cache.New(10*time.Minute, 10*time.Minute),
+		excludeStartedFlows:  excludeStartedFlows,
+	}, nil
+}
+
+const version = "1.0.1"
+
+// VpclogsFlowLayer is the flow layer for a vpc log flow
+type VpclogsFlowLayer struct {
+	Protocol string `json:"Protocol,omitempty"`
+	A        string `json:"A,omitempty"`
+	B        string `json:"B,omitempty"`
+	AName    string `json:"A_Name,omitempty"`
+	BName    string `json:"B_Name,omitempty"`
+}
+
+// VpclogsFlow represents a vpc log flow
+// this structure will be updated when the fields are finalized
+type VpclogsFlow struct {
+	UUID             string            `json:"UUID,omitempty"`
+	LayersPath       string            `json:"LayersPath,omitempty"`
+	Version          string            `json:"Version,omitempty"`
+	Status           string            `json:"Status,omitempty"`
+	FinishType       string            `json:"FinishType,omitempty"`
+	Network          *VpclogsFlowLayer `json:"Network,omitempty"`
+	Transport        *VpclogsFlowLayer `json:"Transport,omitempty"`
+	LastUpdateMetric *flow.FlowMetric  `json:"LastUpdateMetric,omitempty"`
+	Metric           *flow.FlowMetric  `json:"Metric,omitempty"`
+	Start            int64             `json:"Start"`
+	Last             int64             `json:"Last"`
+	UpdateCount      int64             `json:"UpdateCount"`
+	NodeType         string            `json:"NodeType,omitempty"`
+	Action           string            `json:"Action,omitempty"`
+	TrackingID       string            `json:"-"`
+	TID              string            `json:"-"`
+}
+
+// VpclogsFlowTransformer is a custom transformer for flows
+type vpclogsFlowTransformer struct {
+	resolver             sa.Resolver
+	flowUpdateCountCache *cache.Cache
+	excludeStartedFlows  bool
+}
+
+func (ft *vpclogsFlowTransformer) setUpdateCount(f *flow.Flow) int64 {
+	var count int64
+	if countRaw, ok := ft.flowUpdateCountCache.Get(f.UUID); ok {
+		count = countRaw.(int64)
+	}
+
+	if f.FinishType != flow.FlowFinishType_TIMEOUT {
+		if f.FinishType == flow.FlowFinishType_NOT_FINISHED {
+			ft.flowUpdateCountCache.Set(f.UUID, count+1, cache.DefaultExpiration)
+		} else {
+			ft.flowUpdateCountCache.Set(f.UUID, count+1, time.Minute)
+		}
+	} else {
+		ft.flowUpdateCountCache.Delete(f.UUID)
+	}
+
+	return count
+}
+
+func (ft *vpclogsFlowTransformer) getStatus(f *flow.Flow, updateCount int64) string {
+	if f.FinishType != flow.FlowFinishType_NOT_FINISHED {
+		return "ENDED"
+	}
+
+	if updateCount == 0 {
+		return "STARTED"
+	}
+
+	return "UPDATED"
+}
+
+func (ft *vpclogsFlowTransformer) getFinishType(f *flow.Flow) string {
+	if f.FinishType == flow.FlowFinishType_TCP_FIN {
+		return "SYN_FIN"
+	}
+	if f.FinishType == flow.FlowFinishType_TCP_RST {
+		return "SYN_RST"
+	}
+	if f.FinishType == flow.FlowFinishType_TIMEOUT {
+		return "Timeout"
+	}
+	return ""
+}
+
+func (ft *vpclogsFlowTransformer) getNetwork(f *flow.Flow) *VpclogsFlowLayer {
+	if f.Network == nil {
+		return nil
+	}
+
+	aName, _ := ft.resolver.IPToName(f.Network.A, f.NodeTID)
+	bName, _ := ft.resolver.IPToName(f.Network.B, f.NodeTID)
+
+	return &VpclogsFlowLayer{
+		Protocol: f.Network.Protocol.String(),
+		A:        f.Network.A,
+		B:        f.Network.B,
+		AName:    aName,
+		BName:    bName,
+	}
+}
+
+func (ft *vpclogsFlowTransformer) getTransport(f *flow.Flow) *VpclogsFlowLayer {
+	if f.Transport == nil {
+		return nil
+	}
+
+	return &VpclogsFlowLayer{
+		Protocol: f.Transport.Protocol.String(),
+		A:        strconv.FormatInt(f.Transport.A, 10),
+		B:        strconv.FormatInt(f.Transport.B, 10),
+	}
+}
+
+func (v *VpclogsFlow) SetAction(action string) {
+	v.Action = action
+}
+
+// Transform transforms a flow before being stored
+func (ft *vpclogsFlowTransformer) Transform(f *flow.Flow) interface{} {
+
+	logging.GetLogger().Debugf("flow = %s", f)
+	updateCount := ft.setUpdateCount(f)
+	status := ft.getStatus(f, updateCount)
+
+	// do not report new flows (i.e. the first time you see them)
+	if ft.excludeStartedFlows && status == "STARTED" {
+		return nil
+	}
+
+	nodeType, _ := ft.resolver.TIDToType(f.NodeTID)
+
+	return &VpclogsFlow{
+		UUID:             f.UUID,
+		LayersPath:       f.LayersPath,
+		Version:          version,
+		Status:           status,
+		FinishType:       ft.getFinishType(f),
+		Network:          ft.getNetwork(f),
+		Transport:        ft.getTransport(f),
+		LastUpdateMetric: f.LastUpdateMetric,
+		Metric:           f.Metric,
+		Start:            f.Start,
+		Last:             f.Last,
+		UpdateCount:      updateCount,
+		NodeType:         nodeType,
+		TrackingID:       f.L3TrackingID,
+		TID:              f.NodeTID,
+	}
+}

--- a/contrib/exporters/vpclogs/vpclogs.yml.default
+++ b/contrib/exporters/vpclogs/vpclogs.yml.default
@@ -7,6 +7,7 @@ analyzer:
 pipeline:
   subscriber:
     url: ws://127.0.0.1:8082/ws/subscriber/flow
+    capture_id:
   classify:
     # cluster_net_masks:
       # - 10.0.0.0/8
@@ -16,8 +17,13 @@ pipeline:
     # excluded_tags:
       # - internal
       # - other
+  action:
+    type: aws
+    tid1:
+    tid2:
   transform:
-    sa:
+    type: vpclogs
+    secadvisor:
       # exclude_started_flows: true
   store:
     type: buffered


### PR DESCRIPTION
This is to support the "action" feature of aws in the vpc flow logs.
For each flow, specify whether it was Accepted or Rejected.
The assumption is that we have 2 points where the flows are captured: one on each side of a firewall. If a flow appears on only one side, we declare it as Rejected. If the flow appears on both sides, we declare it as Accepted.
When a flow is blocked mid-stream, we need to accurately report the number of bytes and packets that were Accepted.
@hunchback @eranra