### PR TITLE
exporters: Fix call to Mangle()

### DIFF
--- a/contrib/exporters/core/pipeline.go
+++ b/contrib/exporters/core/pipeline.go
@@ -250,7 +250,7 @@ func (p *Pipeline) transform(in map[Tag][]*flow.Flow) map[Tag][]interface{} {
 func (p *Pipeline) mangle(in map[Tag][]interface{}) map[Tag][]interface{} {
 	out := make(map[Tag][]interface{})
 	for tag := range in {
-		out[tag] = p.Mangler.Mangle(out[tag])
+		out[tag] = p.Mangler.Mangle(in[tag])
 	}
 	return out
 }


### PR DESCRIPTION
Before this fix we would always get empty flows input to the storer, because mangle() would always return an empty array per tag.

@hunchback please review.