### PR TITLE
Update nsenter.c

### DIFF
--- a/cmd/skydive/nsenter.c
+++ b/cmd/skydive/nsenter.c
@@ -114,10 +114,10 @@ void nsexec(void)
 	int verbose = 0;
 	int need_to_fork = 0;
 	int option_index;
-	char c;
+	int c;
 	while ((c = getopt_long(argc, argv, ":m:p:u:i:n:v:",
 			longopts, &option_index)) != -1) {
-		switch (c) {
+		switch ((char)c) {
 		case 'u':
 			set_namespace_path(CLONE_NEWUSER, optarg);
 			break;


### PR DESCRIPTION
POWER and other architectures define char to be unsigned (as the C standard leaves this undefined).
The function getopt_long returns a integer, as opposed to char.  In "c" the char type is implementation depenedent. In X86/AMD  architecture char is treated as signed character and in Power PPC64le it is treated as unsigned char. 

It is better to change the variable type from char to int at cmd/skydive/nsenter.c:117. And  then to cast this back to char at cmd/skydive/nsenter.c:120 switch statement. 

Otherwise the while loop on P9/Power machine never terminates.