### PR TITLE
Makefile: check for GO111MODULE before running go mod download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,9 @@ skydive.clean:
 
 .PHONY: moddownload
 moddownload:
+ifeq (${GO111MODULE}, on)
 	go mod download
+endif
 
 .PHONY: genlocalfiles
 genlocalfiles: $(EXTRA_BUILD_TARGET) .proto .bindata .gendecoder .easyjson .vppbinapi


### PR DESCRIPTION
skip skydive-go-fmt
skip skydive-functional-tests-backend-elasticsearch
skip skydive-scale-tests
skip skydive-cdd-overview-tests
skip skydive-unit-tests
skip skydive-k8s-tests
skip skydive-functional-hw-tests