### PR TITLE
Add PATCH method to modify resources -> moved to #2263

### DIFF
--- a/api/server/edge.go
+++ b/api/server/edge.go
@@ -21,6 +21,7 @@
 package server
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/skydive-project/skydive/api/types"
@@ -102,6 +103,23 @@ func (h *EdgeAPIHandler) Delete(id string) error {
 		return common.ErrNotFound
 	}
 	return h.g.DelEdge(edge)
+}
+
+// Update a edge metadata
+func (h *EdgeAPIHandler) Update(id string, resource rest.Resource) error {
+	e := h.g.GetEdge(graph.Identifier(id))
+	if e == nil {
+		return fmt.Errorf("Edge to be updated not found")
+	}
+
+	// Edge to be updated
+	actualEdge := types.Edge(*e)
+	graphEdge := graph.Edge(actualEdge)
+
+	// Edge containing the metadata updated
+	updateData := resource.(*types.Edge)
+
+	return h.g.SetMetadata(&graphEdge, updateData.Metadata)
 }
 
 // RegisterEdgeAPI registers the edge API

--- a/api/server/node.go
+++ b/api/server/node.go
@@ -21,6 +21,7 @@
 package server
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/skydive-project/skydive/api/types"
@@ -102,6 +103,49 @@ func (h *NodeAPIHandler) Delete(id string) error {
 		return common.ErrNotFound
 	}
 	return h.g.DelNode(node)
+}
+
+// Update a node metadata
+func (h *NodeAPIHandler) Update(id string, resource rest.Resource) error {
+	n := h.g.GetNode(graph.Identifier(id))
+	if n == nil {
+		return fmt.Errorf("Node to be updated not found")
+	}
+
+	// Node to be updated
+	actualNode := types.Node(*n)
+	graphNode := graph.Node(actualNode)
+
+	// Node containing the metadata updated
+	updateData := resource.(*types.Node)
+
+	// TODO filter Metadata.TID not to be modified. But looks like its not mandatoy
+
+	// Metadata.Name and Metadata.Type are used to identfy globally the node, they
+	// should not be modified
+	actualNodeName, err := graphNode.Metadata.GetFieldString("Name")
+	if err != nil {
+		panic("Metadata.Name should be always defined")
+	}
+
+	updateNodeName, err := updateData.Metadata.GetFieldString("Name")
+	if err != nil {
+		panic("Metadata.Name should be always defined")
+	}
+
+	if actualNodeName != updateNodeName {
+		return fmt.Errorf("Metadata.Name could not be modified")
+	}
+
+	// Metadata.Type is not mandatory, but should not be changed if it is already defined
+	actualNodeType, _ := graphNode.Metadata.GetFieldString("Type")
+	updateNodeType, _ := updateData.Metadata.GetFieldString("Type")
+
+	if actualNodeType != "" && actualNodeType != updateNodeType {
+		return fmt.Errorf("Metadata.Type could not be modified")
+	}
+
+	return h.g.SetMetadata(&graphNode, updateData.Metadata)
 }
 
 // RegisterNodeAPI registers the node API

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/digitalocean/go-libvirt v0.0.0-20190715144809-7b622097a793
 	github.com/docker/docker v1.13.1
 	github.com/ebay/go-ovn v0.0.0-20190726163905-ca0da4d10c52
+	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/fatih/structs v0.0.0-20171020064819-f5faa72e7309
 	github.com/flosch/pongo2 v0.0.0-20190707114632-bbf5a6c351f4 // indirect
 	github.com/fsnotify/fsnotify v1.4.7

--- a/graffiti/api/rest/rest.go
+++ b/graffiti/api/rest/rest.go
@@ -42,6 +42,7 @@ type Handler interface {
 	Decorate(resource Resource)
 	Create(resource Resource, createOpts *CreateOptions) error
 	Delete(id string) error
+	Update(id string, resource Resource) error
 }
 
 // CreateOptions describes the available options when creating a resource

--- a/graffiti/api/server/server.go
+++ b/graffiti/api/server/server.go
@@ -47,6 +47,7 @@ import (
 
 	auth "github.com/abbot/go-http-auth"
 	etcd "github.com/coreos/etcd/client"
+	jsonpatch "github.com/evanphx/json-patch"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/skydive-project/skydive/graffiti/api/rest"
@@ -194,6 +195,94 @@ func (a *Server) RegisterAPIHandler(handler rest.Handler, authBackend shttp.Auth
 				}
 
 				data, err := json.Marshal(&resource)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+
+				w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+				w.WriteHeader(http.StatusCreated)
+				if _, err := w.Write(data); err != nil {
+					logging.GetLogger().Criticalf("Failed to create %s: %s", name, err)
+				}
+			},
+		},
+		{
+			Name:   title + "Update",
+			Method: "PATCH",
+			Path:   shttp.PathPrefix(fmt.Sprintf("/api/%s/", name)),
+			HandlerFunc: func(w http.ResponseWriter, r *auth.AuthenticatedRequest) {
+				if !rbac.Enforce(r.Username, name, "write") {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
+				id := r.URL.Path[len(fmt.Sprintf("/api/%s/", name)):]
+				if id == "" {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+
+				// Get the resource to be modified
+				resource, ok := handler.Get(id)
+				if !ok {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+
+				// Decode patch operations (json-path format)
+				content, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+
+				patch, err := jsonpatch.DecodePatch(content)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+
+				// Convert node to JSON to apply the JSON patch
+				resourceJSON, err := json.Marshal(resource)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+
+				// Patch are applied to the json body in []byte format
+				resourcePatchedJSON, err := patch.Apply(resourceJSON)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+
+				resourcePatched := handler.New()
+				err = json.Unmarshal(resourcePatchedJSON, resourcePatched)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+
+				if err := a.validator.Validate(name, resourcePatched); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+
+				if err := resourcePatched.Validate(); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+
+				// TODO for node implementation avoid modifiying .Metadata{.TID, .Name, .Type}
+				// Test for *rules, and others resources, that it is working
+				// Test with ES backend
+				if err := handler.Update(id, resourcePatched); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+
+				data, err := json.Marshal(&resourcePatched)
 				if err != nil {
 					http.Error(w, err.Error(), http.StatusBadRequest)
 					return

--- a/graffiti/api/server/server.go
+++ b/graffiti/api/server/server.go
@@ -81,6 +81,16 @@ type Info struct {
 	Service string
 }
 
+// ResourceNotFound error generated when a resource does not exists
+type ResourceNotFound struct {
+	ID   string
+	Type string
+}
+
+func (r ResourceNotFound) Error() string {
+	return fmt.Sprintf("Resource %s with id=%v has not been found", r.Type, r.ID)
+}
+
 // RegisterAPIHandler registers a new handler for an API
 func (a *Server) RegisterAPIHandler(handler rest.Handler, authBackend shttp.AuthenticationBackend) error {
 	name := handler.Name()
@@ -223,13 +233,6 @@ func (a *Server) RegisterAPIHandler(handler rest.Handler, authBackend shttp.Auth
 					return
 				}
 
-				// Get the resource to be modified
-				resource, ok := handler.Get(id)
-				if !ok {
-					w.WriteHeader(http.StatusNotFound)
-					return
-				}
-
 				// Decode patch operations (json-path format)
 				content, err := ioutil.ReadAll(r.Body)
 				if err != nil {
@@ -237,53 +240,11 @@ func (a *Server) RegisterAPIHandler(handler rest.Handler, authBackend shttp.Auth
 					return
 				}
 
-				patch, err := jsonpatch.DecodePatch(content)
-				if err != nil {
-					http.Error(w, err.Error(), http.StatusBadRequest)
+				data, err := patchMethod(handler, a.validator, id, content)
+				if errors.Is(err, ResourceNotFound{}) {
+					w.WriteHeader(http.StatusNotFound)
 					return
-				}
-
-				// Convert node to JSON to apply the JSON patch
-				resourceJSON, err := json.Marshal(resource)
-				if err != nil {
-					http.Error(w, err.Error(), http.StatusBadRequest)
-					return
-				}
-
-				// Patch are applied to the json body in []byte format
-				resourcePatchedJSON, err := patch.Apply(resourceJSON)
-				if err != nil {
-					http.Error(w, err.Error(), http.StatusBadRequest)
-					return
-				}
-
-				resourcePatched := handler.New()
-				err = json.Unmarshal(resourcePatchedJSON, resourcePatched)
-				if err != nil {
-					http.Error(w, err.Error(), http.StatusBadRequest)
-					return
-				}
-
-				if err := a.validator.Validate(name, resourcePatched); err != nil {
-					http.Error(w, err.Error(), http.StatusBadRequest)
-					return
-				}
-
-				if err := resourcePatched.Validate(); err != nil {
-					http.Error(w, err.Error(), http.StatusBadRequest)
-					return
-				}
-
-				// TODO for node implementation avoid modifiying .Metadata{.TID, .Name, .Type}
-				// Test for *rules, and others resources, that it is working
-				// Test with ES backend
-				if err := handler.Update(id, resourcePatched); err != nil {
-					http.Error(w, err.Error(), http.StatusBadRequest)
-					return
-				}
-
-				data, err := json.Marshal(&resourcePatched)
-				if err != nil {
+				} else if err != nil {
 					http.Error(w, err.Error(), http.StatusBadRequest)
 					return
 				}
@@ -472,6 +433,66 @@ func (a *Server) addLoginRoute(authBackend shttp.AuthenticationBackend) {
 	//     description: Unauthorized
 
 	a.HTTPServer.Router.HandleFunc("/login", a.serveLoginHandlerFunc(authBackend))
+}
+
+// patchMethod modifies a resource identified by "id" with the JSON patch.
+// Returns the resource modified or an error
+func patchMethod(handler rest.Handler, validator Validator, id string, jsonPatch []byte) ([]byte, error) {
+	// Get the resource to be modified
+	resource, ok := handler.Get(id)
+	if !ok {
+		return nil, ResourceNotFound{
+			ID:   id,
+			Type: handler.Name(),
+		}
+	}
+
+	// Convert user content to a JSON patch
+	patch, err := jsonpatch.DecodePatch(jsonPatch)
+	if err != nil {
+		return nil, fmt.Errorf("incorrect JSON patch: %v. Patch: %s", err, jsonPatch)
+	}
+
+	// Convert node to JSON to apply the JSON patch
+	resourceJSON, err := json.Marshal(resource)
+	if err != nil {
+		return nil, fmt.Errorf("converting current stored node to JSON: %v", err)
+	}
+
+	// Patch are applied to the json body in []byte format
+	resourcePatchedJSON, err := patch.Apply(resourceJSON)
+	if err != nil {
+		return nil, fmt.Errorf("applying JSON patch to resource: %v", err)
+	}
+
+	// Create a new node with the content of the patched resource
+	resourcePatched := handler.New()
+	if err = json.Unmarshal(resourcePatchedJSON, resourcePatched); err != nil {
+		return nil, fmt.Errorf("creating a new resource from the patched JSON body: %v", err)
+	}
+
+	// Validates new resource is valid
+	if err = validator.Validate(handler.Name(), resourcePatched); err != nil {
+		return nil, fmt.Errorf("validating patched resource: %v", err)
+	}
+
+	if err = resourcePatched.Validate(); err != nil {
+		return nil, fmt.Errorf("validating patched resource: %v", err)
+	}
+
+	// TODO for node implementation avoid modifiying .Metadata{.TID, .Name, .Type}
+	// Test for *rules, and others resources, that it is working
+	// Test with ES backend
+	if err = handler.Update(id, resourcePatched); err != nil {
+		return nil, fmt.Errorf("updating resource with patched version: %v", err)
+	}
+
+	data, err := json.Marshal(&resourcePatched)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling patched resource to JSON: %v", err)
+	}
+
+	return data, nil
 }
 
 // NewAPI creates a new API server based on http

--- a/graffiti/graph/graph.go
+++ b/graffiti/graph/graph.go
@@ -20,6 +20,7 @@ package graph
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -724,6 +725,8 @@ func (g *Graph) SetMetadata(i interface{}, m Metadata) error {
 	case *Edge:
 		e = &i.graphElement
 		kind = EdgeUpdated
+	default:
+		panic(fmt.Sprintf("SetMetadata is only implemented for Node or Edge resources, current type: %T", i))
 	}
 
 	if reflect.DeepEqual(m, e.Metadata) {

--- a/graffiti/graph/memory.go
+++ b/graffiti/graph/memory.go
@@ -41,17 +41,15 @@ type MemoryBackend struct {
 func (m *MemoryBackend) MetadataUpdated(i interface{}) error {
 	switch i := i.(type) {
 	case *Node:
-		node, ok := m.nodes[i.ID]
+		_, ok := m.nodes[i.ID]
 		if !ok {
 			return ErrNodeNotFound
 		}
-		node.graphElement.Metadata = i.graphElement.Metadata
 	case *Edge:
-		edge, ok := m.edges[i.ID]
+		_, ok := m.edges[i.ID]
 		if !ok {
 			return ErrEdgeNotFound
 		}
-		edge.graphElement.Metadata = i.graphElement.Metadata
 	default:
 		panic(fmt.Sprintf("MetadataUpdated is only implemented for Node or Edge resources, current type: %T", i))
 	}

--- a/graffiti/graph/memory.go
+++ b/graffiti/graph/memory.go
@@ -41,14 +41,19 @@ type MemoryBackend struct {
 func (m *MemoryBackend) MetadataUpdated(i interface{}) error {
 	switch i := i.(type) {
 	case *Node:
-		if _, ok := m.nodes[i.ID]; !ok {
-
+		node, ok := m.nodes[i.ID]
+		if !ok {
 			return ErrNodeNotFound
 		}
+		node.graphElement.Metadata = i.graphElement.Metadata
 	case *Edge:
-		if _, ok := m.edges[i.ID]; !ok {
+		edge, ok := m.edges[i.ID]
+		if !ok {
 			return ErrEdgeNotFound
 		}
+		edge.graphElement.Metadata = i.graphElement.Metadata
+	default:
+		panic(fmt.Sprintf("MetadataUpdated is only implemented for Node or Edge resources, current type: %T", i))
 	}
 
 	return nil

--- a/graffiti/http/client.go
+++ b/graffiti/http/client.go
@@ -193,25 +193,31 @@ func (c *CrudClient) Create(resource string, value interface{}, opts *CreateOpti
 }
 
 // Update modify a resource using a PUT call to the API
-func (c *CrudClient) Update(resource string, id string, value interface{}) error {
+// Server JSON response is unmarshalled into "ret"
+func (c *CrudClient) Update(resource string, id string, value interface{}, ret interface{}) error {
 	s, err := json.Marshal(value)
 	if err != nil {
-		return err
+		return fmt.Errorf("marshaling value: %v", err)
 	}
 
 	contentReader := bytes.NewReader(s)
-	resp, err := c.Request("PUT", resource+"/"+id, contentReader, nil)
+	resp, err := c.Request("PATCH", resource+"/"+id, contentReader, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("request: %v", err)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("Failed to update %s, %s: %s", resource, resp.Status, readBody(resp))
 	}
 
 	decoder := json.NewDecoder(resp.Body)
-	return decoder.Decode(value)
+	err = decoder.Decode(ret)
+	if err != nil {
+		return fmt.Errorf("parsing response body: %v", err)
+	}
+
+	return nil
 }
 
 // Delete removes a resource using a DELETE call to the API

--- a/tests/api_test.go
+++ b/tests/api_test.go
@@ -18,6 +18,8 @@
 package tests
 
 import (
+	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/avast/retry-go"
@@ -137,5 +139,461 @@ func TestCaptureAPI(t *testing.T) {
 
 	if err := client.Get("capture", capture.GetID(), &capture2); err == nil {
 		t.Errorf("Found delete capture: %s", capture.GetID())
+	}
+}
+
+// PATCH
+type JSONPatch struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value string `json:"value"`
+}
+
+// Create node, patch node, check modification has been made and updatedAt/revision updated
+func TestAPIPatchNode(t *testing.T) {
+	tests := []struct {
+		name         string
+		originalNode []byte
+		patch        []JSONPatch
+		expectedNode []byte
+	}{
+		{
+			name: "PATCH node, add new attribute",
+			originalNode: []byte(`{
+					"ID": "test1",
+					"Metadata": {
+						"TID": "test1",
+						"Name": "name1",
+						"Type": "type1"
+					},
+					"Host": "host1",
+					"Origin": "origin1",
+					"CreatedAt": 0,
+					"UpdatedAt": 0,
+					"Revision":  0
+				}`),
+			patch: []JSONPatch{
+				{
+					Op:    "add",
+					Path:  "/Metadata/foo",
+					Value: "bar",
+				},
+			},
+			expectedNode: []byte(`{
+					"ID": "test1",
+					"Metadata": {
+						"TID":  "test1",
+						"Name": "name1",
+						"Type": "type1",
+						"foo": "bar"
+					},
+					"Host": "host1",
+					"Origin": "origin1",
+					"CreatedAt": 0,
+					"UpdatedAt": 1,
+					"Revision":  0
+				}`),
+		},
+		{
+			name: "PATCH node, modify attribute",
+			originalNode: []byte(`{
+					"ID": "test2",
+					"Metadata": {
+						"TID": "test2",
+						"Name": "name2",
+						"Type": "type2",
+						"foo": "bar"
+					},
+					"Host": "host2",
+					"Origin": "origin2",
+					"CreatedAt": 0,
+					"UpdatedAt": 0,
+					"Revision":  0
+				}`),
+			patch: []JSONPatch{
+				{
+					Op:    "replace",
+					Path:  "/Metadata/foo",
+					Value: "foo",
+				},
+			},
+			expectedNode: []byte(`{
+					"ID": "test2",
+					"Metadata": {
+						"TID":  "test2",
+						"Name": "name2",
+						"Type": "type2",
+						"foo": "foo"
+					},
+					"Host": "host2",
+					"Origin": "origin2",
+					"CreatedAt": 0,
+					"UpdatedAt": 1,
+					"Revision":  0
+				}`),
+		},
+		{
+			name: "PATCH node, delete attribute",
+			originalNode: []byte(`{
+					"ID": "test3",
+					"Metadata": {
+						"TID": "test3",
+						"Name": "name3",
+						"Type": "type3",
+						"foo": "bar"
+					},
+					"Host": "host3",
+					"Origin": "origin3",
+					"CreatedAt": 0,
+					"UpdatedAt": 0,
+					"Revision":  0
+				}`),
+			patch: []JSONPatch{
+				{
+					Op:   "remove",
+					Path: "/Metadata/foo",
+				},
+			},
+			expectedNode: []byte(`{
+					"ID": "test3",
+					"Metadata": {
+						"TID":  "test3",
+						"Name": "name3",
+						"Type": "type3"
+					},
+					"Host": "host3",
+					"Origin": "origin3",
+					"CreatedAt": 0,
+					"UpdatedAt": 1,
+					"Revision":  0
+				}`),
+		},
+		{
+			name: "PATCH node, modify attribute Metadata.TID is ignored",
+			originalNode: []byte(`{
+					"ID": "test4",
+					"Metadata": {
+						"TID": "test4",
+						"Name": "name4",
+						"Type": "type4"
+					},
+					"Host": "host4",
+					"Origin": "origin4",
+					"CreatedAt": 0,
+					"UpdatedAt": 0,
+					"Revision":  0
+				}`),
+			patch: []JSONPatch{
+				{
+					Op:    "replace",
+					Path:  "/Metadata/TID",
+					Value: "123",
+				},
+			},
+			expectedNode: []byte(`{
+					"ID": "test4",
+					"Metadata": {
+						"TID":  "test4",
+						"Name": "name4",
+						"Type": "type4"
+					},
+					"Host": "host4",
+					"Origin": "origin4",
+					"CreatedAt": 0,
+					"UpdatedAt": 0,
+					"Revision":  0
+				}`),
+		},
+		{
+			name: "PATCH node, modify attribute Metadata.Name is ignored",
+			originalNode: []byte(`{
+					"ID": "test5",
+					"Metadata": {
+						"TID": "test5",
+						"Name": "name5",
+						"Type": "type5"
+					},
+					"Host": "host5",
+					"Origin": "origin5",
+					"CreatedAt": 0,
+					"UpdatedAt": 0,
+					"Revision":  0
+				}`),
+			patch: []JSONPatch{
+				{
+					Op:    "replace",
+					Path:  "/Metadata/Name",
+					Value: "noop",
+				},
+			},
+			expectedNode: []byte(`{
+					"ID": "test5",
+					"Metadata": {
+						"TID":  "test5",
+						"Name": "name5",
+						"Type": "type5"
+					},
+					"Host": "host5",
+					"Origin": "origin5",
+					"CreatedAt": 0,
+					"UpdatedAt": 0,
+					"Revision":  0
+				}`),
+		},
+		{
+			name: "PATCH node, modify attribute Metadata.Type is ignored",
+			originalNode: []byte(`{
+					"ID": "test6",
+					"Metadata": {
+						"TID": "test6",
+						"Name": "name6",
+						"Type": "type6"
+					},
+					"Host": "host6",
+					"Origin": "origin6",
+					"CreatedAt": 0,
+					"UpdatedAt": 0,
+					"Revision":  0
+				}`),
+			patch: []JSONPatch{
+				{
+					Op:    "replace",
+					Path:  "/Metadata/Type",
+					Value: "noop",
+				},
+			},
+			expectedNode: []byte(`{
+					"ID": "test6",
+					"Metadata": {
+						"TID":  "test6",
+						"Name": "name6",
+						"Type": "type6"
+					},
+					"Host": "host6",
+					"Origin": "origin6",
+					"CreatedAt": 0,
+					"UpdatedAt": 0,
+					"Revision":  0
+				}`),
+		},
+		{
+			name: "PATCH node, delete attributes Metadata.TID is ignored",
+			originalNode: []byte(`{
+					"ID": "test7",
+					"Metadata": {
+						"TID": "test7",
+						"Name": "name7",
+						"Type": "type7"
+					},
+					"Host": "host7",
+					"Origin": "origin7",
+					"CreatedAt": 0,
+					"UpdatedAt": 0,
+					"Revision":  0
+				}`),
+			patch: []JSONPatch{
+				{
+					Op:   "remove",
+					Path: "/Metadata/TID",
+				},
+			},
+			expectedNode: []byte(`{
+					"ID": "test7",
+					"Metadata": {
+						"TID":  "test7",
+						"Name": "name7",
+						"Type": "type7"
+					},
+					"Host": "host7",
+					"Origin": "origin7",
+					"CreatedAt": 0,
+					"UpdatedAt": 0,
+					"Revision":  0
+				}`),
+		},
+		{
+			name: "PATCH node, modifying values outside Metadata are ignored",
+			originalNode: []byte(`{
+					"ID": "test8",
+					"Metadata": {
+						"TID": "test8",
+						"Name": "name8",
+						"Type": "type8"
+					},
+					"Host": "host8",
+					"Origin": "origin8",
+					"CreatedAt": 0,
+					"UpdatedAt": 0,
+					"Revision":  0
+				}`),
+			patch: []JSONPatch{
+				{
+					Op:    "replace",
+					Path:  "/Host",
+					Value: "foo",
+				},
+			},
+			expectedNode: []byte(`{
+					"ID": "test8",
+					"Metadata": {
+						"TID":  "test8",
+						"Name": "name8",
+						"Type": "type8"
+					},
+					"Host": "host8",
+					"Origin": "origin8",
+					"CreatedAt": 0,
+					"UpdatedAt": 0,
+					"Revision":  0
+				}`),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client, err := getCrudClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Add originalNode to the graph
+			originalNode := types.Node{}
+			expectedNode := types.Node{}
+			patchedNode := types.Node{}
+			getPatchedNode := types.Node{}
+
+			if err := json.Unmarshal(test.originalNode, &originalNode); err != nil {
+				t.Fatalf("error unmarshal originalNode: %v", err)
+			}
+
+			if err := json.Unmarshal(test.expectedNode, &expectedNode); err != nil {
+				t.Fatalf("error unmarshal expectedNode: %v", err)
+			}
+
+			// Create original node
+			if err := client.Create("node", &originalNode, nil); err != nil {
+				t.Fatalf("Failed to create originalNode: %s", err.Error())
+			}
+
+			// Patch node
+			err = client.Update("node", originalNode.GetID(), test.patch, &patchedNode)
+			if err != nil {
+				t.Fatalf("Failed to apply patch: %s", err.Error())
+			}
+
+			err = client.Get("node", originalNode.GetID(), &getPatchedNode)
+			if err != nil {
+				t.Fatalf("Failed to get node after patching: %s", err.Error())
+			}
+
+			// Compare nodes
+			if !reflect.DeepEqual(expectedNode.Metadata, patchedNode.Metadata) {
+				t.Errorf("JSON Patch was not applied.\nMetadata original: %+v\nMetadata patched:  %+v", originalNode.Metadata, patchedNode.Metadata)
+			}
+
+			if !reflect.DeepEqual(patchedNode.Metadata, getPatchedNode.Metadata) {
+				t.Errorf("Response from PATCH method and node stored are not the same.\nMetadata PATCH response: %+v\nMetadata node stored:  %+v", patchedNode.Metadata, getPatchedNode.Metadata)
+			}
+
+			if expectedNode.Revision != patchedNode.Revision {
+				t.Errorf("Revision version is not being updated by PATCH")
+			}
+
+			// If expectedNode.UpdatedAt is "1", we expect a change in the UpdatedAt field
+			if expectedNode.UpdatedAt.Unix() == 1 && patchedNode.UpdatedAt.IsZero() {
+				t.Error("UpdatedAt is not being updated by PATCH")
+			}
+		})
+	}
+}
+
+// Try to patch a non existing node
+func TestAPIPatchNodeNonExistingNode(t *testing.T) {
+	client, err := getCrudClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add originalNode to the graph
+	patchedNode := types.Node{}
+
+	patch := []JSONPatch{
+		{
+			Op:    "add",
+			Path:  "/Metadata/Foo",
+			Value: "bar",
+		},
+	}
+
+	// Patch node
+	err = client.Update("node", "foo", patch, &patchedNode)
+	if err == nil {
+		t.Fatal("Error should be returned if node id does not exists")
+	}
+}
+
+// Try to patch deleting Metadata.Name generates a validation error
+func TestAPIPatchNodeNameDeleteValidationError(t *testing.T) {
+	client, err := getCrudClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add originalNode to the graph
+	originalNode := types.Node{}
+	patchedNode := types.Node{}
+
+	if err := json.Unmarshal([]byte(`{
+					"ID": "test1",
+					"Metadata": {
+						"TID": "test1",
+						"Name": "name1",
+						"Type": "type1"
+					},
+					"Host": "host1",
+					"Origin": "origin1",
+					"CreatedAt": 0,
+					"UpdatedAt": 0,
+					"Revision":  0
+				}`), &originalNode); err != nil {
+		t.Fatalf("error unmarshal originalNode: %v", err)
+	}
+
+	patch := []JSONPatch{
+		{
+			Op:   "remove",
+			Path: "/Metadata/Name",
+		},
+	}
+
+	// Patch node
+	err = client.Update("node", "foo", patch, &patchedNode)
+	if err == nil {
+		t.Fatal("Error should be returned because trying to remove Metadata.Name violates validation")
+	}
+}
+
+// Erroneous patch
+func TestAPIPatchNodeErroneousPatch(t *testing.T) {
+	client, err := getCrudClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add originalNode to the graph
+	patchedNode := types.Node{}
+
+	patch := []JSONPatch{
+		{
+			Op:    "foobar",
+			Path:  "/Metadata/Foo",
+			Value: "bar",
+		},
+	}
+
+	// Patch node
+	err = client.Update("node", "foo", patch, &patchedNode)
+	if err == nil {
+		t.Fatal("Error should be returned if patch is incorrect")
 	}
 }


### PR DESCRIPTION
Allow a new call to the REST API, using method PATCH, to modify
resources.
The body of the request should use JSON Patch
(https://tools.ietf.org/html/rfc6902) to specify the modifications.

Only metatada could be modified.
For node resources, some fields inside metadata could not be changed.

TODO:
- [x] test noderule/edgerule modifications
- [x] test with ES backend
- [X] tests
- [ ] add to swagger