### PR TITLE
Elasticsearch: store prevRevision when fetching nodes/edges

### DIFF
--- a/graffiti/graph/elasticsearch.go
+++ b/graffiti/graph/elasticsearch.go
@@ -435,6 +435,16 @@ func (b *ElasticSearchBackend) GetEdges(t Context, m ElementMatcher, e ElementMa
 		edges = dedupEdges(edges)
 	}
 
+	for _, e := range edges {
+		raw, err := edgeToRaw(e)
+		if err != nil {
+			b.logger.Errorf("Ignoring edge, failing to marshal: %v", err)
+			continue
+		}
+
+		b.prevRevision[e.ID] = raw
+	}
+
 	return edges
 }
 
@@ -472,6 +482,16 @@ func (b *ElasticSearchBackend) GetNodes(t Context, m ElementMatcher, e ElementMa
 
 	if len(nodes) > 1 && t.TimePoint {
 		nodes = dedupNodes(nodes)
+	}
+
+	for _, n := range nodes {
+		raw, err := nodeToRaw(n)
+		if err != nil {
+			b.logger.Errorf("Ignoring node, failing to marshal: %v", err)
+			continue
+		}
+
+		b.prevRevision[n.ID] = raw
 	}
 
 	return nodes


### PR DESCRIPTION
When skydive fetchs nodes and edges at boot time from elasticsearch,
those nodes/edges were not being saved in the b.prevRevision map.

If later we tried to change the metadata of that nodes/edges (using
MetadataUpdated) it failed because it does not recognise that node/edge.

This commits modifies the GetNodes and GetEdges functions to store into
b.prevRevision nodes/edges fetched from Elasticsearch.

Fixes #2328 