### PR TITLE
Add Dockerfile and make target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:20.04 as builder
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get -y update \
+    && apt-get -y install build-essential git-core golang npm openvswitch-common libpcap0.8 libpcap0.8-dev libxml2-dev protobuf-compiler libprotobuf-dev libvirt-dev \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /go/src/github.com/skydive-project/skydive
+COPY . .
+ARG GOPATH=/go
+RUN make build
+
+FROM ubuntu:20.04 as skydive
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get -y update \
+    && apt-get -y install golang npm openvswitch-common libpcap0.8 libvirt0 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /go/src/github.com/skydive-project/skydive/skydive /usr/bin/skydive
+COPY contrib/docker/skydive.yml /etc/skydive.yml
+ENTRYPOINT ["/usr/bin/skydive", "--conf", "/etc/skydive.yml"]

--- a/Makefile
+++ b/Makefile
@@ -166,3 +166,7 @@ touchlocalfiles: .proto.touch .typescript.touch .bindata.touch .gendecoder.touch
 .PHONY: clean
 clean: skydive.clean test.functionals.clean contribs.clean .ebpf.clean .easyjson.clean .proto.clean .gendecoder.clean .typescript.clean .vppbinapi.clean swagger.clean
 	go clean -i >/dev/null 2>&1 || true
+
+.PHONY: docker
+docker:
+	docker build . -t $(DOCKER_IMAGE):$(DOCKER_TAG)


### PR DESCRIPTION
There is no clear Dockerfile or easy way to build a local docker image.
This patch allows to run 'make docker' and it will use a multi-stage
Dockerfile inspired by the CI Dockerfile for the build.
It allows to use DOCKER_IMAGE and DOCKER_TAG, which are defined on
.mk/dist for docker-image target, which is not great for local
development since the build runs on the host, not in container.