### PR TITLE
Fix missing service account on agents

### DIFF
--- a/contrib/helm/templates/deployment-agents.yaml
+++ b/contrib/helm/templates/deployment-agents.yaml
@@ -22,6 +22,7 @@ spec:
         tier: agent
     spec:
       hostNetwork: true
+      serviceAccountName: skydive-service-account
       dnsPolicy: ClusterFirstWithHostNet
       securityContext:
         runAsNonRoot: false


### PR DESCRIPTION
The agents daemon set requires extensive rights. To be able to deploy it in a cluster with a restrictive default pod security policy we need to have a service account associated with them. 

The pull request adds the skydive-service-account to the agents to be able to assign pod
security policies with a rolebinding - as it is already done for the analyzer.