### PR TITLE
ui: fix raw packets limit display

### DIFF
--- a/statics/js/components/capture-form.js
+++ b/statics/js/components/capture-form.js
@@ -293,6 +293,10 @@ Vue.component('capture-form', {
         }
       }
     },
+
+    captureType: function(newType) {
+      this.targetType = "";
+    }
   },
 
   methods: {


### PR DESCRIPTION
after choosing target type if change the capture type
to ovssflow or ovsnetflow raw packets limit not appear again