### PR TITLE
dpdk: use version 18.11.5

### DIFF
--- a/contrib/ansible/roles/skydive_dev/tasks/dpdk.yml
+++ b/contrib/ansible/roles/skydive_dev/tasks/dpdk.yml
@@ -8,10 +8,10 @@
     - libmnl-devel
     - libibverbs-devel
 - git:
-    repo: 'http://dpdk.org/git/dpdk'
+    repo: 'http://dpdk.org/git/dpdk-stable'
     dest: /usr/local/src/dpdk
-    version: v19.05
+    version: v18.11.5
 - shell: |
     export RTE_TARGET=x86_64-native-linuxapp-gcc
     make -C /usr/local/src/dpdk config T=$RTE_TARGET
-    make -C /usr/local/src/dpdk install T=$RTE_TARGET DESTDIR=/usr/local EXTRA_CFLAGS=-fPIC
+    make -C /usr/local/src/dpdk install T=$RTE_TARGET DESTDIR=/usr/local EXTRA_CFLAGS=-fPIC CONFIG_RTE_KNI_KMOD=n CONFIG_RTE_EAL_IGB_UIO=n CONFIG_RTE_LIBRTE_MLX4_PMD=y CONFIG_RTE_LIBRTE_MLX4_DLOPEN_DEPS=y CONFIG_RTE_LIBRTE_MLX5_PMD=y CONFIG_RTE_LIBRTE_MLX5_DLOPEN_DEPS=y

--- a/contrib/dev/Vagrantfile
+++ b/contrib/dev/Vagrantfile
@@ -153,7 +153,7 @@ Vagrant.configure(2) do |config|
       if not SKYDIVE_SYNC_FOLDER then
         dev.vm.provision "skygive-git-clone", type: "shell", privileged: false, inline: $skydive_git_clone
       end
-      dev.vm.provision "shared-folders", type: "shell", inline: "sudo chown vagrant:vagrant #{GOPATH}/src #{GOPATH}/src/github.com #{GOPATH}/src/github.com/skydive-project"
+      dev.vm.provision "shared-folders", type: "shell", inline: "sudo chown vagrant:vagrant #{GOPATH} #{GOPATH}/src #{GOPATH}/src/github.com #{GOPATH}/src/github.com/skydive-project"
       dev.vm.provision "write-motd", type: "shell", inline: $write_motd_script
       dev.vm.provision "package-update", type: "shell", inline: $package_update_script
 

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/hashicorp/go-version v0.0.0-20180322230233-23480c066577
 	github.com/hashicorp/golang-lru v0.5.3
 	github.com/hydrogen18/stoppableListener v0.0.0-20151210151943-dadc9ccc400c
-	github.com/intel-go/nff-go v0.0.0-20190620122648-8ab691c21da9
+	github.com/intel-go/nff-go v0.8.0
 	github.com/iovisor/gobpf v0.0.0-20190329163444-e0d8d785d368 // indirect
 	github.com/jbowtie/gokogiri v0.0.0-20190301021639-37f655d3078f // indirect
 	github.com/jteeuwen/go-bindata v0.0.0-20180305030458-6025e8de665b


### PR DESCRIPTION
skip go-fmt
skip unit-tests
skip functional-tests-backend-elasticsearch
skip functional-tests-backend-orientdb
skip functional-hw-tests
skip scale-tests
skip cdd-overview-tests
skip k8s-tests