### PR TITLE
websocket: fix deadlock and remove duplicated mutex

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -122,6 +122,7 @@ require (
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v11.0.0+incompatible
+	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 )
 
 replace (


### PR DESCRIPTION
Deadlock trace:

goroutine 103 [semacquire, 4 minutes]:
sync.runtime_SemacquireMutex(0xc00033cfac, 0x0)
/var/lib/jenkins/.gimme/versions/go1.11.13.linux.amd64/src/runtime/sema.go:71 +0x3d
sync.(*RWMutex).RLock(0xc00033cfa0)
/var/lib/jenkins/.gimme/versions/go1.11.13.linux.amd64/src/sync/rwmutex.go:50 +0x99
github.com/skydive-project/skydive/websocket.(*Server).serveMessages(0xc000328a80, 0xcf46a0, 0xc000146700, 0xc00039e240)
/var/lib/jenkins/workspace/skydive-unit-tests/src/github.com/skydive-project/skydive/websocket/server.go:83 +0x536
github.com/skydive-project/skydive/websocket.(*Server).serveMessages-fm(0xcf46a0, 0xc000146700, 0xc00039e240)
/var/lib/jenkins/workspace/skydive-unit-tests/src/github.com/skydive-project/skydive/websocket/server.go:206 +0x60
github.com/skydive-project/skydive/http.postAuthHandler.func1(0xcf46a0, 0xc000146700, 0xc00039e240)
/var/lib/jenkins/workspace/skydive-unit-tests/src/github.com/skydive-project/skydive/http/server.go:173 +0x176
github.com/skydive-project/skydive/http.(*NoAuthenticationBackend).Wrap.func1(0xcf46a0, 0xc000146700, 0xc000153500)
/var/lib/jenkins/workspace/skydive-unit-tests/src/github.com/skydive-project/skydive/http/noauth.go:56 +0x13a
github.com/skydive-project/skydive/http.(*Server).HandleFunc.func1(0xcf46a0, 0xc000146700, 0xc000153500)
/var/lib/jenkins/workspace/skydive-unit-tests/src/github.com/skydive-project/skydive/http/server.go:185 +0x8b

goroutine 102 [semacquire, 4 minutes]:
sync.runtime_SemacquireMutex(0xc00033cfac, 0xc000000000)
/var/lib/jenkins/.gimme/versions/go1.11.13.linux.amd64/src/runtime/sema.go:71 +0x3d
sync.(*RWMutex).RLock(0xc00033cfa0)
/var/lib/jenkins/.gimme/versions/go1.11.13.linux.amd64/src/sync/rwmutex.go:50 +0x99
github.com/skydive-project/skydive/websocket.(*Pool).GetSpeakerByRemoteHost(0xc00033cfa0, 0xc00044a090, 0xf, 0x0, 0x0)
/var/lib/jenkins/workspace/skydive-unit-tests/src/github.com/skydive-project/skydive/websocket/pool.go:240 +0x47
github.com/skydive-project/skydive/websocket.(*Server).serveMessages(0xc000328a80, 0xcf46a0, 0xc0004da000, 0xc0004e2000)
/var/lib/jenkins/workspace/skydive-unit-tests/src/github.com/skydive-project/skydive/websocket/server.go:84 +0x58e
github.com/skydive-project/skydive/websocket.(*Server).serveMessages-fm(0xcf46a0, 0xc0004da000, 0xc0004e2000)
/var/lib/jenkins/workspace/skydive-unit-tests/src/github.com/skydive-project/skydive/websocket/server.go:206 +0x60
github.com/skydive-project/skydive/http.postAuthHandler.func1(0xcf46a0, 0xc0004da000, 0xc0004e2000)
/var/lib/jenkins/workspace/skydive-unit-tests/src/github.com/skydive-project/skydive/http/server.go:173 +0x176
github.com/skydive-project/skydive/http.(*NoAuthenticationBackend).Wrap.func1(0xcf46a0, 0xc0004da000, 0xc000482400)
/var/lib/jenkins/workspace/skydive-unit-tests/src/github.com/skydive-project/skydive/http/noauth.go:56 +0x13a
github.com/skydive-project/skydive/http.(*Server).HandleFunc.func1(0xcf46a0, 0xc0004da000, 0xc000482400)
/var/lib/jenkins/workspace/skydive-unit-tests/src/github.com/skydive-project/skydive/http/server.go:185 +0x8b