### PR TITLE
ovn: remove duplicated goroutine

### DIFF
--- a/topology/probes/ovn/ovn.go
+++ b/topology/probes/ovn/ovn.go
@@ -508,28 +508,6 @@ func (p *Probe) Do(ctx context.Context, wg *sync.WaitGroup) error {
 
 	p.bundle.Start()
 
-	wg.Add(1)
-
-	go func() {
-		defer func() {
-			wg.Done()
-			p.bundle.Stop()
-		}()
-
-		for {
-			select {
-			case eventCallback, ok := <-p.eventChan:
-				if !ok {
-					return
-				}
-				eventCallback()
-			case <-ctx.Done():
-				p.ovndbapi.Close()
-				return
-			}
-		}
-	}()
-
 	// Initial synchronization
 	switches, _ := p.ovndbapi.LSList()
 	for _, ls := range switches {


### PR DESCRIPTION
After #2288 was merged we ended up with a duplicated goroutine.
Remove it.