### PR TITLE
graph/traversal: Fix Sum() unit test

### DIFF
--- a/graffiti/graph/traversal/traversal_test.go
+++ b/graffiti/graph/traversal/traversal_test.go
@@ -195,13 +195,13 @@ func TestBasicTraversal(t *testing.T) {
 	}
 
 	sum := tr.V(ctx).Sum(ctx, "Bytes")
-	bytes, ok := sum.Values()[0].(float64)
+	bytes, ok := sum.Values()[0].(int64)
 	if ok {
 		if bytes != 7072 {
-			t.Fatalf("Should return 7072, instead got %f", bytes)
+			t.Fatalf("Should return 7072, instead got %v", bytes)
 		}
 	} else {
-		t.Logf("Error in Sum() step: %s", sum.Error())
+		t.Fatalf("Error in Sum() step: %s", sum.Error())
 	}
 }
 


### PR DESCRIPTION
Before this fix the tests printed the following log message (while passing):

    === RUN   TestBasicTraversal
    --- PASS: TestBasicTraversal (0.00s)
        traversal_test.go:204: Error in Sum() step: %!s(<nil>)

The fix correctly casts the result to int64 and fails if the `Sum()` function returns the wrong value.