### PR TITLE
ci: add retry to cdd selenium connection

### DIFF
--- a/tests/selenium.go
+++ b/tests/selenium.go
@@ -567,13 +567,24 @@ func newSeleniumHelper(t *testing.T, analyzerAddr string, analyzerPort int, auth
 	}
 	execCmds(t, setupCmds...)
 
-	caps := selenium.Capabilities{"browserName": "chrome"}
-	webdriver, err := selenium.NewRemote(caps, "http://localhost:4444/wd/hub")
+	var webdriver selenium.WebDriver
+	err := common.Retry(func() error {
+		var err error
+
+		caps := selenium.Capabilities{"browserName": "chrome"}
+		webdriver, err = selenium.NewRemote(caps, "http://localhost:4444/wd/hub")
+		if err != nil {
+			return err
+		}
+		webdriver.MaximizeWindow("")
+		webdriver.SetAsyncScriptTimeout(5 * time.Second)
+
+		return nil
+	}, 60, time.Second)
+
 	if err != nil {
 		return nil, err
 	}
-	webdriver.MaximizeWindow("")
-	webdriver.SetAsyncScriptTimeout(5 * time.Second)
 
 	os.Setenv("SKYDIVE_ANALYZERS", fmt.Sprintf("%s:%d", analyzerAddr, analyzerPort))
 


### PR DESCRIPTION
skip skydive-compile-tests
skip skydive-functional-hw-tests
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-go-fmt
skip skydive-k8s-tests
skip skydive-scale-tests
skip skydive-selenium-tests
skip skydive-unit-tests
skip skydive-ppc64-tests