### PR TITLE
Return to the user the reason of the invalid schema

### DIFF
--- a/graffiti/schema/validator.go
+++ b/graffiti/schema/validator.go
@@ -30,13 +30,11 @@ type ErrInvalidSchema struct {
 }
 
 func (e ErrInvalidSchema) Error() string {
-	stringErrors := []string{}
-
-	for _, e := range e.Errors {
-		stringErrors = append(stringErrors, fmt.Sprint(e))
+	msg := make([]string, len(e.Errors))
+	for i, err := range e.Errors {
+		msg[len(e.Errors)-i-1] = err.String()
 	}
-
-	return fmt.Sprintf("invalid schema: %v", strings.Join(stringErrors, "; "))
+	return fmt.Sprintf("invalid schema: %v", strings.Join(msg, "\n"))
 }
 
 // Validator is the interface to implement to validate REST resources

--- a/graffiti/schema/validator.go
+++ b/graffiti/schema/validator.go
@@ -19,6 +19,7 @@ package schema
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/xeipuuv/gojsonschema"
 )
@@ -48,7 +49,7 @@ func (v *JSONValidator) Validate(kind string, obj interface{}) error {
 	if err != nil {
 		return err
 	} else if !result.Valid() {
-		return ErrInvalidSchema
+		return fmt.Errorf("%v: %v", ErrInvalidSchema, result.Errors())
 	}
 	return nil
 }

--- a/graffiti/schema/validator.go
+++ b/graffiti/schema/validator.go
@@ -18,14 +18,26 @@
 package schema
 
 import (
-	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/xeipuuv/gojsonschema"
 )
 
 // ErrInvalidSchema is return when a JSON schema is invalid
-var ErrInvalidSchema = errors.New("Invalid schema")
+type ErrInvalidSchema struct {
+	Errors []gojsonschema.ResultError
+}
+
+func (e ErrInvalidSchema) Error() string {
+	stringErrors := []string{}
+
+	for _, e := range e.Errors {
+		stringErrors = append(stringErrors, fmt.Sprint(e))
+	}
+
+	return fmt.Sprintf("invalid schema: %v", strings.Join(stringErrors, "; "))
+}
 
 // Validator is the interface to implement to validate REST resources
 type Validator interface {
@@ -49,7 +61,7 @@ func (v *JSONValidator) Validate(kind string, obj interface{}) error {
 	if err != nil {
 		return err
 	} else if !result.Valid() {
-		return fmt.Errorf("%v: %v", ErrInvalidSchema, result.Errors())
+		return &ErrInvalidSchema{Errors: result.Errors()}
 	}
 	return nil
 }


### PR DESCRIPTION
Currently an error in the node/edge schema gives no clue to the user to
where is the error.
Append to that message the list of errors returned by the validator.

Eg.:
```
Invalid schema: [CreatedAt: Invalid type. Expected: integer, given: null UpdatedAt: Invalid type. Expected: integer, given: null (root): Must validate all the schemas (allOf)]
```

Could be improved to separate different messages