### PR TITLE
Do not convert hosts to IPs

### DIFF
--- a/graffiti/service/address.go
+++ b/graffiti/service/address.go
@@ -52,19 +52,8 @@ func AddressFromString(addressPort string) (Address, error) {
 		return Address{}, err
 	}
 
-	ips, err := net.LookupIP(host)
-	if err != nil {
-		return Address{}, err
-	}
-	if len(ips) == 0 {
-		return Address{}, fmt.Errorf("no address found for %s", host)
-	}
-
-	// just take the first address returned
-	addr := normalizeIPForURL(ips[0])
-
 	return Address{
-		Addr: addr,
+		Addr: host,
 		Port: portNum,
 	}, nil
 }

--- a/graffiti/service/address_test.go
+++ b/graffiti/service/address_test.go
@@ -18,7 +18,6 @@
 package service
 
 import (
-	"net"
 	"testing"
 )
 
@@ -32,7 +31,7 @@ func TestServiceAddress(t *testing.T) {
 	if err != nil {
 		t.Errorf("should not return an error: %s", err)
 	}
-	if (sa.Addr != "[::1]" && sa.Addr != "127.0.0.1") || sa.Port != 8080 {
+	if (sa.Addr != "[::1]" && sa.Addr != "127.0.0.1" && sa.Addr != "localhost") || sa.Port != 8080 {
 		t.Errorf("expected not found, got: %s", sa)
 	}
 
@@ -48,8 +47,7 @@ func TestServiceAddress(t *testing.T) {
 	if err != nil {
 		t.Errorf("should not return an error: %s", err)
 	}
-	ip := net.ParseIP(sa.Addr)
-	if ip == nil {
-		t.Errorf("IP expected not found, got: %s", sa)
+	if sa.Addr != "skydive.network" {
+		t.Errorf("Expected domain, got: %s", sa.Addr)
 	}
 }


### PR DESCRIPTION
While using TLS, certs use to be valid for domain names, not for IPs.
Without this patch, communication between skydive itself is done using
the IP, failing if the cert does not contain the IP.