### PR TITLE
packaging: file skydive binary location for bash completion build

### DIFF
--- a/contrib/packaging/rpm/skydive.spec
+++ b/contrib/packaging/rpm/skydive.spec
@@ -119,7 +119,7 @@ This package installs and sets up the SELinux policy security module for Skydive
 %build
 export GOPATH=%{_builddir}/skydive-%{fullver}
 make build VERSION=%{fullver} LDFLAGS=%{ldflags} GO111MODULE=off %{with_features}
-%{_builddir}/skydive-%{fullver}/bin/skydive bash-completion
+%{_builddir}/skydive-%{fullver}/src/%{import_path}/skydive bash-completion
 
 # SELinux build
 %if 0%{?fedora} >= 27


### PR DESCRIPTION
skip skydive-compile-tests
skip skydive-functional-hw-tests
skip skydive-functional-tests-backend-elasticsearch
skip skydive-functional-tests-backend-orientdb
skip skydive-go-fmt
skip skydive-k8s-tests
skip skydive-scale-tests
skip skydive-unit-tests
skip skydive-cdd-overview-tests
skip skydive-ppc64-tests
run skydive-vagrant-tests