### PR TITLE
Elasticsearch: define several hosts and allow invalid certs

### DIFF
--- a/analyzer/storage.go
+++ b/analyzer/storage.go
@@ -41,13 +41,17 @@ func NewESConfig(name ...string) es.Config {
 		path += "elasticsearch"
 	}
 
-	cfg.ElasticHost = config.GetString(path + ".host")
+	cfg.ElasticHost = config.GetStringSlice(path + ".hosts")
+	cfg.InsecureSkipVerify = config.GetBool(path + ".ssl_insecure")
+	cfg.Auth = config.GetStringMapString(path + ".auth")
 	cfg.BulkMaxDelay = config.GetInt(path + ".bulk_maxdelay")
 
 	cfg.EntriesLimit = config.GetInt(path + ".index_entries_limit")
 	cfg.AgeLimit = config.GetInt(path + ".index_age_limit")
 	cfg.IndicesLimit = config.GetInt(path + ".indices_to_keep")
 	cfg.NoSniffing = config.GetBool(path + ".disable_sniffing")
+	cfg.SniffingScheme = config.GetString(path + ".sniffing_scheme")
+	cfg.NoHealthcheck = config.GetBool(path + ".disable_healthcheck")
 
 	return cfg
 }

--- a/analyzer/storage.go
+++ b/analyzer/storage.go
@@ -41,7 +41,15 @@ func NewESConfig(name ...string) es.Config {
 		path += "elasticsearch"
 	}
 
-	cfg.ElasticHost = config.GetStringSlice(path + ".hosts")
+	// To be backwards compatible, check if .host key (old) has a string value.
+	// In that case, use that value as .hosts (converting the ip:port to http://ip:port)
+	// .host will have preference over .hosts
+	cfg.ElasticHosts = config.GetStringSlice(path + ".hosts")
+	oldElasticHost := config.GetString(path + ".host")
+	if oldElasticHost != "" {
+		cfg.ElasticHosts = []string{fmt.Sprintf("http://%s", oldElasticHost)}
+	}
+
 	cfg.InsecureSkipVerify = config.GetBool(path + ".ssl_insecure")
 	cfg.Auth = config.GetStringMapString(path + ".auth")
 	cfg.BulkMaxDelay = config.GetInt(path + ".bulk_maxdelay")

--- a/config/config.go
+++ b/config/config.go
@@ -197,18 +197,22 @@ func init() {
 	cfg.SetDefault("rbac.model.policy_effect", []string{"some(where (p_eft == allow)) && !some(where (p_eft == deny))"})
 	cfg.SetDefault("rbac.model.matchers", []string{"g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act"})
 
-	cfg.SetDefault("storage.elasticsearch.driver", "elasticsearch")  // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.elasticsearch.host", "127.0.0.1:9200")   // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.elasticsearch.bulk_maxdelay", 5)         // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.elasticsearch.index_age_limit", 0)       // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.elasticsearch.index_entries_limit", 0)   // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.elasticsearch.indices_to_keep", 0)       // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.memory.driver", "memory")                // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.orientdb.driver", "orientdb")            // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.orientdb.addr", "http://localhost:2480") // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.orientdb.database", "Skydive")           // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.orientdb.username", "root")              // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.orientdb.password", "root")              // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.elasticsearch.driver", "elasticsearch")           // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.elasticsearch.hosts", []string{"127.0.0.1:9200"}) // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.elasticsearch.ssl_insecure", false)               // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.elasticsearch.bulk_maxdelay", 5)                  // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.elasticsearch.index_age_limit", 0)                // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.elasticsearch.index_entries_limit", 0)            // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.elasticsearch.indices_to_keep", 0)                // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.elasticsearch.disable_sniffing", false)           // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.elasticsearch.sniffing_scheme", "http")           // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.elasticsearch.disable_healthcheck", false)        // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.memory.driver", "memory")                         // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.orientdb.driver", "orientdb")                     // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.orientdb.addr", "http://localhost:2480")          // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.orientdb.database", "Skydive")                    // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.orientdb.username", "root")                       // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.orientdb.password", "root")                       // defined for backward compatibility and to set defaults
 
 	cfg.SetDefault("ui", map[string]interface{}{})
 

--- a/config/config.go
+++ b/config/config.go
@@ -197,22 +197,22 @@ func init() {
 	cfg.SetDefault("rbac.model.policy_effect", []string{"some(where (p_eft == allow)) && !some(where (p_eft == deny))"})
 	cfg.SetDefault("rbac.model.matchers", []string{"g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act"})
 
-	cfg.SetDefault("storage.elasticsearch.driver", "elasticsearch")           // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.elasticsearch.hosts", []string{"127.0.0.1:9200"}) // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.elasticsearch.ssl_insecure", false)               // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.elasticsearch.bulk_maxdelay", 5)                  // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.elasticsearch.index_age_limit", 0)                // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.elasticsearch.index_entries_limit", 0)            // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.elasticsearch.indices_to_keep", 0)                // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.elasticsearch.disable_sniffing", false)           // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.elasticsearch.sniffing_scheme", "http")           // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.elasticsearch.disable_healthcheck", false)        // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.memory.driver", "memory")                         // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.orientdb.driver", "orientdb")                     // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.orientdb.addr", "http://localhost:2480")          // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.orientdb.database", "Skydive")                    // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.orientdb.username", "root")                       // defined for backward compatibility and to set defaults
-	cfg.SetDefault("storage.orientdb.password", "root")                       // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.elasticsearch.driver", "elasticsearch")                  // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.elasticsearch.hosts", []string{"http://127.0.0.1:9200"}) // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.elasticsearch.ssl_insecure", false)                      // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.elasticsearch.bulk_maxdelay", 5)                         // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.elasticsearch.index_age_limit", 0)                       // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.elasticsearch.index_entries_limit", 0)                   // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.elasticsearch.indices_to_keep", 0)                       // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.elasticsearch.disable_sniffing", false)                  // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.elasticsearch.sniffing_scheme", "http")                  // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.elasticsearch.disable_healthcheck", false)               // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.memory.driver", "memory")                                // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.orientdb.driver", "orientdb")                            // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.orientdb.addr", "http://localhost:2480")                 // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.orientdb.database", "Skydive")                           // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.orientdb.username", "root")                              // defined for backward compatibility and to set defaults
+	cfg.SetDefault("storage.orientdb.password", "root")                              // defined for backward compatibility and to set defaults
 
 	cfg.SetDefault("ui", map[string]interface{}{})
 

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -383,7 +383,17 @@ storage:
   # Elasticsearch backend information.
   myelasticsearch:
     # driver: elasticsearch
-    # host: 127.0.0.1:9200
+    # hosts:
+    #   - http://127.0.0.1:9200
+
+    # Disable TLS certificate verification
+    # Default: false
+    # ssl_insecure: true
+
+    # Basic auth
+    # auth:
+    #   username: user
+    #   password: secret
 
     # Define the maximum delay before flushing document
     # bulk_maxdelay: 5
@@ -398,6 +408,19 @@ storage:
     # The number of indices to keep before deleting.
     # A value of 0 specifies no limit (i.e. indices will never be deleted)
     # indices_to_keep: 0
+
+    # Snif Nodes Info API to get all the nodes in the cluster
+    # See https://pkg.go.dev/gopkg.in/olivere/elastic.v2?tab=doc#NewClient
+    # Default: false
+    # disable_sniffing: true
+
+    # Define the scheme to connect to discovered nodes via sniffing
+    # Default: http
+    # sniffing_scheme: https
+
+    # Disable health check
+    # Default: false
+    # disable_healthcheck: true
 
   # OrientDB backend information.
   myorientdb:

--- a/graffiti/storage/elasticsearch/client.go
+++ b/graffiti/storage/elasticsearch/client.go
@@ -47,7 +47,7 @@ const (
 
 // Config describes configuration for elasticsearch
 type Config struct {
-	ElasticHost        []string
+	ElasticHosts       []string
 	InsecureSkipVerify bool
 	Auth               map[string]string
 	BulkMaxDelay       int
@@ -533,7 +533,7 @@ func NewClient(indices []Index, cfg Config, electionService etcd.MasterElectionS
 	}
 
 	client := &Client{
-		hosts:          cfg.ElasticHost,
+		hosts:          cfg.ElasticHosts,
 		cfg:            cfg,
 		indices:        indicesMap,
 		masterElection: electionService.NewElection("/elections/es-index-creator-" + u5.String()),

--- a/graffiti/storage/elasticsearch/client.go
+++ b/graffiti/storage/elasticsearch/client.go
@@ -19,9 +19,10 @@ package elasticsearch
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
-	"net/url"
+	"net/http"
 	"sort"
 	"strings"
 	"sync"
@@ -31,7 +32,6 @@ import (
 	version "github.com/hashicorp/go-version"
 	uuid "github.com/nu7hatch/gouuid"
 	elastic "github.com/olivere/elastic/v7"
-	esconfig "github.com/olivere/elastic/v7/config"
 
 	etcd "github.com/skydive-project/skydive/graffiti/etcd/client"
 	"github.com/skydive-project/skydive/graffiti/filters"
@@ -42,17 +42,21 @@ import (
 const (
 	schemaVersion  = "12"
 	indexPrefix    = "skydive"
-	minimalVersion = "5.5"
+	minimalVersion = "7.0"
 )
 
 // Config describes configuration for elasticsearch
 type Config struct {
-	ElasticHost  string
-	BulkMaxDelay int
-	EntriesLimit int
-	AgeLimit     int
-	IndicesLimit int
-	NoSniffing   bool
+	ElasticHost        []string
+	InsecureSkipVerify bool
+	Auth               map[string]string
+	BulkMaxDelay       int
+	EntriesLimit       int
+	AgeLimit           int
+	IndicesLimit       int
+	NoSniffing         bool
+	SniffingScheme     string
+	NoHealthcheck      bool
 }
 
 // ClientInterface describes the mechanism API of ElasticSearch database client
@@ -79,7 +83,7 @@ type Index struct {
 // Client describes a ElasticSearch client connection
 type Client struct {
 	sync.RWMutex
-	url            *url.URL
+	hosts          []string
 	esClient       *elastic.Client
 	bulkProcessor  *elastic.BulkProcessor
 	started        atomic.Value
@@ -88,6 +92,30 @@ type Client struct {
 	rollService    *rollIndexService
 	listeners      []storage.EventListener
 	masterElection etcd.MasterElection
+}
+
+// TraceLogger implements the oliviere/elastic Logger interface to be used with trace messages
+type TraceLogger struct{}
+
+// Printf sends elastic trace messages to skydive logger Debug
+func (l TraceLogger) Printf(format string, v ...interface{}) {
+	logging.GetLogger().Debugf(format, v)
+}
+
+// InfoLogger implements the oliviere/elastic Logger interface to be used with info messages
+type InfoLogger struct{}
+
+// Printf sends elastic info messages to skydive logger Info
+func (l InfoLogger) Printf(format string, v ...interface{}) {
+	logging.GetLogger().Infof(format, v)
+}
+
+// ErrorLogger implements the oliviere/elastic Logger interface to be used with error mesages
+type ErrorLogger struct{}
+
+// Printf sends elastic error messages to skydive logger Error
+func (l ErrorLogger) Printf(format string, v ...interface{}) {
+	logging.GetLogger().Errorf(format, v)
 }
 
 var (
@@ -184,19 +212,30 @@ func (c *Client) createIndices() error {
 }
 
 func (c *Client) start() error {
-	esConfig, err := esconfig.Parse(c.url.String())
-	if err != nil {
-		return err
+	httpClient := http.DefaultClient
+
+	if c.cfg.InsecureSkipVerify {
+		logging.GetLogger().Warning("Skipping SSL certificates verification")
+
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		httpClient = &http.Client{Transport: tr}
 	}
 
-	if c.cfg.NoSniffing {
-		esConfig.Sniff = new(bool)
-		*esConfig.Sniff = false
-	}
-
-	esClient, err := elastic.NewClientFromConfig(esConfig)
+	esClient, err := elastic.NewClient(
+		elastic.SetHttpClient(httpClient),
+		elastic.SetURL(c.hosts...),
+		elastic.SetBasicAuth(c.cfg.Auth["username"], c.cfg.Auth["password"]),
+		elastic.SetSniff(!c.cfg.NoSniffing),
+		elastic.SetScheme(c.cfg.SniffingScheme),
+		elastic.SetHealthcheck(!c.cfg.NoHealthcheck),
+		elastic.SetTraceLog(TraceLogger{}),
+		elastic.SetInfoLog(InfoLogger{}),
+		elastic.SetErrorLog(ErrorLogger{}),
+	)
 	if err != nil {
-		return err
+		return fmt.Errorf("creating elasticsearch client: %s", err)
 	}
 	c.esClient = esClient
 
@@ -217,14 +256,22 @@ func (c *Client) start() error {
 		FlushInterval(time.Duration(c.cfg.BulkMaxDelay) * time.Second).
 		Do(context.Background())
 	if err != nil {
-		return err
+		return fmt.Errorf("creating elasticsearch bulk processor: %s", err)
 	}
 
 	c.bulkProcessor = bulkProcessor
 
-	vt, err := esClient.ElasticsearchVersion(c.url.String())
+	// Get the version from the first working node
+	// Return error if all nodes are failing
+	var vt string
+	for _, host := range c.hosts {
+		vt, err = esClient.ElasticsearchVersion(host)
+		if err == nil {
+			break
+		}
+	}
 	if err != nil {
-		return fmt.Errorf("Unable to get the version: %s", vt)
+		return fmt.Errorf("Unable to get the version: %s", err)
 	}
 
 	v, err := version.NewVersion(vt)
@@ -451,19 +498,6 @@ func (c *Client) Started() bool {
 	return c.started.Load() == true
 }
 
-func urlFromHost(host string) (*url.URL, error) {
-	urlStr := host
-	if !strings.HasPrefix(urlStr, "http://") && !strings.HasPrefix(urlStr, "https://") {
-		urlStr = "http://" + urlStr
-	}
-
-	url, err := url.Parse(urlStr)
-	if err != nil || url.Port() == "" {
-		return nil, ErrBadConfig(fmt.Sprintf("wrong url format, %s", urlStr))
-	}
-	return url, nil
-}
-
 // GetClient returns the elastic client object
 func (c *Client) GetClient() *elastic.Client {
 	return c.esClient
@@ -478,11 +512,6 @@ func (c *Client) AddEventListener(listener storage.EventListener) {
 
 // NewClient creates a new ElasticSearch client based on configuration
 func NewClient(indices []Index, cfg Config, electionService etcd.MasterElectionService) (*Client, error) {
-	url, err := urlFromHost(cfg.ElasticHost)
-	if err != nil {
-		return nil, err
-	}
-
 	var names []string
 
 	indicesMap := make(map[string]Index, 0)
@@ -504,7 +533,7 @@ func NewClient(indices []Index, cfg Config, electionService etcd.MasterElectionS
 	}
 
 	client := &Client{
-		url:            url,
+		hosts:          cfg.ElasticHost,
 		cfg:            cfg,
 		indices:        indicesMap,
 		masterElection: electionService.NewElection("/elections/es-index-creator-" + u5.String()),

--- a/tests/elasticsearch_test.go
+++ b/tests/elasticsearch_test.go
@@ -93,7 +93,7 @@ func TestRollingSimple(t *testing.T) {
 	}
 
 	cfg := es.Config{
-		ElasticHost:  "localhost:9200",
+		ElasticHosts: []string{"http://localhost:9200"},
 		EntriesLimit: 10,
 	}
 


### PR DESCRIPTION
Allow skydive to connect to Elasticsearch servers with TLS but invalid
certs.

For Elasticsearch clusters, be able to only define a single endpoint
creates a SPoF at start time. Allow to pass an array of endpoints.
This breaks the current config, which expect an string in the key
"host".
Now is an slice in the key "hosts".

Expose configuration for basic auth (previously supported with
http://user:password@...)

Add option 'disable_sniffing' to etc/skydive.yml.default

Fix a typo in the error string when Elasticsearch version could not be
obtained.

Some options that could be set previously in the Elasticsearch URL are
now not available: Errorlog, Tracelog, Infolog and Healthcheck
These options could be added easily if needed.
The elastic lib function handling the creation of a new elasticsearch
client from the URL is:
https://github.com/olivere/elastic/blob/v7.0.17/client.go#L431:6

TODO:
- [x] Create a [map](https://github.com/skydive-project/skydive/blob/master/config/config.go#L51) from ``host`` to ``hosts``
- [x] Check that a simple value in ``host`` is mapped as a single element array
- [ ] Tests to check backward compatibility (.host vs .hosts, URI vs host:port)