### PR TITLE
Bump to version 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.26.0] - 2019-10-18
+### Added
+
+- Add new `seed` mechanism to start a probe inside a container/process namespace
+- Add support for plugins
+- Add BESS topology probe (thanks to Tim Rozet)
+- Report active flows status through WebSocket
+
+### Changed
+- Use 1.11 as minimal Golang version
+- Moved to `go mod` to ease import from external projects
+- Use Ubuntu 19.04 as Docker base image
+
 ## [0.25.0] - 2019-09-10
 ### Added
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -22,7 +22,7 @@
 //     Schemes: http, https
 //     Host: localhost:8082
 //     BasePath: /api
-//     Version: 0.25.0
+//     Version: 0.26.0
 //     License: Apache http://opensource.org/licenses/Apache-2.0
 //     Contact: Skydive mailing list <skydive-dev@redhat.com>
 //

--- a/contrib/ansible/roles/skydive_common/defaults/main.yml
+++ b/contrib/ansible/roles/skydive_common/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-skydive_release: v0.25.0
+skydive_release: v0.26.0
 skydive_docker_registry: docker.io
 skydive_docker_image_tag: latest
 skydive_config_file: /etc/skydive/skydive.yml

--- a/contrib/packaging/rpm/skydive.spec
+++ b/contrib/packaging/rpm/skydive.spec
@@ -34,7 +34,7 @@
 %endif
 %endif
 
-%{!?fullver:%global fullver 0.25.0}
+%{!?fullver:%global fullver 0.26.0}
 %define version %{extractversion %{fullver}}
 %{!?tag:%global tag 1}
 
@@ -248,6 +248,9 @@ fi
 %attr(0644,root,root) %{_mandir}/man8/skydive-selinux.8.*
 
 %changelog
+* Fri Oct 18 2019 Sylvain Baubeau <sbaubeau@redhat.com> - 0.26.0-1
+- Bump to version 0.26.0
+
 * Tue Sep 10 2019 Sylvain Baubeau <sbaubeau@redhat.com> - 0.25.0-1
 - Bump to version 0.25.0
 

--- a/contrib/packaging/rpm/skydive.te.fedora
+++ b/contrib/packaging/rpm/skydive.te.fedora
@@ -1,4 +1,4 @@
-policy_module(skydive, 0.25.0)
+policy_module(skydive, 0.26.0)
 
 ########################################
 #

--- a/contrib/packaging/rpm/skydive.te.rhel
+++ b/contrib/packaging/rpm/skydive.te.rhel
@@ -1,4 +1,4 @@
-policy_module(skydive, 0.25.0)
+policy_module(skydive, 0.26.0)
 
 ########################################
 #

--- a/scripts/ci/create-vagrant-boxes.sh
+++ b/scripts/ci/create-vagrant-boxes.sh
@@ -13,7 +13,7 @@ dir="$(dirname "$0")"
 
 # SKYDIVE_RELEASE is a release tag (like "v0.1.2") or "master"
 export SKYDIVE_RELEASE=master
-BOXVERSION=0.26.0.alpha
+BOXVERSION=0.27.0.alpha
 tagname=$(git show-ref --tags $REF)
 if [ -n "$tagname" ]; then
     export SKYDIVE_RELEASE=$(echo $tagname | awk -F "/" "{print \$NF}")


### PR DESCRIPTION
skip skydive-go-fmt
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-scale-tests
skip skydive-cdd-overview-tests
skip skydive-unit-tests
skip skydive-compile-tests
skip skydive-k8s-tests
skip skydive-functional-hw-tests