### PR TITLE
Bump to version 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.27.0] - 2020-12-07
+### Added
+
+- Persist graph element across analyzer restarts
+- Add new block device topology probe
+- Add node and edge APIs
+- Add PATCH method to modify resources
+- Add authentication definition to swagger description
+- Add SSL support to Open vSwitch OpenFlow parser
+- Allow removing nodes and edges in batch from the CLI
+- Support multiple elasticsearch hosts, SSL and authentication
+
+### Changed
+
+- Bump to elasticsearch v7
+- Extract graph engine to its own standalone package 'graffiti'
+- Move hardware related root node data to a probe
+- Use 'flattened' type in elasticsearch to avoid mapping explosion
+
 ## [0.26.0] - 2019-10-18
 ### Added
 

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,9 @@ skydive.clean:
 
 .PHONY: moddownload
 moddownload:
+ifneq ($(OFFLINE), true)
 	go mod download
+endif
 
 .PHONY: genlocalfiles
 genlocalfiles: $(EXTRA_BUILD_TARGET) .proto .bindata .gendecoder .easyjson .vppbinapi

--- a/contrib/ansible/roles/skydive_common/defaults/main.yml
+++ b/contrib/ansible/roles/skydive_common/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-skydive_release: v0.26.0
+skydive_release: v0.27.0
 skydive_docker_registry: docker.io
 skydive_docker_image_tag: latest
 skydive_config_file: /etc/skydive/skydive.yml

--- a/contrib/packaging/rpm/skydive.spec
+++ b/contrib/packaging/rpm/skydive.spec
@@ -118,7 +118,7 @@ This package installs and sets up the SELinux policy security module for Skydive
 
 %build
 export GOPATH=%{_builddir}/skydive-%{fullver}
-make build VERSION=%{fullver} LDFLAGS=%{ldflags} GO111MODULE=off %{with_features}
+make build VERSION=%{fullver} LDFLAGS=%{ldflags} OFFLINE=true GOFLAGS=-mod=vendor %{with_features}
 %{_builddir}/skydive-%{fullver}/src/%{import_path}/skydive bash-completion
 
 # SELinux build
@@ -168,7 +168,7 @@ fi
 %systemd_preun %{basename:%{name}-agent.service}
 
 %postun agent
-%systemd_postun
+%systemd_postun %{basename:%{name}-agent.service}
 if %{_sbindir}/selinuxenabled && [ "$1" = "0" ] ; then
     set +e
     %{_sbindir}/semanage port -d -t skydive_agent_sflow_ports_t -p udp 6343
@@ -192,7 +192,7 @@ fi
 %systemd_preun %{basename:%{name}-analyzer.service}
 
 %postun analyzer
-%systemd_postun
+%systemd_postun %{basename:%{name}-analyzer.service}
 if %{_sbindir}/selinuxenabled && [ "$1" = "0" ] ; then
     set +e
     %{_sbindir}/semanage port -d -t skydive_etcd_ports_t -p tcp 12379-12380

--- a/contrib/packaging/rpm/skydive.spec
+++ b/contrib/packaging/rpm/skydive.spec
@@ -34,7 +34,7 @@
 %endif
 %endif
 
-%{!?fullver:%global fullver 0.26.0}
+%{!?fullver:%global fullver 0.27.0}
 %define version %{extractversion %{fullver}}
 %{!?tag:%global tag 1}
 
@@ -248,6 +248,9 @@ fi
 %attr(0644,root,root) %{_mandir}/man8/skydive-selinux.8.*
 
 %changelog
+* Mon Dec 7 2020 Sylvain Baubeau <lebauce@gmail.com> - 0.27.0-1
+- Bump to version 0.27.0
+
 * Fri Oct 18 2019 Sylvain Baubeau <sbaubeau@redhat.com> - 0.26.0-1
 - Bump to version 0.26.0
 

--- a/contrib/packaging/rpm/skydive.te.fedora
+++ b/contrib/packaging/rpm/skydive.te.fedora
@@ -1,4 +1,4 @@
-policy_module(skydive, 0.26.0)
+policy_module(skydive, 0.27.0)
 
 ########################################
 #

--- a/contrib/packaging/rpm/skydive.te.rhel
+++ b/contrib/packaging/rpm/skydive.te.rhel
@@ -1,4 +1,4 @@
-policy_module(skydive, 0.26.0)
+policy_module(skydive, 0.27.0)
 
 ########################################
 #

--- a/contrib/packaging/rpm/specfile-update-bundles
+++ b/contrib/packaging/rpm/specfile-update-bundles
@@ -1,23 +1,23 @@
 #!/usr/bin/python
 
-import commands
 import json
+import subprocess
 import sys
 
 BUNDLE_MARKER = "### AUTO-BUNDLED-GEN-ENTRY-POINT"
 
 def usage():
-    print sys.argv[0], "<go.mod> <specfile>"
+    print(sys.argv[0], "<go.mod> <specfile>")
 
 if len(sys.argv) != 3:
     usage()
     sys.exit(0)
 
 provides = []
-mod = json.loads(commands.getoutput("go mod edit -json " + sys.argv[1]))
+mod = json.loads(subprocess.check_output(["go", "mod", "edit", "-json", sys.argv[1]]))
 for package in mod["Require"]:
     provides.append("Provides: bundled(golang(%s)) = %s" % (package["Path"], package["Version"].split("-")[-1].split("+")[0]))
 
 spec = open(sys.argv[2]).read()
 spec = spec.replace(BUNDLE_MARKER, "\n".join(provides))
-print spec
+print(spec)

--- a/graffiti/api/server/server.go
+++ b/graffiti/api/server/server.go
@@ -22,7 +22,7 @@
 //     Schemes: http, https
 //     Host: localhost:8082
 //     BasePath: /api
-//     Version: 0.26.0
+//     Version: 0.27.0
 //     License: Apache http://opensource.org/licenses/Apache-2.0
 //     Contact: Skydive mailing list <skydive-dev@redhat.com>
 //

--- a/scripts/ci/create-vagrant-boxes.sh
+++ b/scripts/ci/create-vagrant-boxes.sh
@@ -13,7 +13,7 @@ dir="$(dirname "$0")"
 
 # SKYDIVE_RELEASE is a release tag (like "v0.1.2") or "master"
 export SKYDIVE_RELEASE=master
-BOXVERSION=0.27.0.alpha
+BOXVERSION=0.28.0.alpha
 tagname=$(git show-ref --tags $REF)
 if [ -n "$tagname" ]; then
     export SKYDIVE_RELEASE=$(echo $tagname | awk -F "/" "{print \$NF}")


### PR DESCRIPTION
skip go-fmt
skip unit-tests
skip compile-tests
skip functional-tests-backend-elasticsearch
skip functional-tests-backend-orientdb
skip scale-tests
skip cdd-overview-tests
skip k8s-tests
