### PR TITLE
Charts: enabled newui in skydive-analyzer chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ ebpf/flow.o
 ebpf/flow-gre.o
 js/node_modules/
 .idea
+lint.json
+go.sum

--- a/.mk/tools.mk
+++ b/.mk/tools.mk
@@ -1,0 +1,42 @@
+TOOLSBIN := /usr/local/bin
+export PATH := $(TOOLSBIN):${PATH}
+
+$(TOOLSBIN)/k3d:
+	curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v3.0.0 bash
+
+$(TOOLSBIN)/kind:
+	GOBIN=$(TOOLSBIN) GO111MODULE=on sudo -E $(shell which go) get sigs.k8s.io/kind@v0.8.1
+
+$(TOOLSBIN)/helm:
+	curl -fsSL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | HELM_INSTALL_DIR=$(TOOLSBIN) sudo -E bash -
+
+$(TOOLSBIN)/kubectl:
+	sudo -E curl -fsSL -o $(TOOLSBIN)/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.20.1/bin/linux/amd64/kubectl && \
+		sudo -E chmod a+x $(TOOLSBIN)/kubectl
+
+# NodePorts are in the 30000-32767 range by default, which means a NodePort is
+# unlikely to match a service’s intended port (for example, 8080 may be exposed
+# as 31020).
+K3D_NODEPORTS?=30000-30100
+
+.PHONY: k3d
+k3d: k3d-delete k3d-create
+
+.PHONY: k3d-create
+k3d-create: $(TOOLSBIN)/k3d
+	k3d cluster create manager -p "${K3D_NODEPORTS}:${K3D_NODEPORTS}@server[0]" --agents 2
+
+.PHONY: k3d-delete
+k3d-delete: $(TOOLSBIN)/k3d
+	k3d cluster delete manager 2>/dev/null || true
+
+.PHONY: kind
+kind: kind-delete kind-create
+
+.PHONY: kind-create
+kind-create: $(TOOLSBIN)/kind
+	kind create cluster --name kind
+
+.PHONY: kind-delete
+kind-delete: $(TOOLSBIN)/kind
+	kind delete cluster --name kind 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -49,6 +49,21 @@ SKYDIVE_ETCD_DATA_DIR=/tmp SKYDIVE_ANALYZER_LISTEN=0.0.0.0:8082 sudo -E /usr/loc
 
 Open a browser to http://localhost:8082 to access the analyzer Web UI.
 
+### Helm
+
+If you are using Kubernetes then you can deploy skydive using helm directly from Git:
+
+```console
+helm plugin install https://github.com/aslafy-z/helm-git --version 0.10.0
+helm repo add skydive git+https://github.com/skydive-project/skydive@charts
+helm repo update
+helm install skydive-analyzer skydive/skydive-analyzer
+helm install skydive-agent skydive/skydive-agent
+kubectl port-forward service/skydive-analyzer 8082:8082&
+```
+
+Open a browser to http://localhost:8082 to access the analyzer Web UI.
+
 ### Docker
 
 ```console

--- a/charts/Makefile
+++ b/charts/Makefile
@@ -1,0 +1,11 @@
+SUBDIRS := \
+	skydive-analyzer \
+	skydive-agent
+
+.PHONY: install uninstall status
+install uninstall status:
+	for i in $(SUBDIRS); do \
+		make -C $$i $@; \
+	done
+
+include ../.mk/tools.mk

--- a/charts/skydive-agent/Chart.yaml
+++ b/charts/skydive-agent/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: skydive-agent
+description: Skydive Agent - Network Topology and Protocols Analyzer
+version: 0.0.0
+appVersion: 0.0.0
+icon: http://skydive.network/assets/images/logo.png

--- a/charts/skydive-agent/Makefile
+++ b/charts/skydive-agent/Makefile
@@ -1,0 +1,21 @@
+include ../../.mk/tools.mk
+
+ANALYZER_SERVICE?=skydive-analyzer
+ANALYZER_PORT?=8082
+
+.PHONY: uninstall
+uninstall: $(TOOLSBIN)/helm
+	helm uninstall skydive-agent 2>/dev/null || true
+
+.PHONY: install
+install: $(TOOLSBIN)/helm
+	helm install skydive-agent . \
+		--set analyzer.host=${ANALYZER_SERVICE}:${ANALYZER_PORT}
+
+.PHONY: status
+status: $(TOOLSBIN)/kubectl
+	kubectl get all -l app=skydive-agent
+
+.PHONY: logs
+logs: $(TOOLSBIN)/kubectl
+	kubectl logs -f -l app=skydive-agent

--- a/charts/skydive-agent/templates/_helpers.tpl
+++ b/charts/skydive-agent/templates/_helpers.tpl
@@ -1,0 +1,85 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "platform" -}}
+  {{- if (eq "linux/amd64" .Capabilities.KubeVersion.Platform) }}
+    {{- printf "-%s" "x86_64" }}
+  {{- end -}}
+  {{- if (eq "linux/ppc64le" .Capabilities.KubeVersion.Platform) }}
+    {{- printf "-%s" "ppc64le" }}
+  {{- end -}}
+  {{- if (eq "linux/s390x" .Capabilities.KubeVersion.Platform) }}
+    {{- printf "-%s" "s390x" }}
+  {{- end -}}
+{{- end -}}
+
+{{- define "arch" -}}
+  {{- if (eq "linux/amd64" .Capabilities.KubeVersion.Platform) }}
+    {{- printf "%s" "amd64" }}
+  {{- end -}}
+  {{- if (eq "linux/ppc64le" .Capabilities.KubeVersion.Platform) }}
+    {{- printf "%s" "ppc64le" }}
+  {{- end -}}
+  {{- if (eq "linux/s390x" .Capabilities.KubeVersion.Platform) }}
+    {{- printf "%s" "s390x" }}
+  {{- end -}}
+{{- end -}}
+
+{{/* affinity - https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ */}}
+
+{{- define "nodeaffinity" }}
+#https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityRequiredDuringScheduling" . }}
+    preferredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityPreferredDuringScheduling" . }}
+{{- end }}
+
+{{- define "nodeAffinityRequiredDuringScheduling" }}
+    #If you specify multiple nodeSelectorTerms associated with nodeAffinity types,
+    #then the pod can be scheduled onto a node if one of the nodeSelectorTerms is satisfied.
+    #
+    #If you specify multiple matchExpressions associated with nodeSelectorTerms,
+    #then the pod can be scheduled onto a node only if all matchExpressions can be satisfied.
+    #
+    #valid operators: In, NotIn, Exists, DoesNotExist, Gt, Lt
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+        {{- range $key, $val := (dict "amd64" "2" "ppc64le" "2" "s390x" "2") }}
+          {{- if gt ($val | trunc 1 | int) 0 }}
+          - {{ $key }}
+          {{- end }}
+        {{- end }}
+{{- end }}
+
+{{- define "nodeAffinityPreferredDuringScheduling" }}
+  {{- range $key, $val := (dict "amd64" "2" "ppc64le" "2" "s390x" "2") }}
+    {{- if gt ($val | trunc 1 | int) 0 }}
+    - weight: {{ $val | trunc 1 | int }}
+      preference:
+        matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+          - {{ $key }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/skydive-agent/templates/daemonset.yaml
+++ b/charts/skydive-agent/templates/daemonset.yaml
@@ -1,0 +1,121 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: skydive-agent
+  labels:
+    app: skydive-agent
+spec:
+  selector:
+    matchLabels:
+      app: skydive-agent
+  template:
+    metadata:
+      labels:
+        app: skydive-agent
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      securityContext:
+        runAsNonRoot: false
+      affinity:
+        {{- include "nodeaffinity" . | indent 6 }}
+      containers:
+      - name: skydive-agent
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.imagePullPolicy | default "" | quote }}
+        terminationMessagePolicy: FallbackToLogsOnError
+        args:
+        - agent
+        - --listen=0.0.0.0:8081
+        ports:
+        - containerPort: 8081
+        readinessProbe:
+          httpGet:
+            port: 8081
+            path: /api/status
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            port: 8081
+            path: /api/status
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          failureThreshold: 10
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        env:
+        - name: SKYDIVE_ANALYZERS
+          value: {{ .Values.analyzer.host }}
+        - name: SKYDIVE_FLOW_PROTOCOL
+          value: websocket
+        - name: SKYDIVE_FLOW_DEFAULT_LAYER_KEY_MODE
+          value: L3
+        - name: SKYDIVE_AGENT_TOPOLOGY_PROBES
+          value: "ovsdb docker runc"
+        - name: SKYDIVE_AGENT_TOPOLOGY_RUNC_RUN_PATH
+          value: /var/run/runc /var/run/runc-ctrs /var/run/containerd/runc
+      {{- if .Values.extraEnvs }}
+{{ toYaml .Values.extraEnvs | indent 8 }}
+      {{- end }}
+        securityContext:
+          privileged: true
+          readOnlyRootFilesystem: false
+          allowPrivilegeEscalation: true
+          runAsNonRoot: false
+          runAsUser: 0
+          capabilities:
+            add:
+            - all
+        volumeMounts:
+        - name: docker
+          mountPath: /var/run/docker.sock
+        - name: run
+          mountPath: /host/run
+        - name: ovsdb
+          mountPath: /var/run/openvswitch/db.sock
+        - name: runc
+          mountPath: /var/run/runc
+        - name: runc-ctrs
+          mountPath: /var/run/runc-ctrs
+        - name: containerd-runc
+          mountPath: /var/run/containerd/runc
+        - name: data-kubelet
+          mountPath: /var/data/kubelet
+        - name: lib-kubelet
+          mountPath: /var/lib/kubelet
+        - name: data-openshiftvolumes
+          mountPath: /var/data/openshiftvolumes
+        - name: lib-origin
+          mountPath: /var/lib/origin
+      volumes:
+      - name: docker
+        hostPath:
+          path: /var/run/docker.sock
+      - name: run
+        hostPath:
+          path: /var/run/netns
+      - name: ovsdb
+        hostPath:
+          path: /var/run/openvswitch/db.sock
+      - name: runc
+        hostPath:
+          path: /var/run/runc
+      - name: runc-ctrs
+        hostPath:
+          path: /var/run/runc-ctrs
+      - name: containerd-runc
+        hostPath:
+          path: /var/run/containerd/runc
+      - name: data-kubelet
+        hostPath:
+          path: /var/data/kubelet
+      - name: lib-kubelet
+        hostPath:
+          path: /var/lib/kubelet
+      - name: data-openshiftvolumes
+        hostPath:
+          path: /var/data/openshiftvolumes
+      - name: lib-origin
+        hostPath:
+          path: /var/lib/origin

--- a/charts/skydive-agent/values.yaml
+++ b/charts/skydive-agent/values.yaml
@@ -1,0 +1,18 @@
+image:
+  repository: skydive/skydive
+  tag: "latest"
+  imagePullPolicy: IfNotPresent
+
+resources:
+  limits:
+    cpu: 2000m
+    memory: 8192Mi
+  requests:
+    cpu: 100m
+    memory: 512Mi
+
+analyzer:
+  host: skydive-analyzer:8082
+
+# Extra environment variables to be appended to default skydive variables
+extraEnvs: []

--- a/charts/skydive-analyzer/Chart.yaml
+++ b/charts/skydive-analyzer/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: skydive-analyzer
+description: Skydive Analyzer - Network Topology and Protocols Analyzer
+version: 0.0.0
+appVersion: 0.0.0
+icon: http://skydive.network/assets/images/logo.png

--- a/charts/skydive-analyzer/Makefile
+++ b/charts/skydive-analyzer/Makefile
@@ -1,0 +1,42 @@
+include ../../.mk/tools.mk
+
+# must be within the range of k8s nodePort
+ANALYZER_NODEPORT?=30000
+ANALYZER_PORT?=8082
+ANALYZER_SERVICE?=skydive-analyzer
+ETCD_NODEPORT?=30001
+NEWUI_NODEPORT?=30002
+
+.PHONY: uninstall
+uninstall: $(TOOLSBIN)/helm
+	helm uninstall skydive-analyzer 2>/dev/null || true
+
+.PHONY: install
+install: $(TOOLSBIN)/helm
+	helm install skydive-analyzer . \
+		--set service.port=${ANALYZER_PORT} \
+		--set service.nodePort=${ANALYZER_NODEPORT} \
+		--set etcd.nodePort=${ETCD_NODEPORT} \
+		--set newui.nodePort=${NEWUI_NODEPORT} \
+
+.PHONY: status
+status: $(TOOLSBIN)/kubectl
+	kubectl get all -l app=skydive-analyzer
+
+.PHONY: logs
+logs: $(TOOLSBIN)/kubectl
+	kubectl logs -f -l app=skydive-analyzer -c skydive-analyzer
+
+.PHONY: verify
+verify:
+	curl http://localhost:${ANALYZER_NODEPORT}
+
+.PHONY: port-forward
+port-forward: $(TOOLSBIN)/kubectl
+	kubectl port-forward service/${ANALYZER_SERVICE} ${ANALYZER_PORT}:${ANALYZER_PORT}
+
+.PHONY: help
+help:
+	@echo "Skydive Analyzer is running at: http://localhost:${ANALYZER_NODEPORT}"
+	@echo "Skydive ETCD is running at: http://localhost:${ETCD_NODEPORT}"
+	@echo "Skydive NewUI is running at: http://localhost:${NEWUI_NODEPORT}"

--- a/charts/skydive-analyzer/templates/NOTES.txt
+++ b/charts/skydive-analyzer/templates/NOTES.txt
@@ -1,0 +1,18 @@
+To access skydive GUI execute:
+
+(Bear with us couple of seconds until Skydive starts ...)
+
+{{- if contains "NodePort" .Values.service.type }}
+export UI_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "servicename" . }})
+export UI_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+echo "Skydive UI is running at: http://$UI_IP:$UI_PORT"
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+export UI_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "servicename" . }})
+export UI_IP=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.status.loadBalancer.ingress[0].ip}" services {{ template "servicename" . }})
+echo "Skydive UI is running at: http://$UI_IP:$UI_PORT"
+
+{{- else  }}
+export UI_SERVICE=$(kubectl get --namespace {{ .Release.Namespace }} services {{ template "servicename" . }})
+echo -e "To access Skydive UI use details from\n\n$UI_SERVICE"
+{{- end }}

--- a/charts/skydive-analyzer/templates/_helpers.tpl
+++ b/charts/skydive-analyzer/templates/_helpers.tpl
@@ -1,0 +1,89 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "servicename" -}}
+{{- printf "%s" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "platform" -}}
+  {{- if (eq "linux/amd64" .Capabilities.KubeVersion.Platform) }}
+    {{- printf "-%s" "x86_64" }}
+  {{- end -}}
+  {{- if (eq "linux/ppc64le" .Capabilities.KubeVersion.Platform) }}
+    {{- printf "-%s" "ppc64le" }}
+  {{- end -}}
+  {{- if (eq "linux/s390x" .Capabilities.KubeVersion.Platform) }}
+    {{- printf "-%s" "s390x" }}
+  {{- end -}}
+{{- end -}}
+
+{{- define "arch" -}}
+  {{- if (eq "linux/amd64" .Capabilities.KubeVersion.Platform) }}
+    {{- printf "%s" "amd64" }}
+  {{- end -}}
+  {{- if (eq "linux/ppc64le" .Capabilities.KubeVersion.Platform) }}
+    {{- printf "%s" "ppc64le" }}
+  {{- end -}}
+  {{- if (eq "linux/s390x" .Capabilities.KubeVersion.Platform) }}
+    {{- printf "%s" "s390x" }}
+  {{- end -}}
+{{- end -}}
+
+{{/* affinity - https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ */}}
+
+{{- define "nodeaffinity" }}
+#https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityRequiredDuringScheduling" . }}
+    preferredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityPreferredDuringScheduling" . }}
+{{- end }}
+
+{{- define "nodeAffinityRequiredDuringScheduling" }}
+    #If you specify multiple nodeSelectorTerms associated with nodeAffinity types,
+    #then the pod can be scheduled onto a node if one of the nodeSelectorTerms is satisfied.
+    #
+    #If you specify multiple matchExpressions associated with nodeSelectorTerms,
+    #then the pod can be scheduled onto a node only if all matchExpressions can be satisfied.
+    #
+    #valid operators: In, NotIn, Exists, DoesNotExist, Gt, Lt
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+        {{- range $key, $val := (dict "amd64" "2" "ppc64le" "2" "s390x" "2") }}
+          {{- if gt ($val | trunc 1 | int) 0 }}
+          - {{ $key }}
+          {{- end }}
+        {{- end }}
+{{- end }}
+
+{{- define "nodeAffinityPreferredDuringScheduling" }}
+  {{- range $key, $val := (dict "amd64" "2" "ppc64le" "2" "s390x" "2") }}
+    {{- if gt ($val | trunc 1 | int) 0 }}
+    - weight: {{ $val | trunc 1 | int }}
+      preference:
+        matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+          - {{ $key }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/skydive-analyzer/templates/clusterrolebinging.yaml
+++ b/charts/skydive-analyzer/templates/clusterrolebinging.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: skydive-analyzer
+  labels:
+    app: skydive-analyzer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: skydive-analyzer
+    namespace: {{ .Release.Namespace }}

--- a/charts/skydive-analyzer/templates/deployment.yaml
+++ b/charts/skydive-analyzer/templates/deployment.yaml
@@ -1,0 +1,129 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: skydive-analyzer
+  labels:
+    app: skydive-analyzer
+spec:
+  selector:
+    matchLabels:
+      app: skydive-analyzer
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: skydive-analyzer
+    spec:
+      serviceAccountName: skydive-analyzer
+      dnsPolicy: ClusterFirstWithHostNet
+      affinity:
+        {{- include "nodeaffinity" . | indent 6 }}
+      {{- if .Values.image.secretName }}
+      {{- if ne .Values.image.secretName ""}}
+      imagePullSecrets:
+      - name: {{ .Values.image.secretName }}
+      {{- end }}
+      {{- end }}      
+      containers:
+      - name: skydive-analyzer
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ default "" .Values.image.imagePullPolicy | quote }}
+        terminationMessagePolicy: FallbackToLogsOnError
+        args:
+        - analyzer
+        - --listen=0.0.0.0:{{ .Values.service.port }}
+        ports:
+        - containerPort: {{ .Values.service.port }}
+        - containerPort: {{ .Values.service.port }}
+          protocol: UDP
+        - containerPort: {{ .Values.etcd.port }}
+        readinessProbe:
+          httpGet:
+            port: {{ .Values.service.port }}
+            path: /api/status
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            port: {{ .Values.service.port }}
+            path: /api/status
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          failureThreshold: 10
+        env:
+        - name: SKYDIVE_UI
+          value: '{"theme":"light","k8s_enabled":"true"}'
+        - name: SKYDIVE_ANALYZER_TOPOLOGY_PROBES
+          value: "k8s"
+        - name: SKYDIVE_ANALYZER_TOPOLOGY_FABRIC
+          value: "TOR1->*[Type=host]/eth0"
+        - name: SKYDIVE_ETCD_LISTEN
+          value: 0.0.0.0:{{ .Values.etcd.port }}
+        - name: SKYDIVE_EMBEDDED
+          value: "true"
+        - name: SKYDIVE_FLOW_PROTOCOL
+          value: "websocket"
+      {{- if .Values.elasticsearch.enabled }}
+        - name: SKYDIVE_ANALYZER_FLOW_BACKEND
+          value: "elasticsearchflow"
+        - name: SKYDIVE_ANALYZER_TOPOLOGY_BACKEND
+          value: "elasticsearchtopology"
+        - name: SKYDIVE_STORAGE_ELASTICSEARCHFLOW_DRIVER
+          value: "elasticsearch"
+        - name: SKYDIVE_STORAGE_ELASTICSEARCHTOPOLOGY_DRIVER
+          value: "elasticsearch"
+        - name: SKYDIVE_STORAGE_ELASTICSEARCHFLOW_HOST
+          value: {{ .Values.elasticsearch.host }}
+        - name: SKYDIVE_STORAGE_ELASTICSEARCHFLOW_INDICES_TO_KEEP
+          value: "10"
+        - name: SKYDIVE_STORAGE_ELASTICSEARCHFLOW_INDEX_ENTRIES_LIMIT
+          value: "1000"
+        - name: SKYDIVE_STORAGE_ELASTICSEARCHFLOW_TOTAL_FIELDS_LIMIT
+          value: "1000"
+        - name: SKYDIVE_STORAGE_ELASTICSEARCHFLOW_MAXCONNS
+          value: "10"
+        - name: SKYDIVE_STORAGE_ELASTICSEARCHFLOW_BULK_MAXDOCS
+          value: "1000"
+        - name: SKYDIVE_STORAGE_ELASTICSEARCHFLOW_BULK_MAXDELAY
+          value: "10"
+        - name: SKYDIVE_STORAGE_ELASTICSEARCHFLOW_RETRY
+          value: "5"
+        - name: SKYDIVE_STORAGE_ELASTICSEARCHFLOW_DEBUG
+          value: "true"
+        - name: SKYDIVE_STORAGE_ELASTICSEARCHTOPOLOGY_HOST
+          value: {{ .Values.elasticsearch.host }}
+        - name: SKYDIVE_STORAGE_ELASTICSEARCHTOPOLOGY_INDICES_TO_KEEP
+          value: "10"
+        - name: SKYDIVE_STORAGE_ELASTICSEARCHTOPOLOGY_INDEX_ENTRIES_LIMIT
+          value: "1000"
+        - name: SKYDIVE_STORAGE_ELASTICSEARCHTOPOLOGY_TATAL_FIELDS_LIMIT
+          value: "1000"
+        - name: SKYDIVE_STORAGE_ELASTICSEARCHTOPOLOGY_MAXCONNS
+          value: "10"
+        - name: SKYDIVE_STORAGE_ELASTICSEARCHTOPOLOGY_BULK_MAXDOCS
+          value: "1000"
+        - name: SKYDIVE_STORAGE_ELASTICSEARCHTOPOLOGY_BULK_MAXDELAY
+          value: "10"  
+        - name: SKYDIVE_STORAGE_ELASTICSEARCHTOPOLOGY_RETRY
+          value: "5"        
+        - name: SKYDIVE_STORAGE_ELASTICSEARCHTOPOLOGY_DEBUG
+          value: "true"
+      {{- end }}
+      {{- if .Values.extraEnv }}
+{{ toYaml .Values.extraEnv | indent 8 }}
+      {{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        - name: ssl
+          mountPath: /etc/ssl/certs
+    {{- if .Values.newui.enabled }}
+      - name: skydive-ui
+        image: {{ .Values.newui.image.repository }}:{{ .Values.newui.image.tag }}
+        ports:
+           - containerPort: {{ .Values.newui.port }}
+    {{- end }}
+      volumes:
+      - name: ssl
+        hostPath:
+          path: /etc/ssl/certs

--- a/charts/skydive-analyzer/templates/service.yaml
+++ b/charts/skydive-analyzer/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.service.name }}
+  labels:
+    app: skydive-analyzer
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.port }}
+    name: service
+    nodePort: {{ .Values.service.nodePort }}
+  - port: {{ .Values.etcd.port }}
+    name: etcd
+    nodePort: {{ .Values.etcd.nodePort }}
+  {{- if .Values.newui.enabled }}
+  - port: {{ .Values.newui.port }}
+    name: newui
+    nodePort: {{ .Values.newui.nodePort }}
+  {{- end }}
+  selector:
+    app: skydive-analyzer

--- a/charts/skydive-analyzer/templates/serviceaccount.yaml
+++ b/charts/skydive-analyzer/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: skydive-analyzer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: skydive-analyzer
+imagePullSecrets:
+  - name: sa-{{ .Release.Namespace }}

--- a/charts/skydive-analyzer/values.yaml
+++ b/charts/skydive-analyzer/values.yaml
@@ -22,7 +22,7 @@ etcd:
   nodePort:
 
 newui:
-  enabled: false # FIXME: does not manage to connect to analyzer
+  enabled: true
   image:
     repository: "skydive/skydive-ui"
     tag: "latest"

--- a/charts/skydive-analyzer/values.yaml
+++ b/charts/skydive-analyzer/values.yaml
@@ -1,0 +1,40 @@
+image:
+  repository: skydive/skydive
+  tag: "latest"
+  imagePullPolicy: IfNotPresent
+
+resources:
+  limits:
+    cpu: 2000m
+    memory: 8192Mi
+  requests:
+    cpu: 100m
+    memory: 512Mi
+
+service:
+  type: NodePort # applies for all services
+  name: skydive-analyzer
+  port: 8082
+  nodePort:
+
+etcd:
+  port: 12379
+  nodePort:
+
+newui:
+  enabled: false # FIXME: does not manage to connect to analyzer
+  image:
+    repository: "skydive/skydive-ui"
+    tag: "latest"
+  port: 8080
+  nodePort:
+
+elasticsearch:
+  enabled: false # FIXME: fails due to fields size being 0
+  host: "elasticsearch-master:9200"
+  query:
+
+# Extra environment variables to be appended to default skydive variables
+extraEnvs: []
+#  - name: MY_ENVIRONMENT_VAR
+#    value: the_value_goes_here

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/lunixbochs/struc v0.0.0-20180408203800-02e4c2afbb2a
 	github.com/lxc/lxd v0.0.0-20200330183600-518f06676866
 	github.com/mailru/easyjson v0.7.6
+	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mattn/goveralls v0.0.2
 	github.com/mitchellh/mapstructure v1.3.3
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
@@ -61,6 +62,7 @@ require (
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
 	github.com/olivere/elastic/v7 v7.0.21
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 // indirect
+	github.com/pelletier/go-toml v1.7.0 // indirect
 	github.com/pierrec/xxHash v0.1.5
 	github.com/pkg/errors v0.9.1
 	github.com/pmylund/go-cache v2.1.0+incompatible
@@ -100,7 +102,7 @@ require (
 	istio.io/api v0.0.0-20191029012234-9fe6a7da3673
 	istio.io/client-go v0.0.0-20191024204624-13a7366c1cab
 	k8s.io/api v0.0.0
-	k8s.io/apimachinery v0.0.0
+	k8s.io/apimachinery v0.18.2
 	k8s.io/client-go v11.0.0+incompatible
 )
 


### PR DESCRIPTION
for now there is a bug as the latest webui does not connect to localhost:8082 successfully

to run:

```
cd charts
make k3d
make skydive-analyzer
make install
make status
```

attempting to logout and login with:

- host: http://localhost:802
- user: admin
- password: password

fails:

![image](https://user-images.githubusercontent.com/2760739/105634704-24af2580-5e68-11eb-86b6-5b9379b0ea08.png)

while access localhost:8082 from within the skydive-ui contains succeeds:

![image](https://user-images.githubusercontent.com/2760739/105634740-4e684c80-5e68-11eb-80a9-a542366849e7.png)
