### PR TITLE
Disable upgrade all packages.

### DIFF
--- a/contrib/ansible/roles/skydive_common/tasks/package.yml
+++ b/contrib/ansible/roles/skydive_common/tasks/package.yml
@@ -1,12 +1,13 @@
 ---
-- name: Upgrade all packages
-  yum: name=* state=latest
-  when: ansible_os_family == 'RedHat'
+#- name: Upgrade all packages
+#  yum: name=* state=latest
+#  when: ansible_os_family == 'RedHat'
 
 - name: Install opstools repository
   package:
     name: centos-release-opstools
     state: present
+    update_cache: yes
   when: ansible_distribution == 'CentOS' and skydive_package_location is not defined
 
 - name: Copy skydive packages


### PR DESCRIPTION
Add yum update_cache after install centos-release-opstools
What is issue ansible: fix opstools repo installation?

https://github.com/skydive-project/skydive/commit/b13aef0289b0b4b03065454dc3a4b47d9eddb2d1