### PR TITLE
Fix panic if gremlin query At() and As() were used

### DIFF
--- a/graffiti/graph/traversal/traversal.go
+++ b/graffiti/graph/traversal/traversal.go
@@ -562,7 +562,10 @@ func (t *GraphTraversal) Context(s ...interface{}) *GraphTraversal {
 		return &GraphTraversal{error: err}
 	}
 
-	return &GraphTraversal{Graph: g}
+	return &GraphTraversal{
+		Graph: g,
+		as:    make(map[string]*GraphTraversalAs),
+	}
 }
 
 // V step : [node ID]


### PR DESCRIPTION
Query "G.At(0).V().As('x')" was crashing the analyzer because
a "assignment to entry in nil map".

GraphTraversal.as was not initializated after cloning the graph in the
"At/Context" step.
"As" step produced the panic while trying to assign a value to the
uninitializated map

Fixes #2230 