### PR TITLE
add cluster separation

### DIFF
--- a/topology/probes/k8s/cluster.go
+++ b/topology/probes/k8s/cluster.go
@@ -42,7 +42,7 @@ func (c *clusterCache) addClusterNode(clusterName string) error {
 	var err error
 	metadata := NewMetadata(Manager, Cluster, m, nil, clusterName)
 	if len(clusterName) > 0 {
-		metadata.SetFieldAndNormalize(ClusterNameField, clusterName)
+		metadata.SetField(ClusterNameField, clusterName)
 	}
 	clusterNode, err = c.graph.NewNode(graph.GenID(), metadata)
 	if err != nil {
@@ -92,6 +92,9 @@ func (linker *clusterLinker) createEdge(cluster, object *graph.Node) *graph.Edge
 
 // GetBALinks returns all the incoming links for a node
 func (linker *clusterLinker) GetBALinks(objectNode *graph.Node) (edges []*graph.Edge) {
+	if ! isTheSameCluster(clusterNode, objectNode) {
+		return
+	}
 	edges = append(edges, linker.createEdge(clusterNode, objectNode))
 	return
 }

--- a/topology/probes/k8s/graph.go
+++ b/topology/probes/k8s/graph.go
@@ -20,6 +20,7 @@ package k8s
 import (
 	"github.com/skydive-project/skydive/filters"
 	"github.com/skydive-project/skydive/graffiti/graph"
+	"github.com/skydive-project/skydive/logging"
 	"github.com/skydive-project/skydive/probe"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -88,6 +89,16 @@ func NewEdgeMetadata(manager, name string) graph.Metadata {
 		"RelationType": name,
 	}
 	return m
+}
+
+func isTheSameCluster(aObj, bObj *graph.Node) bool {
+	aCl, aErr := aObj.GetFieldString(ClusterNameField)
+	bCl, bErr := bObj.GetFieldString(ClusterNameField)
+	if aErr != nil || bErr != nil {
+		logging.GetLogger().Warning("ClusterNameFields are not defined \n")
+		return true
+	}
+	return aCl == bCl
 }
 
 func newTypesFilter(manager string, types ...string) *filters.Filter {


### PR DESCRIPTION
When skydive probes several K8s clusters, we have to separate their topology
![skydive-clusters](https://user-images.githubusercontent.com/1816654/75094529-a29de900-5594-11ea-8353-d895c80b38f5.jpg)
