### PR TITLE
Fix python client to get the correct content type

### DIFF
--- a/contrib/python/api/skydive/rest/client.py
+++ b/contrib/python/api/skydive/rest/client.py
@@ -76,7 +76,10 @@ class RESTClient:
         for k, v in self.cookies.items():
             opener.append = (k, v)
 
-        headers = {'Content-Type': 'application/json'}
+        headers = {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json'
+        }
         req = request.Request(url,
                               data=encoded_data,
                               headers=headers)


### PR DESCRIPTION
API server renders the Content-Type header based on the Accept header
(graffiti/api/server/topology.go#L120).
If the client does not specify that header, the response is not
unmarshaled and raise an exception tryinh to get values from a byte
string (instead of a python dict), in function from_object