### PR TITLE
Add SSL support to OVN

### DIFF
--- a/analyzer/probes.go
+++ b/analyzer/probes.go
@@ -114,7 +114,10 @@ func NewTopologyProbeBundleFromConfig(g *graph.Graph) (*probe.Bundle, error) {
 		switch t {
 		case "ovn":
 			addr := config.GetString("analyzer.topology.ovn.address")
-			handler, err = ovn.NewProbe(g, addr)
+			certFile := config.GetString("analyzer.topology.ovn.cert")
+			keyFile := config.GetString("analyzer.topology.ovn.key")
+			cacertFile := config.GetString("analyzer.topology.ovn.cacert")
+			handler, err = ovn.NewProbe(g, addr, certFile, keyFile, cacertFile)
 		case "k8s":
 			handler, err = k8s.NewK8sProbe(g)
 		case "istio":

--- a/etc/skydive.yml.default
+++ b/etc/skydive.yml.default
@@ -174,6 +174,10 @@ analyzer:
       # * tcp:addr:port
       # * unix:/var/run/ovn/ovnnb_db.sock
       # address: unix:/var/run/ovn/ovnnb_db.sock
+      # Specify client, key and CA certificate files for TLS authentication.
+      # cert: /myovnnbcert
+      # key: /myovnkey
+      # cacert: /myovncacert
 
   replication:
     # debug: false


### PR DESCRIPTION
Up till now, OVN would only work if UNIX sockets were used or TCP without authentication.
This change adds parameters and plumbing for client cert, key
and CA cert file.
That is then passed on to the goovn NewClient.