### PR TITLE
Add ClusterName metadata to K8s objects

### DIFF
--- a/topology/probes/istio/istio.go
+++ b/topology/probes/istio/istio.go
@@ -53,7 +53,7 @@ func NewIstioProbe(g *graph.Graph) (*k8s.Probe, error) {
 		"virtualservice":   newVirtualServiceProbe,
 	}
 
-	k8s.InitSubprobes(enabledSubprobes, subprobeHandlers, client, g, Manager)
+	k8s.InitSubprobes(enabledSubprobes, subprobeHandlers, client, g, Manager, "")
 
 	verifierHandlers := []verifierHandler{
 		newVirtualServiceGatewayVerifier,

--- a/topology/probes/k8s/graph.go
+++ b/topology/probes/k8s/graph.go
@@ -32,6 +32,8 @@ const (
 	KubeKey = "K8s"
 	// ExtraKey is the metadata area for k8s extra fields
 	ExtraKey = "K8s.Extra"
+
+	ClusterNameField = "ClusterName"
 )
 
 // MetadataField is generates full path of a k8s specific field

--- a/topology/probes/k8s/probe.go
+++ b/topology/probes/k8s/probe.go
@@ -175,7 +175,7 @@ func NewProbe(g *graph.Graph, manager string, subprobes map[string]Subprobe, lin
 type SubprobeHandler func(client interface{}, g *graph.Graph) Subprobe
 
 // InitSubprobes initializes only the subprobes which are enabled
-func InitSubprobes(enabled []string, subprobeHandlers map[string]SubprobeHandler, client interface{}, g *graph.Graph, manager string) {
+func InitSubprobes(enabled []string, subprobeHandlers map[string]SubprobeHandler, client interface{}, g *graph.Graph, manager, clusterName string) {
 	if subprobes[manager] == nil {
 		subprobes[manager] = make(map[string]Subprobe)
 	}
@@ -189,6 +189,10 @@ func InitSubprobes(enabled []string, subprobeHandlers map[string]SubprobeHandler
 	for _, name := range enabled {
 		if handler := subprobeHandlers[name]; handler != nil {
 			subprobe := handler(client, g)
+			if resourceCache, ok := subprobe.(*ResourceCache); ok {
+				resourceCache.clusterName = clusterName
+			}
+
 			PutSubprobe(manager, name, subprobe)
 		}
 	}


### PR DESCRIPTION
When we have a combine view of several K8s clusters, currently we cannot separate objects from different clusters.
This PR adds the `ClusterName` metadata property to all K8s objects, so UI will be able to separate them. 