### PR TITLE
contrib/exporters/secadvisor: Fix IP's name caching

### DIFF
--- a/contrib/exporters/secadvisor/mod/resolve_cache.go
+++ b/contrib/exporters/secadvisor/mod/resolve_cache.go
@@ -49,7 +49,8 @@ func NewResolveCache(resolver Resolver) Resolver {
 
 // IPToName resolve ip address to name
 func (rc *resolveCache) IPToName(ipString, nodeTID string) (string, error) {
-	name, ok := rc.nameCache.Get(ipString)
+	cacheKey := ipString + "," + nodeTID
+	name, ok := rc.nameCache.Get(cacheKey)
 
 	if !ok {
 		var err error
@@ -61,7 +62,7 @@ func (rc *resolveCache) IPToName(ipString, nodeTID string) (string, error) {
 			return "", err
 		}
 
-		rc.nameCache.Set(ipString, name, cache.DefaultExpiration)
+		rc.nameCache.Set(cacheKey, name, cache.DefaultExpiration)
 	}
 
 	return name.(string), nil


### PR DESCRIPTION
Name resolving for IP addresses depend on the IP address and the TID in
which the flow was captured.  When caching the result, we now use both
IP and TID in the cache key (an IP address might appear in different places
in the cluster and refer to different containers/hosts/...).

@hunchback please review.