### PR TITLE
Use etcd default value for maximum wal and snap files

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -156,6 +156,8 @@ func init() {
 	cfg.SetDefault("etcd.data_dir", "/var/lib/skydive/etcd")
 	cfg.SetDefault("etcd.embedded", true)
 	cfg.SetDefault("etcd.listen", fmt.Sprintf("%s:%d", etcdclient.DefaultServer, etcdclient.DefaultPort))
+	cfg.SetDefault("etcd.max_snap_files", 5)
+	cfg.SetDefault("etcd.max_wal_files", 5)
 	cfg.SetDefault("etcd.name", host)
 
 	cfg.SetDefault("flow.expire", 600)

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -502,8 +502,8 @@ etcd:
   # listen: 0.0.0.0:12379
 
   # maximum number of WAL and snapshot files. 0 means unlimited
-  # max_wal_files: 0
-  # max_snap_files: 0
+  # max_wal_files: 5
+  # max_snap_files: 5
 
   # path where the etcd files will be stored.
   # data_dir: /var/lib/skydive/etcd


### PR DESCRIPTION
skip go-fmt
skip unit-tests
skip compile-tests
skip functional-tests-backend-orientdb
skip scale-tests
skip cdd-overview-tests
skip k8s-tests
