### PR TITLE
Add ovn-kubernetes probe

### DIFF
--- a/.mk/tests.mk
+++ b/.mk/tests.mk
@@ -38,6 +38,13 @@ ifeq ($(WITH_OVN), true)
   ANALYZER_TEST_PROBES+=ovn
 endif
 
+ifeq ($(WITH_OVNK8S), true)
+  ANALYZER_TEST_PROBES+=ovn
+  ANALYZER_TEST_PROBES+=k8s
+  ANALYZER_TEST_PROBES+=ovnk8s
+  EXTRA_ARGS+=-analyzer.topology.ovn.address=$(OVN_ADDRESS)
+endif
+
 
 COVERAGE?=0
 COVERAGE_MODE?=atomic

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,10 @@ ifeq ($(WITH_PACKETINJECT), true)
   BUILD_TAGS+=packetinject
 endif
 
+ifeq ($(WITH_OVNK8S), true)
+  BUILD_TAGS+=k8s ovnk8s
+endif
+
 
 include .mk/ebpf.mk
 include .mk/api.mk

--- a/analyzer/probes.go
+++ b/analyzer/probes.go
@@ -39,6 +39,7 @@ import (
 	"github.com/skydive-project/skydive/topology/probes/nsm"
 	"github.com/skydive-project/skydive/topology/probes/opencontrail"
 	"github.com/skydive-project/skydive/topology/probes/ovn"
+	"github.com/skydive-project/skydive/topology/probes/ovnk8s"
 	"github.com/skydive-project/skydive/topology/probes/ovsdb"
 	"github.com/skydive-project/skydive/topology/probes/peering"
 )
@@ -118,6 +119,8 @@ func NewTopologyProbeBundleFromConfig(g *graph.Graph) (*probe.Bundle, error) {
 			keyFile := config.GetString("analyzer.topology.ovn.key")
 			cacertFile := config.GetString("analyzer.topology.ovn.cacert")
 			handler, err = ovn.NewProbe(g, addr, certFile, keyFile, cacertFile)
+		case "ovnk8s":
+			handler, err = ovnk8s.NewProbe(g)
 		case "k8s":
 			handler, err = k8s.NewK8sProbe(g)
 		case "istio":

--- a/scripts/ci/ovnkube-setup.sh
+++ b/scripts/ci/ovnkube-setup.sh
@@ -87,6 +87,7 @@ do_delete() {
     go clean --modcache
     rm -rf ${WORKSPACE}/go/src/github.com/ovn-org/ovn-kubernetes
     docker rmi ovn-kube-f || true
+    docker network rm kind || true
     rm -f $HOME/admin.conf
     rm -rf ${WORKSPACE}
 }

--- a/scripts/ci/ovnkube-setup.sh
+++ b/scripts/ci/ovnkube-setup.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+set -eu
+
+# DEPENDENCIES:
+# This scripts assumes the following packages are installed:
+#   docker
+#   go
+#   python and pip
+# PERMISSIONS:
+# This script can be executed without root privilegeds. 'sudo' will be used
+# for the specific tasks that do require it
+
+# Global env vars that modify the behavior of the script:
+KIND_VERSION=${KIND_VERSION:-v0.10.0}
+K8S_VERSION=${K8S_VERSION:-v1.20.0}
+OVNK8S_VERSION=${OVNK8S_VERSION:-ab8bcb41ae215afd3890f243fd99e1d0cce5feed}
+OVNK8S_REPO=https://github.com/ovn-org/ovn-kubernetes.git
+
+# Global vars
+WORKSPACE=${WORKSPACE:-${HOME}/ovnkube-setup}
+OS=linux
+ARCH=amd64
+export GOPATH=$WORKSPACE/go
+
+usage(){
+    echo "Usage: $0 command"
+    echo ""
+    echo "commands:"
+    echo "  create:         Create an environment with kind and ovnk8s"
+    echo "  delete:         Delete the environment"
+    echo "  start:          Start the environment"
+    echo "  stop:           Stop the environment"
+}
+
+error() {
+    echo "[error] $@"
+    exit 1
+}
+
+check_dependencies() {
+    # Check docker is installed and running
+    docker version > /dev/null || (error "Docker not installed"; exit 1)
+    # Check go is installed
+    go version > /dev/null || (error "Go not installed"; exit 1)
+}
+
+do_create () {
+    check_dependencies
+
+    # Download needed
+    mkdir -p ${WORKSPACE}/bin
+
+    curl -Lo $WORKSPACE/bin/kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-$(uname)-amd64"
+    chmod +x $WORKSPACE/bin/kind
+
+    curl -Lo ${WORKSPACE}/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/$K8S_VERSION/bin/$OS/$ARCH/kubectl"
+    chmod +x $WORKSPACE/bin/kubectl
+
+    # Need to add port 11337 in the firewall (if it exists)
+    if firewall-cmd -q --state; then
+        sudo firewall-cmd --add-port=11337/tcp
+        sudo firewall-cmd --reload
+    fi
+
+    mkdir -p $GOPATH/src/github.com/ovn-org/
+    pushd $GOPATH/src/github.com/ovn-org/
+      git clone $OVNK8S_REPO
+      pushd ovn-kubernetes
+        git checkout $OVNK8S_VERSION
+        pushd go-controller
+        make
+        popd
+        pushd dist/images
+        make fedora
+        popd
+
+        # Disable SCTPSupport
+        sed -i '/SCTPSupport.*/d' contrib/kind.yaml.j2
+        sed -i '/featureGates.*/d' contrib/kind.yaml.j2
+
+      popd # ovn-kubernetes
+    popd #$GOPATH/src/github.com/ovn-org/
+}
+
+do_delete() {
+    do_stop
+    go clean --modcache
+    rm -rf ${WORKSPACE}/go/src/github.com/ovn-org/ovn-kubernetes
+    docker rmi ovn-kube-f || true
+    rm -f $HOME/admin.conf
+    rm -rf ${WORKSPACE}
+}
+
+do_start() {
+    pushd "$GOPATH/src/github.com/ovn-org/ovn-kubernetes/contrib"
+    (
+        K8S_VERSION=$K8S_VERSION KIND_INSTALL_INGRESS=true PATH="$PATH:${WORKSPACE}/bin" ./kind.sh
+    )
+    popd
+}
+
+do_stop() {
+    if [ -d "$GOPATH/src/github.com/ovn-org/ovn-kubernetes/contrib" ]; then
+        pushd "$GOPATH/src/github.com/ovn-org/ovn-kubernetes/contrib"
+        (
+            K8S_VERSION=$K8S_VERSION KIND_INSTALL_INGRESS=true PATH="$PATH:${WORKSPACE}/bin" ./kind.sh --delete
+        )
+    fi
+}
+
+# Main program
+if [ $# -ne 1 ]; then
+    usage
+    exit 1
+fi
+CMD=$1
+case $CMD in
+    start)
+        do_start $@
+        ;;
+    stop)
+        do_stop $@
+        ;;
+    create)
+        do_create $@
+        ;;
+    delete)
+        do_delete $@
+        ;;
+    forward)
+        do_forward $@ # NEEDED?
+        ;;
+    *)
+        echo "Invalid command $CMD" 1>&2
+        exit 1
+        ;;
+esac

--- a/scripts/ci/ovnkube-setup.sh
+++ b/scripts/ci/ovnkube-setup.sh
@@ -21,7 +21,6 @@ OVNK8S_REPO=https://github.com/ovn-org/ovn-kubernetes.git
 WORKSPACE=${WORKSPACE:-${HOME}/ovnkube-setup}
 OS=linux
 ARCH=amd64
-export GOPATH=$WORKSPACE/go
 
 usage(){
     echo "Usage: $0 command"

--- a/scripts/ci/ovnkube-setup.sh
+++ b/scripts/ci/ovnkube-setup.sh
@@ -89,7 +89,6 @@ do_delete() {
     docker rmi ovn-kube-f || true
     docker network rm kind || true
     rm -f $HOME/admin.conf
-    rm -rf ${WORKSPACE}
 }
 
 do_start() {

--- a/scripts/ci/run-ovnk8s-tests.sh
+++ b/scripts/ci/run-ovnk8s-tests.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -v
+set -e
+
+SCRIPT_FILE=$(realpath -s $0)
+DIR="$(dirname $SCRIPT_FILE)"
+
+. "$DIR/run-tests-utils.sh"
+
+OVN_ADDRESS=""
+
+ovnk8s_setup_start() {
+    $DIR/ovnkube-setup.sh create
+    $DIR/ovnkube-setup.sh start
+}
+
+ovnk8s_setup_stop() {
+    $DIR/ovnkube-setup.sh stop
+    $DIR/ovnkube-setup.sh delete
+}
+
+ovnk8s_setup_start
+OVN_NODE_IP=$(KUBECONFIG=$HOME/admin.conf kubectl get nodes  -o wide | awk '/ovn-control-plane/{print $6}')
+export OVN_ADDRESS="tcp:${OVN_NODE_IP}:6641"
+export K8S_CLUSTER_NAME="kind-ovn"
+export K8S_NUM_NODES=3
+export KUBECONFIG=$HOME/admin.conf
+
+network_setup
+WITH_OVNK8S=true
+TEST_PATTERN='(OVNK8s|K8s)'
+tests_run
+
+ovnk8s_setup_stop
+
+exit $RETCODE
+

--- a/scripts/ci/run-tests-utils.sh
+++ b/scripts/ci/run-tests-utils.sh
@@ -61,7 +61,7 @@ tests_run() {
                 GOFLAGS="$GOFLAGS" VERBOSE=true TAGS="$TAGS" GORACE="history_size=7" TIMEOUT=20m \
                 WITH_HELM="$WITH_HELM" WITH_EBPF="$WITH_EBPF" WITH_EBPF_DOCKER_BUILDER=true \
                 WITH_K8S="$WITH_K8S" WITH_ISTIO="$WITH_ISTIO" \
-                WITH_PROF="$WITH_PROF" ARGS="$ARGS" TEST_PATTERN="$TEST_PATTERN" 2>&1 | tee $LOGFILE
+                WITH_PROF="$WITH_PROF" WITH_OVNK8S="$WITH_OVNK8S" ARGS="$ARGS" TEST_PATTERN="$TEST_PATTERN" 2>&1 | tee $LOGFILE
         RETCODE=$?
 
         if [ "$WITH_PROF" = "true" ]; then

--- a/tests/k8s/deployment_modern.yaml
+++ b/tests/k8s/deployment_modern.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: skydive-test-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: skydive-test-deployment-nginx
+        image: nginx:1.7.9
+        ports:
+        - containerPort: 80

--- a/tests/ovn_test.go
+++ b/tests/ovn_test.go
@@ -65,7 +65,7 @@ func TestOVNLpAdd(t *testing.T) {
 
 		checks: []CheckFunction{func(c *CheckContext) error {
 			gremlin := c.gremlin.V().Has("Name", "ls-test", "Type", "logical_switch")
-			gremlin = gremlin.Out("Type", "logical_port", "Name", "lsp-test")
+			gremlin = gremlin.Out("Type", "logical_switch_port", "Name", "lsp-test")
 
 			_, err := c.gh.GetNode(gremlin)
 			if err != nil {
@@ -170,12 +170,12 @@ func TestOVNRouting(t *testing.T) {
 				return fmt.Errorf("Failed to find switch 'dmz': %s", err)
 			}
 
-			gremlin = gremlin.Out().Has("Name", "dmz-tenant1", "Type", "logical_port")
+			gremlin = gremlin.Out().Has("Name", "dmz-tenant1", "Type", "logical_switch_port")
 			if _, err = c.gh.GetNode(gremlin); err != nil {
 				return fmt.Errorf("Failed to find port 'dmz-tenant1': %s", err)
 			}
 
-			gremlin = gremlin.Out().Has("Name", "tenant1-dmz", "Type", "logical_port")
+			gremlin = gremlin.Out().Has("Name", "tenant1-dmz", "Type", "logical_router_port")
 			if _, err = c.gh.GetNode(gremlin); err != nil {
 				return fmt.Errorf("Failed to find router port 'tenant1-dmz': %s", err)
 			}
@@ -185,12 +185,12 @@ func TestOVNRouting(t *testing.T) {
 				return fmt.Errorf("Failed to find logical router 'tenant1': %s", err)
 			}
 
-			gremlin = gremlin.Out().Has("Name", "tenant1-inside", "Type", "logical_port")
+			gremlin = gremlin.Out().Has("Name", "tenant1-inside", "Type", "logical_router_port")
 			if _, err = c.gh.GetNode(gremlin); err != nil {
 				return fmt.Errorf("Failed to find logical port 'tenant1-inside': %s", err)
 			}
 
-			gremlin = gremlin.In().Has("Name", "inside-tenant1", "Type", "logical_port")
+			gremlin = gremlin.In().Has("Name", "inside-tenant1", "Type", "logical_switch_port")
 			if _, err = c.gh.GetNode(gremlin); err != nil {
 				return fmt.Errorf("Failed to find logical port 'inside-tenant1': %s", err)
 			}
@@ -200,7 +200,7 @@ func TestOVNRouting(t *testing.T) {
 				return fmt.Errorf("Failed to find logical switch 'inside': %s", err)
 			}
 
-			gremlin = gremlin.Out().Has("Name", "inside-vm3", "Type", "logical_port")
+			gremlin = gremlin.Out().Has("Name", "inside-vm3", "Type", "logical_switch_port")
 			if _, err = c.gh.GetNode(gremlin); err != nil {
 				return fmt.Errorf("Failed to find logical switch 'inside': %s", err)
 			}

--- a/tests/ovnk8s_test.go
+++ b/tests/ovnk8s_test.go
@@ -1,4 +1,5 @@
 // +build ovnk8s
+
 /*
  * Copyright (C) 2019 Red Hat, Inc.
  *

--- a/tests/ovnk8s_test.go
+++ b/tests/ovnk8s_test.go
@@ -1,0 +1,82 @@
+// +build ovnk8s
+/*
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package tests
+
+import (
+	"fmt"
+	"testing"
+)
+
+// Test a pod within a deployment gets linked to its LSP
+func TestOVNK8sDeployment(t *testing.T) {
+	const nreplicas = 4
+	test := &Test{
+		setupCmds: []Cmd{
+			{fmt.Sprintf("kubectl create deployment echo --image=k8s.gcr.io/echoserver:1.4 --replicas=%d", nreplicas), false},
+		},
+
+		tearDownCmds: []Cmd{
+			{"kubectl delete deployment echo", false},
+		},
+
+		mode: Replay,
+
+		checks: []CheckFunction{func(c *CheckContext) error {
+			pods, err := c.gh.GetNodes(c.gremlin.V().Has("Type", "pod", "K8s.Labels.app", "echo"))
+			if err != nil {
+				return fmt.Errorf("Failed to find pods")
+			}
+			if len(pods) != nreplicas {
+				return fmt.Errorf("Not enough pods in deployment")
+			}
+			for _, pod := range pods {
+				podName, err := pod.GetFieldString("Name")
+				if err != nil {
+					return err
+				}
+				pod2lspQuery := c.gremlin.V(string(pod.ID)).OutE().Has("Manager", "ovnk8s")
+				podEdges, err := c.gh.GetEdges(pod2lspQuery)
+				if err != nil {
+					return fmt.Errorf("Failed to find a pod edge for pod %s", podName)
+				}
+				if len(podEdges) != 1 {
+					return fmt.Errorf("Wrong number of pod edges, expected 1 got %d", len(podEdges))
+				}
+				lsp, err := c.gh.GetNode(c.gremlin.V(string(podEdges[0].Child)))
+				if err != nil {
+					return fmt.Errorf("Failed to find a switch port for pod %s", podName)
+				}
+				expectedName := fmt.Sprintf("default_%s", podName)
+				portName, err := lsp.GetFieldString("Name")
+				if err != nil {
+					return err
+				}
+				if portName != expectedName {
+					return fmt.Errorf("LSP has wrong name. expected %s got %s", expectedName, podName)
+				}
+				t.Logf("POD found: %v", pod)
+				t.Logf("EDGE found: %v", podEdges[0])
+				t.Logf("PORT found: %v", lsp)
+			}
+			return nil
+		}},
+	}
+
+	RunTest(t, test)
+}

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -80,6 +80,8 @@ analyzer:
   topology:
     backend: {{.TopologyBackend}}
     probes: {{block "analyzerprobes" .}}{{"\n"}}{{range .AnalyzerProbes}}{{println "    -" .}}{{end}}{{end}}
+    ovn:
+      address: {{.OvnAddress}}
   startup:
     capture_gremlin: "g.V().Has('Name','startup-vm2')"
 
@@ -245,6 +247,7 @@ var (
 	standalone        bool
 	topologyBackend   string
 	profile           bool
+	ovnAddress        string
 )
 
 func initConfig(conf string, params ...helperParams) error {
@@ -297,6 +300,9 @@ func initConfig(conf string, params ...helperParams) error {
 	}
 	if agentProbes != "" {
 		params[0]["AgentProbes"] = strings.Split(agentProbes, ",")
+	}
+	if ovnAddress != "" {
+		params[0]["OvnAddress"] = ovnAddress
 	}
 
 	tmpl, err := template.New("config").Parse(conf)
@@ -942,6 +948,7 @@ func init() {
 	flag.StringVar(&analyzerListen, "analyzer.listen", "0.0.0.0:64500", "Specify the analyzer listen address")
 	flag.StringVar(&analyzerProbes, "analyzer.topology.probes", "", "Specify the analyzer probes to enable")
 	flag.StringVar(&agentProbes, "agent.topology.probes", "", "Specify the extra agent probes to enable")
+	flag.StringVar(&ovnAddress, "analyzer.topology.ovn.address", "unix:///var/run/ovn/ovnnb_db.sock", "Specify the ovn address")
 	flag.BoolVar(&ovsOflowNative, "ovs.oflow.native", false, "Use native OpenFlow protocol instead of ovs-ofctl")
 	flag.BoolVar(&profile, "profile", false, "Start profiling")
 }

--- a/topology/probes/ovn/ovn.go
+++ b/topology/probes/ovn/ovn.go
@@ -328,7 +328,7 @@ func (p *Probe) OnLogicalSwitchDelete(ls *goovn.LogicalSwitch) {
 
 func (p *Probe) logicalPortMetadata(lp *goovn.LogicalSwitchPort) graph.Metadata {
 	return graph.Metadata{
-		"Type":    "logical_port",
+		"Type":    "logical_switch_port",
 		"Name":    lp.Name,
 		"UUID":    lp.UUID,
 		"Manager": "ovn",
@@ -348,7 +348,7 @@ func (p *Probe) logicalPortMetadata(lp *goovn.LogicalSwitchPort) graph.Metadata 
 
 func (p *Probe) logicalRouterPortMetadata(lp *goovn.LogicalRouterPort) graph.Metadata {
 	return graph.Metadata{
-		"Type":    "logical_port",
+		"Type":    "logical_router_port",
 		"Name":    lp.Name,
 		"UUID":    lp.UUID,
 		"Manager": "ovn",
@@ -611,7 +611,7 @@ func NewProbe(g *graph.Graph, address string, certFile string, keyFile string, c
 	routerPortIndexer := graph.NewMetadataIndexer(g, p.lspIndexer, nil, "OVN.Options.router-port")
 	p.bundle.AddHandler("routerPortIndexer", routerPortIndexer)
 
-	lpIndexer := graph.NewMetadataIndexer(g, p.lrpIndexer, graph.Metadata{"Type": "logical_port"}, "Name")
+	lpIndexer := graph.NewMetadataIndexer(g, p.lrpIndexer, graph.Metadata{"Type": "logical_router_port"}, "Name")
 	p.bundle.AddHandler("lpIndexer", lpIndexer)
 
 	p.srLinker = graph.NewMetadataIndexerLinker(g, routerPortIndexer, lpIndexer, graph.Metadata{"RelationType": "layer2"})
@@ -623,7 +623,7 @@ func NewProbe(g *graph.Graph, address string, certFile string, keyFile string, c
 	p.ifaces = graph.NewMetadataIndexer(g, g, nil, "ExtID.iface-id")
 	p.bundle.AddHandler("ifaces", p.ifaces)
 
-	lpIndexer2 := graph.NewMetadataIndexer(g, p.lspIndexer, graph.Metadata{"Type": "logical_port"}, "Name")
+	lpIndexer2 := graph.NewMetadataIndexer(g, p.lspIndexer, graph.Metadata{"Type": "logical_switch_port"}, "Name")
 	p.bundle.AddHandler("lpIndexer2", lpIndexer2)
 
 	p.ifaceLinker = graph.NewMetadataIndexerLinker(g, p.ifaces, lpIndexer2, graph.Metadata{"RelationType": "mapping"})

--- a/topology/probes/ovnk8s/ovnk8s.go
+++ b/topology/probes/ovnk8s/ovnk8s.go
@@ -17,33 +17,106 @@
 package ovnk8s
 
 import (
-	"github.com/skydive-project/skydive/probe"
+	"fmt"
+	"strings"
 
 	"github.com/skydive-project/skydive/graffiti/graph"
 	"github.com/skydive-project/skydive/graffiti/logging"
+	"github.com/skydive-project/skydive/probe"
+	"github.com/skydive-project/skydive/topology"
 )
 
 // Probe describes an OVN-kubernetes probe
 type Probe struct {
 	graph.DefaultGraphListener
-	graph  *graph.Graph
-	bundle *probe.Bundle
+	graph         *graph.Graph
+	bundle        *probe.Bundle
+	podIndexer    *graph.MetadataIndexer
+	lspPodIndexer *graph.MetadataIndexer
+	ovnPodLinker  *graph.ResourceLinker
 }
 
+// Start starts the probe. Part of Probe interface
 func (p *Probe) Start() error {
 	return p.bundle.Start()
 }
 
+// Stop stops the probe. Part of Probe interface
 func (p *Probe) Stop() {
 	p.bundle.Stop()
+}
+
+// OnError handles linker errors. Part of LinkerEventListener interface
+func (p *Probe) OnError(err error) {
+	logging.GetLogger().Error("Linker error: %s", err.Error())
+}
+
+// ovnPodLinker implements ResourceLinker and creates links between pods and
+// logical_switch_ports
+type ovnPodLinker struct {
+	probe *Probe
+}
+
+// GetABLinks returns the links from a Pod to it's logical switch port
+func (l *ovnPodLinker) GetABLinks(podNode *graph.Node) (edges []*graph.Edge) {
+	name, _ := podNode.GetFieldString("Name")
+	namespace, _ := podNode.GetFieldString("K8s.Namespace")
+	combined := fmt.Sprintf("%s_%s", namespace, name)
+	lsPortNode, _ := l.probe.lspPodIndexer.GetNode(combined)
+	if lsPortNode != nil {
+		link, err := topology.NewLink(l.probe.graph, podNode, lsPortNode, topology.Layer2Link, nil)
+		if err != nil {
+			logging.GetLogger().Error(link)
+		}
+		logging.GetLogger().Debugf("Linking Pod (%s/%s) with Logical Port (%s)",
+			namespace, name, combined)
+		edges = append(edges, link)
+	}
+	return edges
+}
+
+// GetBALinks returns the links from a LogicalSwitchPort to its Pod
+func (l *ovnPodLinker) GetBALinks(lsPortNode *graph.Node) (edges []*graph.Edge) {
+	name, _ := lsPortNode.GetFieldString("Name")
+	split := strings.Split(name, "_")
+	if len(split) < 2 {
+		return edges
+	}
+	podNode, _ := l.probe.podIndexer.GetNode(split[1], split[0])
+	if podNode != nil {
+		link, err := topology.NewLink(l.probe.graph, podNode, lsPortNode, topology.Layer2Link, nil)
+		if err != nil {
+			logging.GetLogger().Error(link)
+		}
+		logging.GetLogger().Debugf("Linking Pod (%s/%s) with Logical Port (%s)",
+			split[0], split[1], name)
+		edges = append(edges, link)
+	}
+	return edges
 }
 
 // NewProbe creates a new graph OVN-kubernetes probe
 func NewProbe(g *graph.Graph) (probe.Handler, error) {
 	p := &Probe{
 		graph:  g,
-		bundle: &probe.Bundle{},
+		bundle: probe.NewBundle(),
 	}
+
+	p.podIndexer = graph.NewMetadataIndexer(g, g, graph.Metadata{"Type": "pod"}, "Name", "K8s.Namespace")
+	p.bundle.AddHandler("podIndexer", p.podIndexer)
+
+	p.lspPodIndexer = graph.NewMetadataIndexer(g, g, graph.Metadata{"Type": "logical_switch_port", "OVN.ExtID.pod": "true"}, "Name")
+	p.bundle.AddHandler("lspIndexer", p.lspPodIndexer)
+
+	p.ovnPodLinker = graph.NewResourceLinker(g,
+		[]graph.ListenerHandler{p.podIndexer},
+		[]graph.ListenerHandler{p.lspPodIndexer},
+		&ovnPodLinker{probe: p}, graph.Metadata{"Manager": "ovnk8s"})
+	p.bundle.AddHandler("ovnPodLinker", p.ovnPodLinker)
+	// Add Probe as event listener to report errors
+	p.ovnPodLinker.AddEventListener(p)
+
 	logging.GetLogger().Info("OVN-kubenetes probe created")
+
 	return p, nil
 }

--- a/topology/probes/ovnk8s/ovnk8s.go
+++ b/topology/probes/ovnk8s/ovnk8s.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+package ovnk8s
+
+import (
+	"github.com/skydive-project/skydive/probe"
+
+	"github.com/skydive-project/skydive/graffiti/graph"
+	"github.com/skydive-project/skydive/graffiti/logging"
+)
+
+// Probe describes an OVN-kubernetes probe
+type Probe struct {
+	graph.DefaultGraphListener
+	graph  *graph.Graph
+	bundle *probe.Bundle
+}
+
+func (p *Probe) Start() error {
+	return p.bundle.Start()
+}
+
+func (p *Probe) Stop() {
+	p.bundle.Stop()
+}
+
+// NewProbe creates a new graph OVN-kubernetes probe
+func NewProbe(g *graph.Graph) (probe.Handler, error) {
+	p := &Probe{
+		graph:  g,
+		bundle: &probe.Bundle{},
+	}
+	logging.GetLogger().Info("OVN-kubenetes probe created")
+	return p, nil
+}


### PR DESCRIPTION
## What this PR does
Add a new probe that enriches the topology graph with ovn-kubernetes information.
For now it is a very simple probe that only links pods with their logical switch ports based on their name. Starting with this as the base for more future features.

## Why it's useful
In deployments where ovn-kubernetes is present (e.g: openshift), this probes connects the information provided by the ovn probe and the kubernetes objects dectected by the k8s probe.

## Testing
This PR introduces a basic testing infrastructure:
- A new [kind](https://kind.sigs.k8s.io/)-based environment that also installs ovnk8s on top of it (based on [OVN kubernetes KIND setup](https://github.com/ovn-org/ovn-kubernetes/blob/master/docs/kind.md)). The ovnk8s-kind setup is controlled by a script in `scripts/ci/ovnkube-setup.sh`. This script is could eventually move to skydive-ci.
- Required changes to current k8s tests so that they also work on new setup
- ovnk8s-specific tests

Based on a clean fedora32, the script has the following dependencies:
- docker
- go
- python and pip
- skydive's build dependencies (libxml2-devel, libvirt-devel, libpcap-devel, protobuf-devel, npm)
It also requires the following ENV vars to be set:
- WORKSPACE: pointing to a directory where the test result logs will be stored
- GOPATH: where skydive source lives

Once the above dependencies are installed and ENV variables set, just run:
```
cd scripts/ci; ./run-ovnk8s-tests.sh
```
