### PR TITLE
Elasticsearch: define several hosts and allow invalid certs

### DIFF
--- a/analyzer/server.go
+++ b/analyzer/server.go
@@ -21,6 +21,7 @@ package analyzer
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -34,6 +35,7 @@ import (
 	ondemand "github.com/skydive-project/skydive/flow/ondemand/client"
 	"github.com/skydive-project/skydive/flow/server"
 	"github.com/skydive-project/skydive/flow/storage"
+	"github.com/skydive-project/skydive/graffiti/api/rest"
 	etcdclient "github.com/skydive-project/skydive/graffiti/etcd/client"
 	etcdserver "github.com/skydive-project/skydive/graffiti/etcd/server"
 	"github.com/skydive-project/skydive/graffiti/graph"
@@ -120,7 +122,10 @@ func (s *Server) createStartupCapture() error {
 	logging.GetLogger().Infof("Invoke capturing of type '%s' from startup with gremlin: %s and BPF: %s", captureType, gremlin, bpf)
 	capture := types.NewCapture(gremlin, bpf)
 	capture.Type = captureType
-	return apiHandler.Create(capture, nil)
+	if err := apiHandler.Create(capture, nil); err != nil && !errors.Is(err, rest.ErrDuplicatedResource) {
+		return err
+	}
+	return nil
 }
 
 // Start the analyzer server

--- a/analyzer/storage.go
+++ b/analyzer/storage.go
@@ -41,15 +41,27 @@ func NewESConfig(name ...string) es.Config {
 		path += "elasticsearch"
 	}
 
-	cfg.ElasticHost = config.GetString(path + ".host")
+	// To be backwards compatible, check if .host key (old) has a string value.
+	// In that case, use that value as .hosts (converting the ip:port to http://ip:port)
+	// .host will have preference over .hosts
+	cfg.ElasticHosts = config.GetStringSlice(path + ".hosts")
+	oldElasticHost := config.GetString(path + ".host")
+	if oldElasticHost != "" {
+		cfg.ElasticHosts = []string{fmt.Sprintf("http://%s", oldElasticHost)}
+	}
+
+	cfg.InsecureSkipVerify = config.GetBool(path + ".ssl_insecure")
+	cfg.Username = config.GetString(path + ".auth.username")
+	cfg.Password = config.GetString(path + ".auth.password")
 	cfg.BulkMaxDelay = config.GetInt(path + ".bulk_maxdelay")
 	cfg.TotalFieldsLimit = config.GetInt(path + ".total_fields_limit")
-
 	cfg.EntriesLimit = config.GetInt(path + ".index_entries_limit")
 	cfg.AgeLimit = config.GetInt(path + ".index_age_limit")
 	cfg.IndicesLimit = config.GetInt(path + ".indices_to_keep")
 	cfg.NoSniffing = config.GetBool(path + ".disable_sniffing")
 	cfg.IndexPrefix = config.GetString(path + ".index_prefix")
+	cfg.NoHealthcheck = config.GetBool(path + ".disable_healthcheck")
+	cfg.Debug = config.GetBool(path + ".debug")
 
 	return cfg
 }

--- a/config/config.go
+++ b/config/config.go
@@ -197,9 +197,10 @@ func init() {
 	cfg.SetDefault("rbac.model.policy_effect", []string{"some(where (p_eft == allow)) && !some(where (p_eft == deny))"})
 	cfg.SetDefault("rbac.model.matchers", []string{"g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act"})
 
-	// defined for backward compatibility and to set defaults
+	// storage section is defined for backward compatibility and to set defaults
 	cfg.SetDefault("storage.elasticsearch.driver", "elasticsearch")
-	cfg.SetDefault("storage.elasticsearch.host", "127.0.0.1:9200")
+	cfg.SetDefault("storage.elasticsearch.hosts", []string{"http://127.0.0.1:9200"})
+	cfg.SetDefault("storage.elasticsearch.ssl_insecure", false)
 	cfg.SetDefault("storage.elasticsearch.bulk_maxdelay", 5)
 	cfg.SetDefault("storage.elasticsearch.total_fields_limit", 1000)
 	cfg.SetDefault("storage.elasticsearch.index_age_limit", 0)
@@ -219,6 +220,8 @@ func init() {
 		"Metadata.OVN.Options",
 		"Metadata.OVN.IPv6RAConfigs",
 	})
+	cfg.SetDefault("storage.elasticsearch.disable_sniffing", false)
+	cfg.SetDefault("storage.elasticsearch.disable_healthcheck", false)
 	cfg.SetDefault("storage.memory.driver", "memory")
 	cfg.SetDefault("storage.orientdb.driver", "orientdb")
 	cfg.SetDefault("storage.orientdb.addr", "http://localhost:2480")

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -383,7 +383,17 @@ storage:
   # Elasticsearch backend information.
   myelasticsearch:
     # driver: elasticsearch
-    # host: 127.0.0.1:9200
+    # hosts:
+    #   - http://127.0.0.1:9200
+
+    # Disable TLS certificate verification
+    # Default: false
+    # ssl_insecure: true
+
+    # Basic auth
+    # auth:
+    #   username: user
+    #   password: secret
 
     # Define the maximum delay before flushing document
     # bulk_maxdelay: 5
@@ -415,6 +425,18 @@ storage:
     #   - Metadata.OVN.ExtID
     #   - Metadata.OVN.Options
     #   - Metadata.OVN.IPv6RAConfigs
+
+    # Snif Nodes Info API to get all the nodes in the cluster
+    # See https://pkg.go.dev/gopkg.in/olivere/elastic.v2?tab=doc#NewClient
+    # Default: false
+    # disable_sniffing: true
+
+    # Disable health check
+    # Default: false
+    # disable_healthcheck: true
+
+    # Debug queries
+    # debug: false
 
   # OrientDB backend information.
   myorientdb:

--- a/graffiti/go.mod
+++ b/graffiti/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
 	github.com/olivere/elastic/v7 v7.0.21
 	github.com/pierrec/xxHash v0.1.5
+	github.com/pkg/errors v0.9.1
 	github.com/pmylund/go-cache v2.1.0+incompatible
 	github.com/safchain/insanelock v0.0.0-20200217234559-cfbf166e05b3
 	github.com/skydive-project/go-debouncer v1.0.0

--- a/scripts/ci/run-tests-utils.sh
+++ b/scripts/ci/run-tests-utils.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+
+set -v
+
 network_setup() {
         sudo iptables -F
         sudo iptables -P FORWARD ACCEPT

--- a/tests/elasticsearch_test.go
+++ b/tests/elasticsearch_test.go
@@ -93,7 +93,7 @@ func TestRollingSimple(t *testing.T) {
 	}
 
 	cfg := es.Config{
-		ElasticHost:      "localhost:9201",
+		ElasticHosts:     []string{"http://localhost:9200"},
 		EntriesLimit:     10,
 		IndexPrefix:      "skydive_",
 		TotalFieldsLimit: 1000,

--- a/tests/elasticsearch_test.go
+++ b/tests/elasticsearch_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/avast/retry-go"
 
+	"github.com/skydive-project/skydive/config"
 	etcd "github.com/skydive-project/skydive/graffiti/etcd/client"
 	"github.com/skydive-project/skydive/graffiti/filters"
 	es "github.com/skydive-project/skydive/graffiti/storage/elasticsearch"
@@ -93,7 +94,7 @@ func TestRollingSimple(t *testing.T) {
 	}
 
 	cfg := es.Config{
-		ElasticHosts:     []string{"http://localhost:9200"},
+		ElasticHosts:     []string{"http://" + config.GetString("storage.elasticsearch.host")},
 		EntriesLimit:     10,
 		IndexPrefix:      "skydive_",
 		TotalFieldsLimit: 1000,


### PR DESCRIPTION
Allow skydive to connect to Elasticsearch servers with TLS but invalid
certs.

For Elasticsearch clusters, be able to only define a single endpoint
creates a SPoF at start time. Allow to pass an array of endpoints.
This breaks the current config, which expect an string in the key
"host".
Now is an slice in the key "hosts".

Expose configuration for basic auth (previously supported with
http://user:password@...)

Add option 'disable_sniffing' to etc/skydive.yml.default, already
implemented.

Add option 'disable_healthcheck' to etc/skydive.yml.default.

Fix a typo in the error string when Elasticsearch version could not be
obtained.

Add olivere/elastic logging to skydive logger. Ease debuging problems
with Elasticsearch.