### PR TITLE
elasticsearch: rolles indices should keep the same mapping

### DIFF
--- a/graffiti/storage/elasticsearch/rollindex.go
+++ b/graffiti/storage/elasticsearch/rollindex.go
@@ -20,6 +20,7 @@ package elasticsearch
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -99,6 +100,11 @@ func (r *rollIndexService) roll(force bool) {
 				needToRoll = true
 			}
 		}
+
+		// Use the same mapping for the new created index
+		indexMapping := map[string]interface{}{}
+		json.Unmarshal([]byte(index.Mapping), &indexMapping)
+		ri.Mappings(indexMapping)
 
 		if needToRoll {
 			alias := index.Alias(r.config.IndexPrefix)


### PR DESCRIPTION
When the archive index is rolled, it was not keeping the mappings from
the original archive index.
This produces an incorrect index of values and could reach the max
fields limit if we are using some of the fields that should be
"flattened"