### PR TITLE
analyzer: Allow setting startup capture type

### DIFF
--- a/analyzer/server.go
+++ b/analyzer/server.go
@@ -123,9 +123,10 @@ func (s *Server) createStartupCapture(ch *api.CaptureAPIHandler) error {
 	}
 
 	bpf := config.GetString("analyzer.startup.capture_bpf")
-	logging.GetLogger().Infof("Invoke capturing from the startup with gremlin: %s and BPF: %s", gremlin, bpf)
+	captureType := config.GetString("analyzer.startup.capture_type")
+	logging.GetLogger().Infof("Invoke capturing of type '%s' from startup with gremlin: %s and BPF: %s", captureType, gremlin, bpf)
 	capture := types.NewCapture(gremlin, bpf)
-	capture.Type = "pcap"
+	capture.Type = captureType
 	return ch.Create(capture, nil)
 }
 

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -69,6 +69,11 @@ analyzer:
     # capture_gremlin: "G.V().has('Name', NE('lo'))"
     # capture_bpf: "port 80"
 
+    # By default (capture_type: "") the capture type is chosen automatically;
+    # or set here to one of pcap, afpacket, ebpf, sflow, pcapsocket, ovsmirror,
+    # dpdk, ovssflow, or ovsnetflow.
+    # capture_type: ""
+
   # Flow storage engine
   flow:
     # Storage backend name: myelasticsearch, myorientdb


### PR DESCRIPTION
When using a startup capture, the config allowed setting the capture's
gremlin (which nodes should capture) and BPF filter string, but the
capture type was hard-coded to "pcap".

This change allows setting the type from the configuration: either
setting the `analyzer.startup.capture_type` key in the YAML config file or
by setting the `SKYDIVE_ANALYZER_STARTUP_CAPTURE_TYPE` environment
variable.

Possible values for `capture_type` are those that appear in `ProbeTypes`
(see `common/capture.go`); they are listed in a comment in the example
config file.

The default value for this config is `""`, which lets Skydive choose the capture type.

@eranra or @hunchback : please review.