### PR TITLE
Charts: added make command to run helm based elasticsearch/kibana

### DIFF
--- a/contrib/charts/Makefile
+++ b/contrib/charts/Makefile
@@ -1,4 +1,6 @@
 SUBDIRS := \
+	elasticsearch \
+	kibana \
 	skydive-analyzer \
 	skydive-agent
 

--- a/contrib/charts/elasticsearch/Makefile
+++ b/contrib/charts/elasticsearch/Makefile
@@ -1,0 +1,52 @@
+include ../../../.mk/k8s.mk
+
+# must be within the range of k8s nodePort
+ES_NODEPORT?=30020
+ES_PORT?=9200
+ES_SERVICE?=elasticsearch-master
+
+.PHONY: repo
+repo: $(TOOLSBIN)/helm
+	helm repo remove elastic https://helm.elastic.co 2>/dev/null || true
+	helm repo add elastic https://helm.elastic.co
+	helm repo update
+
+.PHONY: uninstall
+uninstall: $(TOOLSBIN)/helm
+	helm uninstall elasticsearch 2>/dev/null || true
+
+.PHONY: install
+install: $(TOOLSBIN)/helm
+	helm install elasticsearch elastic/elasticsearch \
+		--set masterService=${ES_SERVICE} \
+		--set service.port=${ES_PORT} \
+		--set service.type=NodePort \
+		--set service.nodePort=${ES_NODEPORT}
+
+.PHONY: status
+status: $(TOOLSBIN)/kubectl
+	kubectl get all -l app=elasticsearch-master
+
+.PHONY: logs
+logs: $(TOOLSBIN)/kubectl
+	kubectl logs -f -l app=elasticsearch-master
+
+.PHONY: verify
+verify:
+	curl http://localhost:${ES_NODEPORT}
+
+.PHONY: port-forward
+port-forward: $(TOOLSBIN)/kubectl
+	kubectl port-forward service/${ES_SERVICE} ${ES_PORT}:${ES_PORT}
+
+.PHONY: delete
+delete:
+	curl -X DELETE http://localhost:${ES_NODEPORT}/_all
+
+.PHONY: indices
+indices:
+	curl http://localhost:${ES_NODEPORT}/_cat/indices
+
+.PHONY: help
+help:
+	@echo "ElasticSearch is running at: http://localhost:${ES_NODEPORT}"

--- a/contrib/charts/kibana/Makefile
+++ b/contrib/charts/kibana/Makefile
@@ -1,0 +1,45 @@
+include ../../../.mk/k8s.mk
+
+# must be within the range of k8s nodePort
+KIBANA_NODEPORT?=30030
+KIBANA_PORT?=5601
+ES_SERVICE?=elasticsearch-master
+ES_PORT?=9200
+
+.PHONY: repo
+repo: $(TOOLSBIN)/helm
+	helm repo remove elastic https://helm.elastic.co 2>/dev/null || true
+	helm repo add elastic https://helm.elastic.co
+	helm repo update
+
+.PHONY: uninstall
+uninstall: $(TOOLSBIN)/helm
+	helm uninstall kibana 2>/dev/null || true
+
+.PHONY: install
+install: $(TOOLSBIN)/helm
+	helm install kibana elastic/kibana \
+		--set elasticsearchHosts="http://${ES_SERVICE}:${ES_PORT}" \
+		--set service.port=${KIBANA_PORT} \
+		--set service.type=NodePort \
+		--set service.nodePort=${KIBANA_NODEPORT}
+
+.PHONY: status
+status: $(TOOLSBIN)/kubectl
+	kubectl get all -l app=kibana
+
+.PHONY: logs
+logs: $(TOOLSBIN)/kubectl
+	kubectl logs -f -l app=kibana
+
+.PHONY: verify
+verify:
+	curl http://localhost:${KIBANA_NODEPORT}/app/dashborads
+
+.PHONY: port-forward
+port-forward: $(TOOLSBIN)/kubectl
+	kubectl port-forward service/kibana-kibana ${KIBANA_PORT}:${KIBANA_PORT}
+
+.PHONY: help
+help:
+	@echo "Kibana is running at: http://localhost:${ELASTIC_NODEPORT}"

--- a/contrib/charts/skydive-analyzer/Makefile
+++ b/contrib/charts/skydive-analyzer/Makefile
@@ -17,6 +17,7 @@ install: $(TOOLSBIN)/helm
 		--set service.port=${ANALYZER_PORT} \
 		--set service.nodePort=${ANALYZER_NODEPORT} \
 		--set etcd.nodePort=${ETCD_NODEPORT} \
+		--set elasticsearch.enabled=true \
 		--set newui.nodePort=${NEWUI_NODEPORT} \
 
 .PHONY: status


### PR DESCRIPTION
this is an extention above skydive-analyzer helm to enable it to use an external elasticsearch (which is visualized by kibana)

to use this:

```
cd charts
make install
```

now access skydive browser at http://localhost:30000
and access kibana with browser at http://localhost:30030

![image](https://user-images.githubusercontent.com/2760739/106012755-676d3980-60c4-11eb-9561-89c5629034a7.png)

![image](https://user-images.githubusercontent.com/2760739/106013113-d2b70b80-60c4-11eb-925f-173e6f034bd1.png)
