### PR TITLE
exporters/core: store_direct: use flow's tag name as printed filename

### DIFF
--- a/contrib/exporters/core/store_direct.go
+++ b/contrib/exporters/core/store_direct.go
@@ -34,7 +34,7 @@ func (s *storeDirect) SetPipeline(pipeline *Pipeline) {
 
 // StoreFlows store flows in memory, before being written to the object store
 func (s *storeDirect) StoreFlows(flows map[Tag][]interface{}) error {
-	for _, val := range flows {
+	for t, val := range flows {
 		encoded, err := s.pipeline.Encoder.Encode(val)
 		if err != nil {
 			logging.GetLogger().Error("Failed to encode object: ", err)
@@ -47,7 +47,7 @@ func (s *storeDirect) StoreFlows(flows map[Tag][]interface{}) error {
 			return err
 		}
 
-		err = s.pipeline.Writer.Write("my_dirname", "my_filename", compressed.String(),
+		err = s.pipeline.Writer.Write("my_dirname", string(t), compressed.String(),
 			"application/json", "gzip", map[string]*string{})
 		if err != nil {
 			logging.GetLogger().Error("Failed to store object: ", err)


### PR DESCRIPTION
To ease debugging using the `direct` storer, use the flow's tag name as
the dummy filename.

Example output (with `secadvisor` transformer and encoder):

```
--- my_dirname/internal ---
{
        "data": [
                {
                        "UUID": "b87c1a5fe29b85dc",
                        "LayersPath": "Ethernet/IPv4/TCP",
                        "Version": "1.0.8",
                        "Status": "UPDATED",
                        "Network": {
                                "Protocol": "IPV4",
...
...
...
                }
        ]
}

--- my_dirname/egress ---
{
        "data": [
                {
                        "UUID": "4b9cc309b204a8ae",
                        "LayersPath": "Ethernet/IPv4/UDP/DNS",
                        "Version": "1.0.8",
                        "Status": "ENDED",
                        "FinishType": "Timeout",
                        "Network": {
                                "Protocol": "IPV4",
...

```

@hunchback please review; not urgent.