### PR TITLE
Adds BESS topology probe

### DIFF
--- a/agent/topology_probes.go
+++ b/agent/topology_probes.go
@@ -30,6 +30,7 @@ import (
 	"github.com/skydive-project/skydive/probe"
 	"github.com/skydive-project/skydive/topology/probes"
 	tp "github.com/skydive-project/skydive/topology/probes"
+	"github.com/skydive-project/skydive/topology/probes/bess"
 	"github.com/skydive-project/skydive/topology/probes/docker"
 	"github.com/skydive-project/skydive/topology/probes/libvirt"
 	"github.com/skydive-project/skydive/topology/probes/lldp"
@@ -71,6 +72,8 @@ func NewTopologyProbe(name string, ctx tp.Context, bundle *probe.Bundle) (probe.
 		return runc.NewProbe(ctx, bundle)
 	case "vpp":
 		return vpp.NewProbe(ctx, bundle)
+	case "bess":
+		return bess.NewProbe(ctx, bundle)
 	default:
 		return nil, fmt.Errorf("unsupported probe %s", name)
 	}

--- a/analyzer/probes.go
+++ b/analyzer/probes.go
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * You may obtain a copy ofthe License at
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/config/config.go
+++ b/config/config.go
@@ -123,6 +123,8 @@ func init() {
 	cfg.SetDefault("agent.topology.runc.run_path", []string{"/run/containerd/runc", "/run/runc", "/run/runc-ctrs"})
 	cfg.SetDefault("agent.topology.socketinfo.host_update", 10)
 	cfg.SetDefault("agent.topology.vpp.connect", "")
+	cfg.SetDefault("agent.topology.bess.host", "127.0.0.1")
+	cfg.SetDefault("agent.topology.bess.port", 10514)
 
 	cfg.SetDefault("analyzer.auth.cluster.backend", "noauth")
 	cfg.SetDefault("analyzer.auth.api.backend", "noauth")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/skydive-project/skydive
 
 require (
+        github.com/nimbess/nimbess-agent v0.0.0-20190919205041-4e6f317ac4fd
 	git.fd.io/govpp.git v0.0.0-20190321220742-345201eedce4
 	github.com/GehirnInc/crypt v0.0.0-20170404120257-5a3fafaa7c86
 	github.com/IBM/ibm-cos-sdk-go v0.0.0-20190328184230-08c1143e8d36

--- a/topology/probes/bess/bess.go
+++ b/topology/probes/bess/bess.go
@@ -1,0 +1,251 @@
+// Copyright (c) 2019 Red Hat and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bess
+
+import (
+	"context"
+	"fmt"
+	"github.com/skydive-project/skydive/filters"
+	"google.golang.org/grpc"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nimbess/nimbess-agent/pkg/proto/bess_pb"
+
+	"github.com/skydive-project/skydive/common"
+	"github.com/skydive-project/skydive/graffiti/graph"
+	"github.com/skydive-project/skydive/probe"
+	"github.com/skydive-project/skydive/topology"
+	"github.com/skydive-project/skydive/topology/probes"
+)
+
+const BessManager = "BESS"
+
+type Probe struct {
+	graph.DefaultGraphListener
+	Ctx         probes.Context
+	bessClient  bess_pb.BESSControlClient
+	state       common.ServiceState
+	bessPort    int
+	bessHost    string
+	bessContext context.Context
+}
+
+func (p *Probe) walkAndRender(moduleName string, parentNode *graph.Node, edgeList *[]*graph.Edge) {
+	modRes, err := p.bessClient.GetModuleInfo(p.bessContext, &bess_pb.GetModuleInfoRequest{Name: moduleName})
+	if err != nil {
+		p.Ctx.Logger.Errorf("Error getting module information for module: %s", moduleName)
+		return
+	}
+
+	nodeID := graph.GenID(moduleName)
+	node := p.Ctx.Graph.GetNode(nodeID)
+	if node == nil {
+		node, err = p.Ctx.Graph.NewNode(nodeID, graph.Metadata{"Name": moduleName,
+			"Type": modRes.GetMclass(), "Manager": BessManager})
+		p.Ctx.Logger.Infof("Creating node: %s", moduleName)
+		if err != nil {
+			p.Ctx.Logger.Errorf("Error creating node: %s, %v", moduleName, err)
+			return
+		}
+	}
+	if parentNode != nil && !topology.HaveOwnershipLink(p.Ctx.Graph, parentNode, node) {
+		topology.AddOwnershipLink(p.Ctx.Graph, parentNode, node, nil)
+	}
+	for _, oGate := range modRes.GetOgates() {
+		p.walkAndRender(oGate.GetName(), parentNode, edgeList)
+		edgeID := graph.GenID(moduleName, string(oGate.Igate), string(oGate.Ogate), oGate.GetName())
+		if p.Ctx.Graph.GetEdge(edgeID) == nil {
+			p.Ctx.Graph.NewEdge(edgeID, node,
+				p.Ctx.Graph.GetNode(graph.GenID(oGate.GetName())),
+				graph.Metadata{"RelationType": "layer2", "Directed": true, "Manager": BessManager})
+		}
+		*edgeList = append(*edgeList, p.Ctx.Graph.GetEdge(edgeID))
+	}
+
+}
+
+func (p *Probe) Do(ctx context.Context, wg *sync.WaitGroup) error {
+	p.Ctx.Logger.Info("Connecting to BESS")
+	conn, err := grpc.Dial(fmt.Sprintf("%s:%d", p.bessHost, p.bessPort), grpc.WithInsecure())
+	if err != nil {
+		return err
+	}
+	p.Ctx.Logger.Info("Connected to BESS")
+	p.bessClient = bess_pb.NewBESSControlClient(conn)
+	verResponse, err := p.bessClient.GetVersion(context.Background(), &bess_pb.EmptyRequest{})
+	if err != nil {
+		return err
+	} else if verResponse.Error != nil {
+		return fmt.Errorf("could not get version: %s, %s", verResponse.GetError(), err)
+	}
+	p.Ctx.Logger.Infof("BESS connected with version: %s", verResponse.Version)
+
+	metadata := graph.Metadata{
+		"Name":    "bess",
+		"Type":    "bess",
+		"Program": "bessd",
+		"Version": verResponse.GetVersion(),
+		"Manager": BessManager,
+	}
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		// probe running function
+		for {
+			// get modules and data from bess
+			modsRes, err := p.bessClient.ListModules(p.bessContext, &bess_pb.EmptyRequest{})
+			if err != nil {
+				p.Ctx.Logger.Errorf("Unable to query module list for BESS: %s", err)
+				return
+			}
+
+			portRes, err := p.bessClient.ListPorts(p.bessContext, &bess_pb.EmptyRequest{})
+			if err != nil {
+				p.Ctx.Logger.Errorf("Unable to query port list for BESS: %s", err)
+				return
+			}
+
+			var foundMods []string
+			var foundEdges []*graph.Edge
+			p.Ctx.Graph.Lock()
+
+			// build main bess node
+			bessID := graph.GenID("bessd", p.bessHost)
+			bessNode := p.Ctx.Graph.GetNode(bessID)
+			if bessNode == nil {
+				bessNode, err = p.Ctx.Graph.NewNode(bessID, metadata)
+				if err != nil {
+					p.Ctx.Logger.Errorf("Failed to create bess node")
+					return
+				}
+			}
+			if !topology.HaveOwnershipLink(p.Ctx.Graph, p.Ctx.RootNode, bessNode) {
+				topology.AddOwnershipLink(p.Ctx.Graph, p.Ctx.RootNode, bessNode, nil)
+			}
+
+			// find ports to figure out pipeline roots
+			portMap := make(map[string]*graph.Node)
+			var bessPort *graph.Node
+			for _, port := range portRes.GetPorts() {
+				portID := graph.GenID(port.GetName())
+				bessPort = p.Ctx.Graph.GetNode(portID)
+				if bessPort == nil {
+					bessPort, err = p.Ctx.Graph.NewNode(portID, graph.Metadata{
+						"Name":    port.GetName(),
+						"MAC":     port.GetMacAddr(),
+						"Type":    port.GetDriver(),
+						"Manager": BessManager,
+					})
+					if err != nil {
+						p.Ctx.Logger.Errorf("Failed to create bessPort: %v", bessPort)
+						continue
+					}
+				}
+				if !topology.HaveOwnershipLink(p.Ctx.Graph, bessNode, bessPort) {
+					topology.AddOwnershipLink(p.Ctx.Graph, bessNode, bessPort, nil)
+				}
+				portMap[port.GetName()] = bessPort
+			}
+
+			// find modules and associate to pipelines/ports
+			for _, module := range modsRes.GetModules() {
+				if module.GetName() == "" {
+					continue
+				}
+				moduleName := module.GetName()
+				// find first modules in pipeline
+				if module.GetMclass() == "PortInc" {
+					p.walkAndRender(moduleName, portMap[strings.TrimSuffix(moduleName, "_ingress")], &foundEdges)
+				}
+				foundMods = append(foundMods, moduleName)
+			}
+
+			// if there are any remaining modules then they do not belong to a port pipeline, render them anyway,
+			// log warning, parent node will be bess node itself
+			for _, module := range foundMods {
+				node := p.Ctx.Graph.GetNode(graph.GenID(module))
+				if node == nil {
+					p.Ctx.Logger.Warningf("Node found in bess that is not part of any port pipeline: %s", module)
+					p.walkAndRender(module, bessNode, &foundEdges)
+				}
+			}
+
+			// Now check for any nodes that need to be removed
+			filter := graph.NewElementFilter(filters.NewTermStringFilter("Manager", BessManager))
+			nodes := p.Ctx.Graph.GetNodes(filter)
+			// foundNodes will contain all nodes we know should exist
+			var foundNodes []string
+			foundNodes = append(foundNodes, foundMods...)
+			for k := range portMap {
+				foundNodes = append(foundNodes, k)
+			}
+
+			for _, node := range nodes {
+				modFound := false
+				// special case for bess root itself
+				if node.ID == bessID {
+					continue
+				}
+
+				for _, module := range foundNodes {
+					if node.ID == graph.GenID(module) {
+						modFound = true
+						break
+					}
+				}
+				if !modFound {
+					p.Ctx.Logger.Debugf("Deleting node: %+v", *node)
+					p.Ctx.Graph.DelNode(node)
+				}
+			}
+
+			// now check edges
+			edges := p.Ctx.Graph.GetEdges(filter)
+			for _, edge := range edges {
+				edgeFound := false
+				for _, knownEdge := range foundEdges {
+					if edge == knownEdge {
+						edgeFound = true
+						break
+					}
+				}
+				if !edgeFound {
+					p.Ctx.Logger.Debugf("Deleting edge: %+v", *edge)
+					p.Ctx.Graph.DelEdge(edge)
+				}
+			}
+
+			p.Ctx.Graph.Unlock()
+			time.Sleep(1 * time.Second)
+		}
+	}()
+	return nil
+}
+
+// NewProbe returns a BESS topology probe
+func NewProbe(ctx probes.Context, bundle *probe.Bundle) (probe.Handler, error) {
+	p := &Probe{
+		Ctx:	ctx,
+	}
+	p.state.Store(common.StoppedState)
+	p.bessHost = ctx.Config.GetString("agent.topology.bess.host")
+	p.bessPort = ctx.Config.GetInt("agent.topology.bess.port")
+	p.bessContext = context.Background()
+
+	return probes.NewProbeWrapper(p), nil
+}


### PR DESCRIPTION
Berkley Extensible Software Switch (BESS) is a modular network data
plane. This patch adds topology support for BESS instances running on
different hosts through an agent probe. Adding metrics and
monitoring/tcpdump is still WIP and will be added in a follow up patch.

Signed-off-by: Tim Rozet <trozet@redhat.com>