### PR TITLE
ui: Fix typo in rule-detail parsing

### DIFF
--- a/statics/js/components/rule-detail.js
+++ b/statics/js/components/rule-detail.js
@@ -247,7 +247,7 @@ function summarizeGroup(group) {
     var content;
     var actions = bucket.Actions.map(textAction).join(',');
     if (bucket.Meta) {
-      content = bucket.meta.map(textMeta).join(',') + ',actions=' + actions;
+      content = bucket.Meta.map(textMeta).join(',') + ',actions=' + actions;
     } else {
       content = 'actions=' + actions;
     }


### PR DESCRIPTION
Currently, expanding the Rule detail view on a OvS Bridge fails with:

```
vue.min-2.5.16.js:6 TypeError: Cannot read property 'map' of undefined
    at textBucket (rule-detail.js:250)
    at Array.map (<anonymous>)
    at summarizeGroup (rule-detail.js:257)
    at BridgeLayout.extract (rule-detail.js:404)
    at BridgeLayout.compute (rule-detail.js:433)
    at new BridgeLayout (rule-detail.js:376)
    at o.layout (rule-detail.js:786)
    at St.get (vue.min-2.5.16.js:6)
    at St.evaluate (vue.min-2.5.16.js:6)
    at o.layout (vue.min-2.5.16.js:6)
```

The fix is quite simple :)