### PR TITLE
Change the blockdev node name to just the base name insead of full path

### DIFF
--- a/tests/blockdev_test.go
+++ b/tests/blockdev_test.go
@@ -300,7 +300,7 @@ func TestBlockDevWithJSON(t *testing.T) {
 		mode: Replay,
 
 		checks: []CheckFunction{func(c *CheckContext) error {
-			gremlin := c.gremlin.V().Has("Type", "cluster", "Manager", "blockdev", "Name", "/dev/mapper/mirror_vg-mirror_lv")
+			gremlin := c.gremlin.V().Has("Type", "cluster", "Manager", "blockdev", "Name", "/tmp/database")
 			_, err := c.gh.GetNode(gremlin)
 			if err != nil {
 				return err


### PR DESCRIPTION
When the full path to a block device is used for the node name it can be difficult to read on a graph with many devices.

Also, update block metadata from "WWN" to "ID" since not all block devices have WWNs.