### PR TITLE
Add build flag to disable packet injection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ WITH_OPENCONTRAIL?=true
 WITH_LIBVIRT_GO?=true
 WITH_EBPF_DOCKER_BUILDER?=true
 WITH_VPP?=false
+WITH_PACKETINJECT?=true
 
 EXTRA_BUILD_TARGET=
 
@@ -96,6 +97,10 @@ endif
 
 ifeq ($(WITH_OPENCONTRAIL), true)
   BUILD_TAGS+=opencontrail
+endif
+
+ifeq ($(WITH_PACKETINJECT), true)
+  BUILD_TAGS+=packetinject
 endif
 
 include .mk/ebpf.mk

--- a/api/server/no_packet_injector.go
+++ b/api/server/no_packet_injector.go
@@ -1,0 +1,30 @@
+// +build !packetinject
+
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package server
+
+import (
+	"fmt"
+
+	"github.com/skydive-project/skydive/api/types"
+)
+
+func (pi *PacketInjectorAPI) validateRequest(ppr *types.PacketInjection) error {
+	return fmt.Errorf("packet injection disabled because skydive was not built with \"packetinject\" build tag")
+}

--- a/api/server/packet_injector.go
+++ b/api/server/packet_injector.go
@@ -1,5 +1,4 @@
-//go:generate sh -c "go run github.com/gomatic/renderizer --name=injection --resource=injectpacket --type=PacketInjection --title='Injection' --article=an swagger_operations.tmpl > packet_injector_swagger.go"
-//go:generate sh -c "go run github.com/gomatic/renderizer --name=injection --resource=injectpacket --type=PacketInjection --title='Injection' swagger_definitions.tmpl > packet_injector_swagger.json"
+// +build packetinject
 
 /*
  * Copyright (C) 2016 Red Hat, Inc.
@@ -26,42 +25,8 @@ import (
 	"net"
 
 	"github.com/skydive-project/skydive/api/types"
-	"github.com/skydive-project/skydive/graffiti/api/rest"
-	api "github.com/skydive-project/skydive/graffiti/api/server"
-	"github.com/skydive-project/skydive/graffiti/graph"
-	ge "github.com/skydive-project/skydive/gremlin/traversal"
-	shttp "github.com/skydive-project/skydive/http"
 	"github.com/skydive-project/skydive/topology"
 )
-
-type packetInjectorResourceHandler struct {
-	rest.ResourceHandler
-}
-
-// PacketInjectorAPI exposes the packet injector API
-type PacketInjectorAPI struct {
-	rest.BasicAPIHandler
-	Graph *graph.Graph
-}
-
-func (pirh *packetInjectorResourceHandler) Name() string {
-	return "injectpacket"
-}
-
-func (pirh *packetInjectorResourceHandler) New() rest.Resource {
-	return &types.PacketInjection{}
-}
-
-// Create allocates a new packet injection
-func (pi *PacketInjectorAPI) Create(r rest.Resource, opts *rest.CreateOptions) error {
-	ppr := r.(*types.PacketInjection)
-
-	if err := pi.validateRequest(ppr); err != nil {
-		return err
-	}
-	e := pi.BasicAPIHandler.Create(ppr, opts)
-	return e
-}
 
 func (pi *PacketInjectorAPI) validateRequest(ppr *types.PacketInjection) error {
 	pi.Graph.RLock()
@@ -121,37 +86,4 @@ func (pi *PacketInjectorAPI) validateRequest(ppr *types.PacketInjection) error {
 	}
 
 	return nil
-}
-
-func (pi *PacketInjectorAPI) getNode(gremlinQuery string) *graph.Node {
-	res, err := ge.TopologyGremlinQuery(pi.Graph, gremlinQuery)
-	if err != nil {
-		return nil
-	}
-
-	for _, value := range res.Values() {
-		switch value.(type) {
-		case *graph.Node:
-			return value.(*graph.Node)
-		default:
-			return nil
-		}
-	}
-	return nil
-}
-
-// RegisterPacketInjectorAPI registers a new packet injector resource in the API
-func RegisterPacketInjectorAPI(g *graph.Graph, apiServer *api.Server, authBackend shttp.AuthenticationBackend) (*PacketInjectorAPI, error) {
-	pia := &PacketInjectorAPI{
-		BasicAPIHandler: rest.BasicAPIHandler{
-			ResourceHandler: &packetInjectorResourceHandler{},
-			EtcdKeyAPI:      apiServer.EtcdKeyAPI,
-		},
-		Graph: g,
-	}
-	if err := apiServer.RegisterAPIHandler(pia, authBackend); err != nil {
-		return nil, err
-	}
-
-	return pia, nil
 }

--- a/api/server/packet_injector_common.go
+++ b/api/server/packet_injector_common.go
@@ -1,0 +1,92 @@
+//go:generate sh -c "go run github.com/gomatic/renderizer --name=injection --resource=injectpacket --type=PacketInjection --title='Injection' --article=an swagger_operations.tmpl > packet_injector_swagger.go"
+//go:generate sh -c "go run github.com/gomatic/renderizer --name=injection --resource=injectpacket --type=PacketInjection --title='Injection' swagger_definitions.tmpl > packet_injector_swagger.json"
+
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package server
+
+import (
+	"github.com/skydive-project/skydive/api/types"
+	"github.com/skydive-project/skydive/graffiti/api/rest"
+	api "github.com/skydive-project/skydive/graffiti/api/server"
+	"github.com/skydive-project/skydive/graffiti/graph"
+	ge "github.com/skydive-project/skydive/gremlin/traversal"
+	shttp "github.com/skydive-project/skydive/http"
+)
+
+type packetInjectorResourceHandler struct {
+	rest.ResourceHandler
+}
+
+// PacketInjectorAPI exposes the packet injector API
+type PacketInjectorAPI struct {
+	rest.BasicAPIHandler
+	Graph *graph.Graph
+}
+
+func (pirh *packetInjectorResourceHandler) Name() string {
+	return "injectpacket"
+}
+
+func (pirh *packetInjectorResourceHandler) New() rest.Resource {
+	return &types.PacketInjection{}
+}
+
+// Create allocates a new packet injection
+func (pi *PacketInjectorAPI) Create(r rest.Resource, opts *rest.CreateOptions) error {
+	ppr := r.(*types.PacketInjection)
+
+	if err := pi.validateRequest(ppr); err != nil {
+		return err
+	}
+	e := pi.BasicAPIHandler.Create(ppr, opts)
+	return e
+}
+
+func (pi *PacketInjectorAPI) getNode(gremlinQuery string) *graph.Node {
+	res, err := ge.TopologyGremlinQuery(pi.Graph, gremlinQuery)
+	if err != nil {
+		return nil
+	}
+
+	for _, value := range res.Values() {
+		switch value.(type) {
+		case *graph.Node:
+			return value.(*graph.Node)
+		default:
+			return nil
+		}
+	}
+	return nil
+}
+
+// RegisterPacketInjectorAPI registers a new packet injector resource in the API
+func RegisterPacketInjectorAPI(g *graph.Graph, apiServer *api.Server, authBackend shttp.AuthenticationBackend) (*PacketInjectorAPI, error) {
+	pia := &PacketInjectorAPI{
+		BasicAPIHandler: rest.BasicAPIHandler{
+			ResourceHandler: &packetInjectorResourceHandler{},
+			EtcdKeyAPI:      apiServer.EtcdKeyAPI,
+		},
+		Graph: g,
+	}
+	if err := apiServer.RegisterAPIHandler(pia, authBackend); err != nil {
+		return nil, err
+	}
+
+	return pia, nil
+}

--- a/packetinjector/no_server.go
+++ b/packetinjector/no_server.go
@@ -1,0 +1,37 @@
+// +build !packetinject
+
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package packetinjector
+
+import (
+	"fmt"
+
+	"github.com/skydive-project/skydive/ondemand"
+
+	"github.com/skydive-project/skydive/graffiti/api/rest"
+	"github.com/skydive-project/skydive/graffiti/graph"
+)
+
+func (o *onDemandPacketInjectServer) CreateTask(srcNode *graph.Node, resource rest.Resource) (ondemand.Task, error) {
+	return nil, fmt.Errorf("packet injection %s ignored on %s because skydive was not built with \"packetinject\" build tag", resource.ID(), srcNode.ID)
+}
+
+func (o *onDemandPacketInjectServer) RemoveTask(n *graph.Node, resource rest.Resource, task ondemand.Task) error {
+	return nil
+}

--- a/packetinjector/server_common.go
+++ b/packetinjector/server_common.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package packetinjector
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/skydive-project/skydive/graffiti/api/rest"
+	"github.com/skydive-project/skydive/graffiti/graph"
+	ws "github.com/skydive-project/skydive/graffiti/websocket"
+	"github.com/skydive-project/skydive/ondemand/server"
+)
+
+const (
+	// Namespace PacketInjector
+	Namespace    = "PacketInjector"
+	resourceName = "PacketInjection"
+)
+
+type onDemandPacketInjectServer struct {
+	sync.RWMutex
+	graph *graph.Graph
+}
+
+// NewOnDemandInjectionServer creates a new Ondemand probes server based on graph and websocket
+func NewOnDemandInjectionServer(g *graph.Graph, pool *ws.StructClientPool) (*server.OnDemandServer, error) {
+	return server.NewOnDemandServer(g, pool, &onDemandPacketInjectServer{
+		graph: g,
+	})
+}
+
+func (o *onDemandPacketInjectServer) ResourceName() string {
+	return resourceName
+}
+
+func (o *onDemandPacketInjectServer) DecodeMessage(msg json.RawMessage) (rest.Resource, error) {
+	var params PacketInjectionRequest
+	if err := json.Unmarshal(msg, &params); err != nil {
+		return nil, fmt.Errorf("Unable to decode packet inject param message %v", msg)
+	}
+	return &params, nil
+}


### PR DESCRIPTION
Packet may be a security concern. When it is not needed it is
better to no have it available at all.
This patch adds a build flag "nopacketinject" to disable packet
injection if needed.