### PR TITLE
Change apiVersions and add selectors to fits new k8s release >=1.16

### DIFF
--- a/contrib/kubernetes/skydive.yaml
+++ b/contrib/kubernetes/skydive.yaml
@@ -61,12 +61,16 @@ data:
   SKYDIVE_AGENT_TOPOLOGY_PROBES: runc docker
   SKYDIVE_AGENT_LISTEN: 127.0.0.1:8081
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: skydive-analyzer
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: skydive
+      tier: analyzer
   template:
     metadata:
       labels:
@@ -114,11 +118,15 @@ spec:
         ports:
         - containerPort: 9200
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: skydive-agent
 spec:
+  selector:
+    matchLabels:
+      app: skydive
+      tier: agent
   template:
     metadata:
       labels:


### PR DESCRIPTION
On the new kubernetes release some changes is needed like the name of the apiVersion and selector which is mandatory.