### PR TITLE
k8s: wait for k8s resources to be deleted in tests

### DIFF
--- a/tests/k8s_test.go
+++ b/tests/k8s_test.go
@@ -48,8 +48,7 @@ func setupFromConfigPath(path string) []Cmd {
 
 func tearDownFromConfigPath(path string) []Cmd {
 	return []Cmd{
-		{"kubectl delete --grace-period=0 --force -f " + path, false},
-		{"sleep 10", true},
+		{"kubectl delete --wait=true --grace-period=0 --force -f " + path, false},
 	}
 }
 


### PR DESCRIPTION
skip go-fmt
skip unit-tests
skip compile-tests
skip functional-tests-backend-elasticsearch
skip functional-tests-backend-orientdb
skip functional-hw-tests
skip scale-tests
skip cdd-overview-tests