### PR TITLE
how  switches can be discovered in the network topology?how to configure ？My question just likes yours.

### DIFF
--- a/agent/probes.go
+++ b/agent/probes.go
@@ -40,7 +40,9 @@ import (
 )
 
 // NewTopologyProbeBundleFromConfig creates a new topology probe.Bundle based on the configuration
-func NewTopologyProbeBundleFromConfig(g *graph.Graph, hostNode *graph.Node) (*probe.Bundle, error) {
+// 最后一个括号是函数的返回值，可以有多个
+// 第一括号为接收器
+func NewTopologyProbeBundleFromConfig(g *graph.Graph, hostNode *graph.Node) (*probe.Bundle, error) { 
 	list := config.GetStringSlice("agent.topology.probes")
 	logging.GetLogger().Infof("Topology probes: %v", list)
 


### PR DESCRIPTION
My question is similar to yours. There are two hosts and one switch. The host numbers are set to 192.168.1.100 and 192.168.1.50 respectively. I am not sure whether my switch has activated the LLDP probe, so I manually grab the port information in the form of fiber configuration. Why are there no two host nodes and one switch in my topology diagram.@lebauce @RunningXJ