### PR TITLE
exporter/allinone: Register logstatus mangler

### DIFF
--- a/contrib/exporters/allinone/main.go
+++ b/contrib/exporters/allinone/main.go
@@ -28,6 +28,7 @@ func main() {
 }
 
 func init() {
+	core.ManglerHandlers.Register("logstatus", secadvisor.NewMangleLogStatus, false)
 	core.EncoderHandlers.Register("secadvisor", secadvisor.NewEncode, false)
 	core.TransformerHandlers.Register("awsflowlogs", awsflowlogs.NewTransform, false)
 	core.TransformerHandlers.Register("vpclogs", secadvisor.NewTransform, false)


### PR DESCRIPTION
Allow using the `logstatus` mangler in the allinone flow exporter.

Before this fix we get the following error with the default allinone config file:

```
2019-10-15T07:57:42.891Z        ERROR   core/main.go:45 Main    : Failed to initialize pipeline: mangle type logstatus not supported
```

Note that I'm not sure whether this registration line should be added to other exporters as well (vpclogs, awsflowlogs).

@hunchback please review.