### PR TITLE
ci/create-docker-image.sh: Remove unused BASE build-arg

### DIFF
--- a/scripts/ci/create-docker-image.sh
+++ b/scripts/ci/create-docker-image.sh
@@ -60,7 +60,6 @@ docker_skydive_builder() {
         ${TARGET_ARCH:+--build-arg TARGET_ARCH=${TARGET_ARCH}} \
         ${TARGET_GOARCH:+--build-arg TARGET_GOARCH=${TARGET_GOARCH}} \
         ${DEBARCH:+--build-arg DEBARCH=${DEBARCH}} \
-        ${BASE:+--build-arg BASE=${BASE}} \
         --build-arg UID=$uid \
         -f $DOCKER_DIR/$dockerfile $DOCKER_DIR
     docker volume create $GOMOD_VOL


### PR DESCRIPTION
Both Docker.compile and Docker.crosscompile don't use the `BASE`
build-arg at all.  The output log of the CI ([example](http://ci-logs.skydive.network/skydive-create-docker-image/builds/3/log)) shows this:

    [Warning] One or more build-args [BASE] were not consumed

This patch removes this unused build-arg from the
`skydive-compile-build` image building (it is still used in the skydive
or snapshot images to allow setting `BASE` per architecture).