### PR TITLE
common: Add unit test for GetMapField

### DIFF
--- a/common/types_test.go
+++ b/common/types_test.go
@@ -201,6 +201,63 @@ func TestDelField(t *testing.T) {
 	}
 }
 
+func TestGetMapField(t *testing.T) {
+	data := map[string]interface{}{
+		"a": map[string]interface{}{
+			"b": map[string]interface{}{
+				"c": "c_value",
+			},
+		},
+		"d": map[string]interface{}{
+			"e": "e_value",
+			"f": []interface{}{
+				map[string]interface{}{
+					"name": "f_0_name",
+					"type": "f_0_type",
+				},
+				map[string]interface{}{
+					"name": "f_1_name",
+					"type": "f_1_type",
+				},
+				map[string]interface{}{
+					"name": "f_2_name",
+					"type": "f_2_type",
+					"extra": map[string]interface{}{
+						"g": "g_value",
+					},
+				},
+			},
+		},
+	}
+
+	type testInstance struct {
+		key      string
+		expected interface{}
+	}
+	tests := []testInstance{
+		testInstance{"a.b", map[string]interface{}{"c": "c_value"}},
+		testInstance{"a.b.c", "c_value"},
+		testInstance{"d.e", "e_value"},
+		testInstance{"d.f.name", []interface{}{"f_0_name", "f_1_name", "f_2_name"}},
+		testInstance{"d.f.type", []interface{}{"f_0_type", "f_1_type", "f_2_type"}},
+		testInstance{"d.f.extra.g", []interface{}{"g_value"}},
+	}
+	for _, ti := range tests {
+		actual, err := GetMapField(data, ti.key)
+		if err != nil {
+			t.Errorf("Expected GetMapField to find the key: %s", ti.key)
+		}
+		if !reflect.DeepEqual(ti.expected, actual) {
+			t.Errorf("Key: %s, Expected: %+v, actual: %+v", ti.key, ti.expected, actual)
+		}
+	}
+
+	_, err := GetMapField(data, "a.non_existing")
+	if err == nil {
+		t.Errorf("Expected GetMapField to fail for non-existing key")
+	}
+}
+
 type structB struct {
 	I int16
 	S string


### PR DESCRIPTION
In my attempts to understand how gremlin query like `G.V().Has('a.b.c.d', 'value')` accesses the value of `a.b.c.d`, and especially what happens if the node's metadata contains arrays (Kubernetes pod metadata, I'm looking at you), I ended up writing a unit test for `common.GetMapField` to validate my assumptions.

Ideally eventually we would add some documentation to http://skydive.network/documentation/api-gremlin , which has some examples of lookup of keys inside a nested map (like `G.V().Has('Docker.Labels.io.kubernetes.pod.namespace' ,'my-namespace').Descendants()`) but doesn't mention what happens if the metadata contains arrays.