### PR TITLE
Check skydive_container_cli

### DIFF
--- a/contrib/ansible/roles/skydive_common/tasks/container.yml
+++ b/contrib/ansible/roles/skydive_common/tasks/container.yml
@@ -13,10 +13,21 @@
   when:
     - skydive_container_cli is none or skydive_container_cli == ""
 
+- name: "Check {{ skydive_container_cli }}"
+  package:
+    list="{{ packages }}"
+  vars:
+    packages:
+    - "{{ skydive_container_cli }}"
+    - docker-ce
+  register: package_skydive_container_cli
+
 - name: "Install {{ skydive_container_cli }}"
   package:
     name: "{{ skydive_container_cli }}"
     state: present
+  when:
+    - package_skydive_container_cli.results | length != 0
 
 - name: Enable Docker service
   service:


### PR DESCRIPTION
Add check installed docker and docker-ce
I installed skydive by ansible playbook and it work.
This is hard code. Need refactored.

```
[root@skydive-apatsev-3 ~]# yum list installed docker*
Installed Packages
docker-ce.x86_64      3:19.03.4-3.el7 @docker-ce-stable
docker-ce-cli.x86_64  1:19.03.4-3.el7 @docker-ce-stable
```

Need think about docker package.
Should docker package installed for skydive? Or not? Thanks
