### PR TITLE
Charts:  use fleet to deploy skydive-analyzer on multi-cluster

### DIFF
--- a/.mk/k8s.mk
+++ b/.mk/k8s.mk
@@ -14,6 +14,10 @@ $(TOOLSBIN)/kubectl:
 	sudo -E curl -fsSL -o $(TOOLSBIN)/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.20.1/bin/linux/amd64/kubectl && \
 		sudo -E chmod a+x $(TOOLSBIN)/kubectl
 
+$(TOOLSBIN)/jq:
+	sudo wget -O $@ https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
+		sudo chmod a+x $@
+
 # NodePorts are in the 30000-32767 range by default, which means a NodePort is
 # unlikely to match a service’s intended port (for example, 8080 may be exposed
 # as 31020).

--- a/contrib/charts/skydive-analyzer/Makefile
+++ b/contrib/charts/skydive-analyzer/Makefile
@@ -1,11 +1,11 @@
 include ../../../.mk/k8s.mk
 
 # must be within the range of k8s nodePort
-ANALYZER_NODEPORT?=30000
+ANALYZER_NODEPORT?=30082
 ANALYZER_PORT?=8082
 ANALYZER_SERVICE?=skydive-analyzer
-ETCD_NODEPORT?=30001
-NEWUI_NODEPORT?=30002
+ETCD_NODEPORT?=30079
+NEWUI_NODEPORT?=30080
 
 .PHONY: uninstall
 uninstall: $(TOOLSBIN)/helm
@@ -14,10 +14,12 @@ uninstall: $(TOOLSBIN)/helm
 .PHONY: install
 install: $(TOOLSBIN)/helm
 	helm install skydive-analyzer . \
+		--set service.type=NodePort \
 		--set service.port=${ANALYZER_PORT} \
 		--set service.nodePort=${ANALYZER_NODEPORT} \
 		--set etcd.nodePort=${ETCD_NODEPORT} \
 		--set elasticsearch.enabled=true \
+		--set newui.enabled=true \
 		--set newui.nodePort=${NEWUI_NODEPORT} \
 
 .PHONY: status

--- a/contrib/charts/skydive-analyzer/fleet.yaml
+++ b/contrib/charts/skydive-analyzer/fleet.yaml
@@ -1,0 +1,70 @@
+defaultNamespace: default
+targetCustomizations:
+- name: broker
+  helm:
+    values:
+      newui:
+        enabled: false
+      service:
+        type: NodePort
+        nodePort: 30082
+      etcd:
+        nodePort: 30079
+      extraEnvs:
+        - name: SKYDIVE_HOST_ID
+          value: "broker"
+        - name: SKYDIVE_ANALYZER_TOPOLOGY_FABRIC
+          value: null
+        - name: SKYDIVE_ANALYZER_TOPOLOGY_K8S_CLUSTER_NAME
+          value: "broker"
+  clusterSelector:
+    matchLabels:
+      name: local
+
+- name: east
+  helm:
+    values:
+      newui:
+        enabled: false
+      service:
+        type: ClusterIP
+      extraEnvs:
+        - name: SKYDIVE_HOST_ID
+          value: "east"
+        - name: SKYDIVE_ANALYZERS
+          value: "broker:30082"
+        - name: SKYDIVE_ANALYZER_TOPOLOGY_FABRIC
+          value: null
+        - name: SKYDIVE_ANALYZER_TOPOLOGY_K8S_CLUSTER_NAME
+          value: "east"
+        - name: SKYDIVE_ETCD_EMBEDDED
+          value: "false"
+        - name: SKYDIVE_ETCD_SERVERS
+          value: "http://broker:30079"
+  clusterSelector:
+    matchLabels:
+      env: east
+
+- name: west
+  helm:
+    values:
+      newui:
+        enabled: false
+      service:
+        type: ClusterIP
+      extraEnvs:
+        - name: SKYDIVE_HOST_ID
+          value: "west"
+        - name: SKYDIVE_ANALYZERS
+          value: "broker:30082"
+        - name: SKYDIVE_ANALYZER_TOPOLOGY_FABRIC
+          value: null
+        - name: SKYDIVE_ANALYZER_TOPOLOGY_K8S_CLUSTER_NAME
+          value: "west"
+        - name: SKYDIVE_ETCD_EMBEDDED
+          value: "false"
+        - name: SKYDIVE_ETCD_SERVERS
+          value: "http://broker:30079"
+  clusterSelector:
+    matchLabels:
+      env: west

--- a/contrib/charts/skydive-analyzer/values.yaml
+++ b/contrib/charts/skydive-analyzer/values.yaml
@@ -22,7 +22,7 @@ etcd:
   nodePort:
 
 newui:
-  enabled: true
+  enabled: false
   image:
     repository: "skydive/skydive-ui"
     tag: "latest"

--- a/contrib/fleet/Makefile
+++ b/contrib/fleet/Makefile
@@ -1,0 +1,9 @@
+include ../../.mk/k8s.mk
+
+.PHONY: install uinstall status logs
+install uninstall status logs: $(TOOLSBIN)/k3d $(TOOLSBIN)/helm $(TOOLSBIN)/kubectl $(TOOLSBIN)/jq
+	./skydive.sh $@
+
+.PHONY: broker east west
+broker east west: $(TOOLSBIN)/kubectl
+	kubectl --context k3d-$@ port-forward service/skydive-analyzer 8082:8082

--- a/contrib/fleet/skydive.sh
+++ b/contrib/fleet/skydive.sh
@@ -1,0 +1,309 @@
+#/usr/bin/env bash
+
+set -x
+set -e
+
+WITHOUT_BROKER=${WITHOUT_BROKER:-false}
+WITHOUT_SPOKE=${WITHOUT_SPOKE:-false}
+K3D_AGENTS=${K3D_AGENTS:-0}
+FLEET_VERSION=${FLEET_VERSION:-0.3.0}
+ANALYZER_NODEPORTS=${ANALYZER_NODEPORTS:-30082}
+ETCD_NODEPORTS=${ETCD_NODEPORTS:-30079}
+
+GIT_REPO=https://github.com/hunchback/skydive/
+GIT_BRANCH=charts-fleet
+GIT_PATH=contrib/charts/skydive-analyzer
+GIT_APP=skydive-analyzer
+
+K3D_SPOKES=${K3D_SPOKES:-east west}
+
+k3d_install() {
+	which k3d 2>/dev/null && return
+	curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v3.0.0 bash
+}
+
+tools() {
+	k3d_install
+}
+
+k3d_delete() {
+	local name=$1
+	k3d cluster delete $name 2>/dev/null || true
+}
+
+k3d_coredns_broker_entry() {
+	local hostname=broker
+	local ipaddr=$(hostname -I)
+	local nodehosts="$(kubectl get configmap coredns -n kube-system -o json | jq -r .data.NodeHosts)"
+	kubectl patch configmap coredns -n kube-system -p \
+"{
+  \"data\":{
+    \"NodeHosts\":
+      \"${nodehosts}\n $ipaddr $hostname\n\"
+  }
+}"
+	kubectl get configmap coredns -n kube-system -o json | jq .data.NodeHosts
+}
+
+k3d_create() {
+	local name=$1; shift
+	k3d cluster create --agents $K3D_AGENTS $name $*
+	sleep 5
+	k3d_coredns_broker_entry
+}
+
+helm_uninstall() {
+	local context=$1; shift
+	local name=$1; shift
+	helm --kube-context $context --namespace fleet-system uninstall $name 2>/dev/null || true
+}
+
+helm_install() {
+	local context=$1; shift
+	local name=$1; shift
+	helm --kube-context $context --namespace fleet-system install --create-namespace $* \
+	    $name https://github.com/rancher/fleet/releases/download/v${FLEET_VERSION}/${name}-${FLEET_VERSION}.tgz 
+}
+
+helm_status() {
+	local context=$1; shift
+	helm --kube-context $context --namespace fleet-system list
+}
+
+####################
+#####  broker ######
+####################
+
+broker_delete() {
+	k3d_delete broker
+}
+
+broker_create() {
+	k3d_create broker \
+		-p "${ANALYZER_NODEPORTS}:${ANALYZER_NODEPORTS}@server[0]" \
+		-p "${ETCD_NODEPORTS}:${ETCD_NODEPORTS}@server[0]"
+}
+
+broker_install() {
+	local context=k3d-broker
+	local url=broker:8080
+	helm_install $context fleet-crd
+	helm_install $context fleet \
+		--wait \
+		--set apiServerURL=$url
+}
+
+broker_status() {
+	local context=k3d-broker
+	helm_status $context
+}
+
+broker_token() {
+	local context=k3d-broker
+	local name=token
+	local namespace=clusters
+
+	cat <<EOF | kubectl apply --context $context --wait -f - 
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $namespace
+---
+kind: ClusterRegistrationToken
+apiVersion: "fleet.cattle.io/v1alpha1"
+metadata:
+    name: $name
+    namespace: $namespace
+spec:
+    ttl: 240h
+EOF
+	kubectl --context $context --namespace $namespace get secret $name -o 'jsonpath={.data.values}' | \
+		base64 --decode > /tmp/values.yaml
+	cat /tmp/values.yaml
+}
+
+broker_proxy_kill() {
+	sudo killall -9 kubectl 2>/dev/null || true
+}
+
+broker_proxy() {
+	local context=k3d-broker
+	kubectl proxy --accept-hosts '^.*' --address 0.0.0.0 --port 8080 --context $context&
+}
+
+broker_logs() {
+	local context=k3d-broker
+	kubectl --context $context --namespace fleet-system logs -l app=fleet-controller || true
+	kubectl --context $context --namespace fleet-system get pods -l app=fleet-controller || true
+}
+
+broker() {
+	broker_create
+	broker_install
+	broker_status
+	broker_token
+	broker_proxy
+}
+
+####################
+#####  spoke  ######
+####################
+
+spoke_delete() {
+	local name=$1; shift
+	k3d_delete $name
+}
+
+spoke_create() {
+	local name=$1; shift
+	k3d_create $name
+}
+
+spoke_install() {
+	local name=$1; shift
+	local context=k3d-$name
+	helm_install $context fleet-crd
+	helm_install $context fleet-agent \
+		--set-string labels.env=$name \
+		--values /tmp/values.yaml
+}
+
+spoke_status() {
+	local name=$1; shift
+	local context=k3d-$name
+	helm_status $context
+}
+
+spoke_logs() {
+	local name=$1; shift
+	local context=k3d-$name
+	kubectl --context $context --namespace fleet-system logs -l app=fleet-agent || true
+	kubectl --context $context --namespace fleet-system get pods -l app=fleet-agent || true
+}
+
+spoke() {
+	local name=$1; shift
+	spoke_delete $name
+	spoke_create $name
+	spoke_install $name
+}
+
+####################
+#####   app   ######
+####################
+
+gitrepo_create() {
+	local context=k3d-broker
+	local namespace=$1; shift
+	kubectl --context $context create namespace $namespace 2>/dev/null || true
+	cat <<EOF | kubectl apply --context $context -f -
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: sample
+  namespace: $namespace
+spec:
+  repo: $GIT_REPO
+  branch: $GIT_BRANCH
+  paths:
+  - $GIT_PATH
+  targets:
+  - name: local
+    clusterSelector:
+      matchLabels:
+        name: local
+  - name: east
+    clusterSelector:
+      matchLabels:
+        env: east
+  - name: west
+    clusterSelector:
+      matchLabels:
+        env: west
+EOF
+}
+
+gitrepo_status() {
+	local context=k3d-broker
+	local namespace=$1; shift
+	kubectl --context $context --namespace $namespace get fleet
+}
+
+broker_app_install() {
+	gitrepo_create fleet-local
+}
+
+spoke_app_install() {
+	gitrepo_create clusters
+}
+
+app_status() {
+	local context=k3d-$1; shift
+	local namespace=default
+	local name=$GIT_APP
+	#kubectl --context $context rollout status deploy --namespace $namespace $name --timeout 30s || true
+	kubectl --context $context get deploy --namespace $namespace $name || true
+}
+
+####################
+#####  main   ######
+####################
+
+uninstall() {
+	broker_proxy_kill
+	broker_delete
+	for i in $K3D_SPOKES; do
+		spoke_delete $i
+	done
+}
+
+install() {
+	broker
+	$WITHOUT_BROKER || broker_app_install
+	for i in $K3D_SPOKES; do
+		spoke $i
+	done
+	$WITHOUT_SPOKE || spoke_app_install
+}
+
+state() {
+	broker_status
+	for i in $K3D_SPOKES; do
+		spoke_status $i
+	done
+
+	$WITHOUT_SPOKE || gitrepo_status fleet-local
+	$WITHOUT_SPOKE || gitrepo_status clusters
+
+	$WITHOUT_BROKER || app_status broker
+	for i in $K3D_SPOKES; do
+		$WITHOUT_SPOKE || app_status $i
+	done
+}
+
+logs() {
+	broker_logs
+	for i in $K3D_SPOKES; do
+		$WITHOUT_SPOKE || spoke_logs $i
+	done
+}
+
+case "$1" in 
+        tools)
+		tools
+		;;
+	install)
+		install
+		;;
+	uninstall)
+		uninstall
+		;;
+	status)
+		state
+		;;
+	logs)
+		logs
+		;;
+	*)
+		echo "usage: skydive.sh [tools|install|uninstall|status|logs]"
+esac


### PR DESCRIPTION
using fleet we deploy the following
- broker (the cluster running the fleet manager)
- east (1st spoke)
- west (2nd spoke)

to test please run:

```
cd contrib/fleet
make tools
make install
make status
```

to connect to any specific cluster via webui localhost:8082 run:

```
make broker
# or
make east
# or
make west
```

![image](https://user-images.githubusercontent.com/2760739/106448927-18405380-648c-11eb-8b2f-1b579c49dc84.png)

and when viewing the broker you see all clusters:

![image](https://user-images.githubusercontent.com/2760739/106907381-dcfd8900-6706-11eb-8d24-be70e653d3cb.png)

