### PR TITLE
contrib/exporters: Run tests with verbose flag by default

### DIFF
--- a/contrib/exporters/Makefile.conf
+++ b/contrib/exporters/Makefile.conf
@@ -1,3 +1,10 @@
+VERBOSE_FLAGS?=-v
+VERBOSE?=true
+ifeq ($(VERBOSE), false)
+  VERBOSE_FLAGS:=
+endif
+TIMEOUT?=1m
+
 all: LDFLAGS:=
 static: LDFLAGS:=-ldflags '-extldflags "-static"'
 
@@ -16,7 +23,7 @@ clean:
 
 .PHONY: test
 test: $(TESTS)
-	(cd mod 2>/dev/null && go test) || true
+	go test $(VERBOSE_FLAGS) -timeout ${TIMEOUT} ./...
 
 .PHONY: run
 run: all


### PR DESCRIPTION
More verbose test output is useful when examining CI logs.

The VERBOSE and TIMEOUT settings will be passed from the main Skydive makefile (when set).

To simplify, instead of specifically changing to the `mod` folder and running `go test` there, just run `go test` with the recursive pattern `./...` which fill find any `*_test.go` files and run them. This allows any exporter to choose its own folder structure.

@hunchback please review.