### PR TITLE
exporters/core: Fix lint warnings

### DIFF
--- a/contrib/exporters/core/classify.go
+++ b/contrib/exporters/core/classify.go
@@ -98,7 +98,7 @@ func NewClassifySubnet(cfg *viper.Viper) (interface{}, error) {
 	for _, netMask := range clusterNetMasks {
 		_, sa, err := net.ParseCIDR(netMask)
 		if err != nil {
-			return nil, fmt.Errorf("Cannot parse netmask '%s': %s", netMask, err)
+			return nil, fmt.Errorf("cannot parse netmask '%s': %s", netMask, err)
 		}
 		parsedNetMasks = append(parsedNetMasks, sa)
 	}

--- a/contrib/exporters/core/compress.go
+++ b/contrib/exporters/core/compress.go
@@ -44,7 +44,9 @@ type compressGzip struct {
 func (e *compressGzip) Compress(in []byte) (*bytes.Buffer, error) {
 	var out bytes.Buffer
 	w := gzip.NewWriter(&out)
-	w.Write(in)
+	if _, err := w.Write(in); err != nil {
+		return nil, err
+	}
 	w.Close()
 	return &out, nil
 }

--- a/contrib/exporters/core/pipeline.go
+++ b/contrib/exporters/core/pipeline.go
@@ -256,7 +256,9 @@ func (p *Pipeline) mangle(in map[Tag][]interface{}) map[Tag][]interface{} {
 }
 
 func (p *Pipeline) store(in map[Tag][]interface{}) {
-	p.Storer.StoreFlows(in)
+	if err := p.Storer.StoreFlows(in); err != nil {
+		logging.GetLogger().Error("failed to store flows: ", err)
+	}
 }
 
 func (p *Pipeline) process(flows []*flow.Flow) {
@@ -276,12 +278,12 @@ func (p *Pipeline) OnStructMessage(c ws.Speaker, msg *ws.StructMessage) {
 	case "store":
 		var flows []*flow.Flow
 		if err := json.Unmarshal(msg.Obj, &flows); err != nil {
-			logging.GetLogger().Error("Failed to unmarshal flows: ", err)
+			logging.GetLogger().Error("failed to unmarshal flows: ", err)
 			return
 		}
 
 		p.process(flows)
 	default:
-		logging.GetLogger().Error("Unknown message type: ", msg.Type)
+		logging.GetLogger().Error("unknown message type: ", msg.Type)
 	}
 }

--- a/contrib/exporters/core/store_direct.go
+++ b/contrib/exporters/core/store_direct.go
@@ -47,7 +47,8 @@ func (s *storeDirect) StoreFlows(flows map[Tag][]interface{}) error {
 			return err
 		}
 
-		err = s.pipeline.Writer.Write("my_direname", "my_filename", string(compressed.Bytes()), "application/json", "gzip", map[string]*string{})
+		err = s.pipeline.Writer.Write("my_dirname", "my_filename", compressed.String(),
+			"application/json", "gzip", map[string]*string{})
 		if err != nil {
 			logging.GetLogger().Error("Failed to store object: ", err)
 			return err

--- a/contrib/exporters/core/subscriber.go
+++ b/contrib/exporters/core/subscriber.go
@@ -49,7 +49,7 @@ func NewSubscriber(pipeline *Pipeline, cfg *viper.Viper) (*websocket.StructSpeak
 	subscriberURLString := cfg.GetString(CfgRoot + "subscriber.url")
 	subscriberURL, err := url.Parse(subscriberURLString)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to parse subscriber URL: %s", err)
+		return nil, fmt.Errorf("failed to parse subscriber URL: %s", err)
 	}
 
 	namespace := "flow"
@@ -64,7 +64,7 @@ func NewSubscriber(pipeline *Pipeline, cfg *viper.Viper) (*websocket.StructSpeak
 	}
 	wsClient, err := config.NewWSClient(common.AnalyzerService, subscriberURL, clientOpts)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create websocket client: %s", err)
+		return nil, fmt.Errorf("failed to create websocket client: %s", err)
 	}
 	structSpeaker := wsClient.UpgradeToStructSpeaker()
 	structSpeaker.AddStructMessageHandler(pipeline, []string{namespace})
@@ -77,7 +77,7 @@ func SubscriberRun(s *websocket.StructSpeaker) {
 	s.Start()
 	defer s.Stop()
 
-	ch := make(chan os.Signal)
+	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 	<-ch
 }

--- a/contrib/exporters/core/write_s3.go
+++ b/contrib/exporters/core/write_s3.go
@@ -36,7 +36,8 @@ type writeS3 struct {
 }
 
 // Write stores a single file
-func (s *writeS3) Write(dirname, filename, content, contentType, contentEncoding string, metadata map[string]*string) error {
+func (s *writeS3) Write(dirname, filename, content, contentType, contentEncoding string,
+	metadata map[string]*string) error {
 	_, err := s.s3c.PutObject(&s3.PutObjectInput{
 		Body:            strings.NewReader(content),
 		Bucket:          aws.String(dirname),

--- a/contrib/exporters/core/write_stdout.go
+++ b/contrib/exporters/core/write_stdout.go
@@ -27,7 +27,8 @@ type writeStdout struct {
 }
 
 // Write stores a single file
-func (s *writeStdout) Write(dirname, filename, content, contentType, contentEncoding string, metadata map[string]*string) error {
+func (s *writeStdout) Write(dirname, filename, content, contentType, contentEncoding string,
+	metadata map[string]*string) error {
 	fmt.Printf("--- %s/%s ---\n", dirname, filename)
 	fmt.Printf("%s\n", content)
 	return nil


### PR DESCRIPTION
Fix most of the lint comments in `contrib/exporters/core`.

Here are the lint warnings that are still left (for this package) after these fixes:

```
subscriber.go:48:20: `pipeline` can be `github.com/skydive-project/skydive/websocket.SpeakerStructMessageHandler` (interfacer)
func NewSubscriber(pipeline *Pipeline, cfg *viper.Viper) (*websocket.StructSpeaker, error) {
                   ^
pipeline.go:114:1: don't use `init` function (gochecknoinits)
func init() {
^
pipeline.go:85:2: `ManglerHandlers` is a global variable (gochecknoglobals)
        ManglerHandlers     HandlersMap
        ^
pipeline.go:86:2: `TransformerHandlers` is a global variable (gochecknoglobals)
        TransformerHandlers HandlersMap
        ^
pipeline.go:87:2: `ClassifierHandlers` is a global variable (gochecknoglobals)
        ClassifierHandlers  HandlersMap
        ^
pipeline.go:88:2: `FiltererHandlers` is a global variable (gochecknoglobals)
        FiltererHandlers    HandlersMap
        ^
pipeline.go:89:2: `EncoderHandlers` is a global variable (gochecknoglobals)
        EncoderHandlers     HandlersMap
        ^
pipeline.go:90:2: `CompressorHandlers` is a global variable (gochecknoglobals)
        CompressorHandlers  HandlersMap
        ^
pipeline.go:91:2: `StorerHandlers` is a global variable (gochecknoglobals)
        StorerHandlers      HandlersMap
        ^
pipeline.go:92:2: `WriterHandlers` is a global variable (gochecknoglobals)
        WriterHandlers      HandlersMap
        ^
store_buffered.go:64: Function 'StoreFlows' is too long (73 > 60) (funlen)
func (s *storeBuffered) StoreFlows(in map[Tag][]interface{}) error {
```

These require more substantial refactoring in order to fix.