### PR TITLE
Neighbors step

### DIFF
--- a/analyzer/server.go
+++ b/analyzer/server.go
@@ -333,6 +333,7 @@ func NewServerFromConfig() (*Server, error) {
 	tr.AddTraversalExtension(ge.NewSocketsTraversalExtension())
 	tr.AddTraversalExtension(ge.NewDescendantsTraversalExtension())
 	tr.AddTraversalExtension(ge.NewAscendantsTraversalExtension())
+	tr.AddTraversalExtension(ge.NewNeighborsTraversalExtension())
 	tr.AddTraversalExtension(ge.NewNextHopTraversalExtension())
 	tr.AddTraversalExtension(ge.NewGroupTraversalExtension())
 

--- a/go.mod
+++ b/go.mod
@@ -77,6 +77,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
+	github.com/stretchr/testify v1.7.0
 	github.com/t-yuki/gocover-cobertura v0.0.0-20180217150009-aaee18c8195c
 	github.com/tebeka/go2xunit v1.4.10
 	github.com/tebeka/selenium v0.0.0-20170314201507-657e45ec600f

--- a/go.sum
+++ b/go.sum
@@ -1001,8 +1001,9 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20160928074757-e7cb7fa329f4/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=

--- a/graffiti/graph/cachedbackend.go
+++ b/graffiti/graph/cachedbackend.go
@@ -99,6 +99,17 @@ func (c *CachedBackend) GetNode(i Identifier, t Context) []*Node {
 	return c.persistent.GetNode(i, t)
 }
 
+// GetNodesFromIDs retrieve the list of nodes for the list of identifiers from the cache within a time slice
+func (c *CachedBackend) GetNodesFromIDs(i []Identifier, t Context) []*Node {
+	mode := c.cacheMode.Load()
+
+	if t.TimeSlice == nil || mode == CacheOnlyMode || c.persistent == nil {
+		return c.memory.GetNodesFromIDs(i, t)
+	}
+
+	return c.persistent.GetNodesFromIDs(i, t)
+}
+
 // GetNodeEdges retrieve a list of edges from a node within a time slice, matching metadata
 func (c *CachedBackend) GetNodeEdges(n *Node, t Context, m ElementMatcher) (edges []*Edge) {
 	mode := c.cacheMode.Load()

--- a/graffiti/graph/cachedbackend.go
+++ b/graffiti/graph/cachedbackend.go
@@ -110,6 +110,17 @@ func (c *CachedBackend) GetNodeEdges(n *Node, t Context, m ElementMatcher) (edge
 	return c.persistent.GetNodeEdges(n, t, m)
 }
 
+// GetNodesEdges return the list of all edges for a list of nodes within time slice, matching metadata
+func (c *CachedBackend) GetNodesEdges(n []*Node, t Context, m ElementMatcher) (edges []*Edge) {
+	mode := c.cacheMode.Load()
+
+	if t.TimeSlice == nil || mode == CacheOnlyMode || c.persistent == nil {
+		return c.memory.GetNodesEdges(n, t, m)
+	}
+
+	return c.persistent.GetNodesEdges(n, t, m)
+}
+
 // EdgeAdded add an edge in the cache
 func (c *CachedBackend) EdgeAdded(e *Edge) error {
 	mode := c.cacheMode.Load()

--- a/graffiti/graph/graph.go
+++ b/graffiti/graph/graph.go
@@ -112,6 +112,7 @@ type Backend interface {
 	NodeDeleted(n *Node) error
 	GetNode(i Identifier, at Context) []*Node
 	GetNodeEdges(n *Node, at Context, m ElementMatcher) []*Edge
+	GetNodesEdges(n []*Node, at Context, m ElementMatcher) []*Edge
 
 	EdgeAdded(e *Edge) error
 	EdgeDeleted(e *Edge) error
@@ -1363,6 +1364,14 @@ func (g *Graph) GetEdgeNodes(e *Edge, parentMetadata, childMetadata ElementMatch
 // GetNodeEdges returns a list of edges of a node
 func (g *Graph) GetNodeEdges(n *Node, m ElementMatcher) []*Edge {
 	return g.backend.GetNodeEdges(n, g.context, m)
+}
+
+// GetNodesEdges returns the list with all edges for a list of nodes
+func (g *Graph) GetNodesEdges(n []*Node, m ElementMatcher) []*Edge {
+	if len(n) == 0 {
+		return []*Edge{}
+	}
+	return g.backend.GetNodesEdges(n, g.context, m)
 }
 
 func (g *Graph) String() string {

--- a/graffiti/graph/graph.go
+++ b/graffiti/graph/graph.go
@@ -111,6 +111,7 @@ type Backend interface {
 	NodeAdded(n *Node) error
 	NodeDeleted(n *Node) error
 	GetNode(i Identifier, at Context) []*Node
+	GetNodesFromIDs(i []Identifier, at Context) []*Node
 	GetNodeEdges(n *Node, at Context, m ElementMatcher) []*Edge
 	GetNodesEdges(n []*Node, at Context, m ElementMatcher) []*Edge
 
@@ -1184,6 +1185,14 @@ func (g *Graph) GetNode(i Identifier) *Node {
 		return nodes[0]
 	}
 	return nil
+}
+
+// GetNodesFromIDs returns a list of nodes from a list of identifiers
+func (g *Graph) GetNodesFromIDs(i []Identifier) []*Node {
+	if len(i) == 0 {
+		return []*Node{}
+	}
+	return g.backend.GetNodesFromIDs(i, g.context)
 }
 
 // CreateNode returns a new node not bound to a graph

--- a/graffiti/graph/memory.go
+++ b/graffiti/graph/memory.go
@@ -138,6 +138,17 @@ func (m *MemoryBackend) GetNode(i Identifier, t Context) []*Node {
 	return nil
 }
 
+// GetNodesFromIDs from the graph backend
+func (m *MemoryBackend) GetNodesFromIDs(identifiersList []Identifier, t Context) []*Node {
+	nodes := []*Node{}
+	for _, i := range identifiersList {
+		if n, ok := m.nodes[i]; ok {
+			nodes = append(nodes, n.Node)
+		}
+	}
+	return nodes
+}
+
 // GetNodeEdges returns a list of edges of a node
 func (m *MemoryBackend) GetNodeEdges(n *Node, t Context, meta ElementMatcher) []*Edge {
 	edges := []*Edge{}

--- a/graffiti/graph/memory.go
+++ b/graffiti/graph/memory.go
@@ -153,6 +153,22 @@ func (m *MemoryBackend) GetNodeEdges(n *Node, t Context, meta ElementMatcher) []
 	return edges
 }
 
+// GetNodesEdges returns the list of edges for a list of nodes
+func (m *MemoryBackend) GetNodesEdges(nodeList []*Node, t Context, meta ElementMatcher) []*Edge {
+	edges := []*Edge{}
+	for _, n := range nodeList {
+		if n, ok := m.nodes[n.ID]; ok {
+			for _, e := range n.edges {
+				if e.MatchMetadata(meta) {
+					edges = append(edges, e.Edge)
+				}
+			}
+		}
+	}
+
+	return edges
+}
+
 // EdgeDeleted in the graph backend
 func (m *MemoryBackend) EdgeDeleted(e *Edge) error {
 	if _, ok := m.edges[e.ID]; !ok {

--- a/graffiti/graph/orientdb.go
+++ b/graffiti/graph/orientdb.go
@@ -222,6 +222,23 @@ func (o *OrientDBBackend) GetNode(i Identifier, t Context) (nodes []*Node) {
 	return o.searchNodes(t, query)
 }
 
+func (o *OrientDBBackend) GetNodesFromIDs(identifiersList []Identifier, t Context) (nodes []*Node) {
+	query := orientdb.FilterToExpression(getTimeFilter(t.TimeSlice), nil)
+	query += fmt.Sprintf(" AND (")
+	for i, id := range identifiersList {
+		if i == len(identifiersList)-1 {
+			query += fmt.Sprintf(" ID = '%s') ORDER BY Revision", id)
+		} else {
+			query += fmt.Sprintf(" ID = '%s' OR", id)
+		}
+	}
+
+	if t.TimePoint {
+		query += " DESC LIMIT 1"
+	}
+	return o.searchNodes(t, query)
+}
+
 // GetNodeEdges returns a list of a node edges within time slice
 func (o *OrientDBBackend) GetNodeEdges(n *Node, t Context, m ElementMatcher) (edges []*Edge) {
 	query := orientdb.FilterToExpression(getTimeFilter(t.TimeSlice), nil)

--- a/graffiti/graph/traversal/traversal.go
+++ b/graffiti/graph/traversal/traversal.go
@@ -1415,14 +1415,12 @@ func (tv *GraphTraversalV) SubGraph(ctx StepContext, s ...interface{}) *GraphTra
 
 	// then insert edges, ignore edge insert error since one of the linked node couldn't be part
 	// of the SubGraph
-	for _, n := range tv.nodes {
-		edges := tv.GraphTraversal.Graph.GetNodeEdges(n, nil)
-		for _, e := range edges {
-			switch err := memory.EdgeAdded(e); err {
-			case nil, graph.ErrParentNotFound, graph.ErrChildNotFound, graph.ErrEdgeConflict:
-			default:
-				return &GraphTraversal{error: fmt.Errorf("Error while adding edge to SubGraph: %s", err)}
-			}
+	edges := tv.GraphTraversal.Graph.GetNodesEdges(tv.nodes, nil)
+	for _, e := range edges {
+		switch err := memory.EdgeAdded(e); err {
+		case nil, graph.ErrParentNotFound, graph.ErrChildNotFound, graph.ErrEdgeConflict:
+		default:
+			return &GraphTraversal{error: fmt.Errorf("Error while adding edge to SubGraph: %s", err)}
 		}
 	}
 

--- a/gremlin/traversal/neighbors.go
+++ b/gremlin/traversal/neighbors.go
@@ -1,0 +1,188 @@
+package traversal
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/skydive-project/skydive/graffiti/filters"
+	"github.com/skydive-project/skydive/graffiti/graph"
+	"github.com/skydive-project/skydive/graffiti/graph/traversal"
+	"github.com/skydive-project/skydive/topology"
+)
+
+// NeighborsTraversalExtension describes a new extension to enhance the topology
+type NeighborsTraversalExtension struct {
+	NeighborsToken traversal.Token
+}
+
+// NeighborsGremlinTraversalStep navigate the graph starting from a node, following edges
+// from parent to child and from child to parent.
+// It follows the same sintaxis as Ascendants and Descendants step.
+// The behaviour is like Ascendants+Descendants combined.
+// If only one param is defined, it is used as depth, eg: G.V('id').Neighbors(4)
+// If we have an event number of parameters, they are used as edge filter, and
+// depth is defaulted to one, eg.: G.V('id').Neighbors("Type","foo","RelationType","bar")
+// If we have an odd, but >1, number of parameters, all but the last one are used as
+// edge filters and the last one as depth, eg.: G.V('id').Neighbors("Type","foo","RelationType","bar",3)
+type NeighborsGremlinTraversalStep struct {
+	context    traversal.GremlinTraversalContext
+	maxDepth   int64
+	edgeFilter graph.ElementMatcher
+	// nextStepOnlyIDs is set to true if the next step only needs node IDs and not the whole node info
+	nextStepOnlyIDs bool
+}
+
+// NewNeighborsTraversalExtension returns a new graph traversal extension
+func NewNeighborsTraversalExtension() *NeighborsTraversalExtension {
+	return &NeighborsTraversalExtension{
+		NeighborsToken: traversalNeighborsToken,
+	}
+}
+
+// ScanIdent returns an associated graph token
+func (e *NeighborsTraversalExtension) ScanIdent(s string) (traversal.Token, bool) {
+	switch s {
+	case "NEIGHBORS":
+		return e.NeighborsToken, true
+	}
+	return traversal.IDENT, false
+}
+
+// ParseStep parses neighbors step
+func (e *NeighborsTraversalExtension) ParseStep(t traversal.Token, p traversal.GremlinTraversalContext) (traversal.GremlinTraversalStep, error) {
+	switch t {
+	case e.NeighborsToken:
+	default:
+		return nil, nil
+	}
+
+	maxDepth := int64(1)
+	edgeFilter, _ := topology.OwnershipMetadata().Filter()
+
+	switch len(p.Params) {
+	case 0:
+	default:
+		i := len(p.Params) / 2 * 2
+		filter, err := traversal.ParamsToFilter(filters.BoolFilterOp_OR, p.Params[:i]...)
+		if err != nil {
+			return nil, errors.Wrap(err, "Neighbors accepts an optional number of key/value tuples and an optional depth")
+		}
+		edgeFilter = filter
+
+		if i == len(p.Params) {
+			break
+		}
+
+		fallthrough
+	case 1:
+		depth, ok := p.Params[len(p.Params)-1].(int64)
+		if !ok {
+			return nil, errors.New("Neighbors last argument must be the maximum depth specified as an integer")
+		}
+		maxDepth = depth
+	}
+
+	return &NeighborsGremlinTraversalStep{context: p, maxDepth: maxDepth, edgeFilter: graph.NewElementFilter(edgeFilter)}, nil
+}
+
+// getNeighbors given a list of nodes, get its neighbors nodes for "maxDepth" depth relationships.
+// Edges between nodes must fulfill "edgeFilter" filter.
+// Nodes passed to this function will always be in the response.
+func (d *NeighborsGremlinTraversalStep) getNeighbors(g *graph.Graph, nodes []*graph.Node) []*graph.Node {
+	// visitedNodes store neighors and avoid visiting twice the same node
+	visitedNodes := map[graph.Identifier]interface{}{}
+
+	// currentDepthNodesIDs slice with the nodes being processed in each depth.
+	// We use "empty" while procesing the neighbors nodes to avoid extra calls to the backend.
+	var currentDepthNodesIDs []graph.Identifier
+	// nextDepthNodes slice were next depth nodes are being stored.
+	// Initializated with the list of origin nodes where it should start from.
+	nextDepthNodesIDs := make([]graph.Identifier, 0, len(nodes))
+
+	// Mark origin nodes as already visited
+	// Neighbor step will return also the origin nodes
+	for _, n := range nodes {
+		visitedNodes[n.ID] = struct{}{}
+		nextDepthNodesIDs = append(nextDepthNodesIDs, n.ID)
+	}
+
+	// DFS
+	// BFS must not be used because could lead to ignore some servers in this case:
+	//   A -> B
+	//   B -> C
+	//   C -> D
+	//   A -> C
+	//   With depth=2, BFS will return A,B,C (C is visited in A->B->C, si ignored in A->C->D)
+	//   DFS will return, the correct, A,B,C,D
+	for i := 0; i < int(d.maxDepth); i++ {
+		// Copy values from nextDepthNodes to currentDepthNodes
+		currentDepthNodesIDs = make([]graph.Identifier, len(nextDepthNodesIDs))
+		copy(currentDepthNodesIDs, nextDepthNodesIDs)
+
+		nextDepthNodesIDs = nextDepthNodesIDs[:0] // Clean slice, keeping capacity
+		// Get all edges for the list of nodes, filtered by edgeFilter
+		// Convert the list of node ids to a list of nodes
+
+		currentDepthNodes := make([]*graph.Node, 0, len(currentDepthNodesIDs))
+		for _, nID := range currentDepthNodesIDs {
+			currentDepthNodes = append(currentDepthNodes, graph.CreateNode(nID, graph.Metadata{}, graph.Unix(0, 0), "", ""))
+		}
+		edges := g.GetNodesEdges(currentDepthNodes, d.edgeFilter)
+
+		for _, e := range edges {
+			// Get nodeID of the other side of the edge
+			// Store neighbors
+			// We don't know in which side of the edge are the neighbors, so, add both sides if not already visited
+			_, okParent := visitedNodes[e.Parent]
+			if !okParent {
+				visitedNodes[e.Parent] = struct{}{}
+				// Do not walk nodes already processed
+				nextDepthNodesIDs = append(nextDepthNodesIDs, e.Parent)
+			}
+			_, okChild := visitedNodes[e.Child]
+			if !okChild {
+				visitedNodes[e.Child] = struct{}{}
+				nextDepthNodesIDs = append(nextDepthNodesIDs, e.Child)
+			}
+		}
+	}
+
+	// Return "empty" nodes (just with the ID) if the next step only need that info
+	if d.nextStepOnlyIDs {
+		ret := make([]*graph.Node, 0, len(visitedNodes))
+		for nID := range visitedNodes {
+			ret = append(ret, graph.CreateNode(nID, graph.Metadata{}, graph.Unix(0, 0), "", ""))
+		}
+		return ret
+	}
+
+	// Get concurrentl all nodes for the list of neighbors ids
+	nodesIDs := make([]graph.Identifier, 0, len(visitedNodes))
+	for n := range visitedNodes {
+		nodesIDs = append(nodesIDs, n)
+	}
+
+	return g.GetNodesFromIDs(nodesIDs)
+}
+
+// Exec Neighbors step
+func (d *NeighborsGremlinTraversalStep) Exec(last traversal.GraphTraversalStep) (traversal.GraphTraversalStep, error) {
+	switch tv := last.(type) {
+	case *traversal.GraphTraversalV:
+		tv.GraphTraversal.RLock()
+		neighbors := d.getNeighbors(tv.GraphTraversal.Graph, tv.GetNodes())
+		tv.GraphTraversal.RUnlock()
+
+		return traversal.NewGraphTraversalV(tv.GraphTraversal, neighbors), nil
+	}
+	return nil, traversal.ErrExecutionError
+}
+
+// Reduce Neighbors step
+func (d *NeighborsGremlinTraversalStep) Reduce(next traversal.GremlinTraversalStep) (traversal.GremlinTraversalStep, error) {
+	return next, nil
+}
+
+// Context Neighbors step
+func (d *NeighborsGremlinTraversalStep) Context() *traversal.GremlinTraversalContext {
+	return &d.context
+}

--- a/gremlin/traversal/neighbors_test.go
+++ b/gremlin/traversal/neighbors_test.go
@@ -1,0 +1,489 @@
+package traversal
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/skydive-project/skydive/graffiti/filters"
+	"github.com/skydive-project/skydive/graffiti/graph"
+	"github.com/skydive-project/skydive/graffiti/graph/traversal"
+	"github.com/skydive-project/skydive/topology"
+	"github.com/stretchr/testify/assert"
+)
+
+// FakeNeighborsSlowGraphBackend simulate a backend with history that could store different revisions of nodes
+type FakeNeighborsSlowGraphBackend struct {
+	Backend *graph.MemoryBackend
+}
+
+func (f *FakeNeighborsSlowGraphBackend) NodeAdded(n *graph.Node) error {
+	return f.Backend.NodeAdded(n)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) NodeDeleted(n *graph.Node) error {
+	return f.Backend.NodeDeleted(n)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) GetNode(i graph.Identifier, at graph.Context) []*graph.Node {
+	time.Sleep(20 * time.Millisecond)
+	return f.Backend.GetNode(i, at)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) GetNodesFromIDs(i []graph.Identifier, at graph.Context) []*graph.Node {
+	time.Sleep(40 * time.Millisecond)
+	return f.Backend.GetNodesFromIDs(i, at)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) GetNodeEdges(n *graph.Node, at graph.Context, m graph.ElementMatcher) []*graph.Edge {
+	time.Sleep(20 * time.Millisecond)
+	return f.Backend.GetNodeEdges(n, at, m)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) GetNodesEdges(n []*graph.Node, at graph.Context, m graph.ElementMatcher) []*graph.Edge {
+	time.Sleep(40 * time.Millisecond)
+	return f.Backend.GetNodesEdges(n, at, m)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) EdgeAdded(e *graph.Edge) error {
+	return f.Backend.EdgeAdded(e)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) EdgeDeleted(e *graph.Edge) error {
+	return f.Backend.EdgeDeleted(e)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) GetEdge(i graph.Identifier, at graph.Context) []*graph.Edge {
+	return f.Backend.GetEdge(i, at)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) GetEdgeNodes(e *graph.Edge, at graph.Context, parentMetadata graph.ElementMatcher, childMetadata graph.ElementMatcher) ([]*graph.Node, []*graph.Node) {
+	return f.Backend.GetEdgeNodes(e, at, parentMetadata, childMetadata)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) MetadataUpdated(e interface{}) error {
+	return f.Backend.MetadataUpdated(e)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) GetNodes(t graph.Context, e graph.ElementMatcher) []*graph.Node {
+	return f.Backend.GetNodes(t, e)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) GetEdges(t graph.Context, e graph.ElementMatcher) []*graph.Edge {
+	return f.Backend.GetEdges(t, e)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) IsHistorySupported() bool {
+	return f.Backend.IsHistorySupported()
+}
+
+func TestGetNeighbors(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		graphNodes    []*graph.Node
+		graphEdges    []*graph.Edge
+		originNodes   []*graph.Node
+		maxDepth      int64
+		edgeFilter    graph.ElementMatcher
+		onlyIDs       bool
+		expectedNodes []*graph.Node
+	}{
+		{
+			desc: "one graph node",
+			graphNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("A"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+			graphEdges: []*graph.Edge{},
+			originNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("A"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+			maxDepth:   0,
+			edgeFilter: nil,
+			expectedNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("A"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+		},
+		{
+			desc: "one graph node with only ids strip all node data except id",
+			graphNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("A"), graph.Metadata{"foo": "bar"}, graph.Unix(100, 0), "host", "origin"),
+			},
+			graphEdges: []*graph.Edge{},
+			originNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("A"), graph.Metadata{"foo": "bar"}, graph.Unix(100, 0), "host", "origin"),
+			},
+			maxDepth:   0,
+			edgeFilter: nil,
+			onlyIDs:    true,
+			expectedNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("A"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+		},
+		{
+			desc: "interface connected to host and to other interface",
+			graphNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+			graphEdges: []*graph.Edge{
+				graph.CreateEdge(
+					graph.Identifier("HostA-IntA"),
+					graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.Metadata{"RelationType": "ownership"},
+					graph.Unix(0, 0),
+					"",
+					"",
+				),
+				graph.CreateEdge(
+					graph.Identifier("IntA-IntB"),
+					graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.Metadata{"RelationType": "ConnectsTo"},
+					graph.Unix(0, 0),
+					"",
+					"",
+				),
+			},
+			originNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+			maxDepth:   1,
+			edgeFilter: nil,
+			expectedNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+		},
+		{
+			desc: "host connected to interface and that to other interface, depth 2",
+			graphNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+			graphEdges: []*graph.Edge{
+				graph.CreateEdge(
+					graph.Identifier("HostA-IntA"),
+					graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.Metadata{"RelationType": "ownership"},
+					graph.Unix(0, 0),
+					"",
+					"",
+				),
+				graph.CreateEdge(
+					graph.Identifier("IntA-IntB"),
+					graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.Metadata{"RelationType": "ConnectsTo"},
+					graph.Unix(0, 0),
+					"",
+					"",
+				),
+			},
+			originNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+			maxDepth:   2,
+			edgeFilter: nil,
+			expectedNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+		},
+		{
+			desc: "two hosts connected through interfaces, depth 3",
+			graphNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("HostB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+			graphEdges: []*graph.Edge{
+				graph.CreateEdge(
+					graph.Identifier("HostA-IntA"),
+					graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.Metadata{"RelationType": "ownership"},
+					graph.Unix(0, 0),
+					"",
+					"",
+				),
+				graph.CreateEdge(
+					graph.Identifier("HostB-IntB"),
+					graph.CreateNode(graph.Identifier("HostB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.Metadata{"RelationType": "ownership"},
+					graph.Unix(0, 0),
+					"",
+					"",
+				),
+				graph.CreateEdge(
+					graph.Identifier("IntA-IntB"),
+					graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.Metadata{"RelationType": "ConnectsTo"},
+					graph.Unix(0, 0),
+					"",
+					"",
+				),
+			},
+			originNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+			maxDepth:   3,
+			edgeFilter: nil,
+			expectedNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("HostB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+		}, {
+			desc: "two hosts connected through interfaces, reverse connection, depth 3",
+			graphNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("HostB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+			graphEdges: []*graph.Edge{
+				graph.CreateEdge(
+					graph.Identifier("HostA-IntA"),
+					graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.Metadata{"RelationType": "ownership"},
+					graph.Unix(0, 0),
+					"",
+					"",
+				),
+				graph.CreateEdge(
+					graph.Identifier("HostB-IntB"),
+					graph.CreateNode(graph.Identifier("HostB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.Metadata{"RelationType": "ownership"},
+					graph.Unix(0, 0),
+					"",
+					"",
+				),
+				graph.CreateEdge(
+					graph.Identifier("IntB-IntA"),
+					graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.Metadata{"RelationType": "ConnectsTo"},
+					graph.Unix(0, 0),
+					"",
+					"",
+				),
+			},
+			originNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+			maxDepth:   3,
+			edgeFilter: nil,
+			expectedNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("HostB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+		},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			b, err := graph.NewMemoryBackend()
+			if err != nil {
+				t.Error(err.Error())
+			}
+			g := graph.NewGraph("testhost", b, "analyzer.testhost")
+
+			for _, n := range tC.graphNodes {
+				err := g.AddNode(n)
+				if err != nil {
+					t.Error(err.Error())
+				}
+			}
+
+			for _, e := range tC.graphEdges {
+				err := g.AddEdge(e)
+				if err != nil {
+					t.Error(err.Error())
+				}
+			}
+
+			d := NeighborsGremlinTraversalStep{
+				maxDepth:        tC.maxDepth,
+				edgeFilter:      tC.edgeFilter,
+				nextStepOnlyIDs: tC.onlyIDs,
+			}
+			neighbors := d.getNeighbors(g, tC.originNodes)
+
+			assert.ElementsMatch(t, neighbors, tC.expectedNodes)
+
+		})
+	}
+}
+
+func TestNeighborsParseStep(t *testing.T) {
+	ownershipFilter, err := topology.OwnershipMetadata().Filter()
+	assert.Nil(t, err)
+
+	relationTypeFooFilter, err := traversal.ParamsToFilter(filters.BoolFilterOp_OR, "RelationType", "foo")
+	assert.Nil(t, err)
+
+	relationTypeFooTypeBarFilter, err := traversal.ParamsToFilter(filters.BoolFilterOp_OR, "RelationType", "foo", "Type", "bar")
+	assert.Nil(t, err)
+
+	tests := []struct {
+		name                  string
+		token                 traversal.Token
+		traversalCtx          traversal.GremlinTraversalContext
+		expectedTraversalStep traversal.GremlinTraversalStep
+		expectedError         string
+	}{
+		{
+			name:  "non merge token",
+			token: traversal.COUNT,
+		},
+		{
+			name:  "nil traversalCtx is default values, depth one and ownership edge filter",
+			token: traversalNeighborsToken,
+			expectedTraversalStep: &NeighborsGremlinTraversalStep{
+				maxDepth:   1,
+				edgeFilter: graph.NewElementFilter(ownershipFilter),
+			},
+		},
+		{
+			name:  "one string param",
+			token: traversalNeighborsToken,
+			traversalCtx: traversal.GremlinTraversalContext{
+				Params: []interface{}{"foo"},
+			},
+			expectedError: "Neighbors last argument must be the maximum depth specified as an integer",
+		},
+		{
+			name:  "only one param, int number, is depth",
+			token: traversalNeighborsToken,
+			traversalCtx: traversal.GremlinTraversalContext{
+				Params: []interface{}{int64(3)},
+			},
+			expectedTraversalStep: &NeighborsGremlinTraversalStep{
+				context: traversal.GremlinTraversalContext{
+					Params: []interface{}{int64(3)},
+				},
+				maxDepth:   3,
+				edgeFilter: graph.NewElementFilter(ownershipFilter),
+			},
+		},
+		{
+			name:  "two string params are used as edge filter",
+			token: traversalNeighborsToken,
+			traversalCtx: traversal.GremlinTraversalContext{
+				Params: []interface{}{"RelationType", "foo"},
+			},
+			expectedTraversalStep: &NeighborsGremlinTraversalStep{
+				context: traversal.GremlinTraversalContext{
+					Params: []interface{}{"RelationType", "foo"},
+				},
+				maxDepth:   1,
+				edgeFilter: graph.NewElementFilter(relationTypeFooFilter),
+			},
+		},
+		{
+			name:  "four string params are used as edge filter and last int64 as depth",
+			token: traversalNeighborsToken,
+			traversalCtx: traversal.GremlinTraversalContext{
+				Params: []interface{}{"RelationType", "foo", "Type", "bar", int64(5)},
+			},
+			expectedTraversalStep: &NeighborsGremlinTraversalStep{
+				context: traversal.GremlinTraversalContext{
+					Params: []interface{}{"RelationType", "foo", "Type", "bar", int64(5)},
+				},
+				maxDepth:   5,
+				edgeFilter: graph.NewElementFilter(relationTypeFooTypeBarFilter),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			e := NeighborsTraversalExtension{NeighborsToken: traversalNeighborsToken}
+
+			traversalStep, err := e.ParseStep(test.token, test.traversalCtx)
+			if test.expectedError != "" {
+				assert.EqualErrorf(t, err, test.expectedError, "error")
+			} else {
+				assert.Nil(t, err, "nil error")
+			}
+
+			assert.Equalf(t, test.expectedTraversalStep, traversalStep, "step")
+		})
+	}
+}
+
+func BenchmarkGetNeighbors(b *testing.B) {
+	// Create graph with nodes and edges
+	backend, err := graph.NewMemoryBackend()
+	if err != nil {
+		b.Error(err.Error())
+	}
+
+	slowBackend := FakeNeighborsSlowGraphBackend{backend}
+	g := graph.NewGraph("testhost", &slowBackend, "analyzer.testhost")
+
+	parentNodes := 20
+
+	var node *graph.Node
+	var nodeChild *graph.Node
+	for n := 0; n < parentNodes; n++ {
+		node, err = g.NewNode(graph.Identifier(fmt.Sprintf("%d", n)), graph.Metadata{})
+		if err != nil {
+			b.Error(err.Error())
+		}
+
+		//  Childs of this node
+		for nc := 0; nc < 60; nc++ {
+			nodeChild, err = g.NewNode(graph.Identifier(fmt.Sprintf("%d-%d", n, nc)), graph.Metadata{})
+			if err != nil {
+				b.Error(err.Error())
+			}
+
+			_, err = g.NewEdge(graph.Identifier(fmt.Sprintf("%d-%d", n, nc)), node, nodeChild, graph.Metadata{})
+			if err != nil {
+				b.Error(err.Error())
+			}
+		}
+	}
+
+	// Each node connects with its next
+	nextNodeConnect := 5
+	for n := 0; n < parentNodes-nextNodeConnect; n++ {
+		for p := 1; p < nextNodeConnect; p++ {
+			// Connect interfaces
+			ifaceParentNode := g.GetNode(graph.Identifier(fmt.Sprintf("%d-%d", n, p)))
+			ifaceChildNode := g.GetNode(graph.Identifier(fmt.Sprintf("%d-%d", n+p, n)))
+
+			_, err = g.NewEdge(graph.Identifier(fmt.Sprintf("c-%d-%d", n, p)), ifaceParentNode, ifaceChildNode, graph.Metadata{})
+			if err != nil {
+				b.Error(err.Error())
+			}
+		}
+
+	}
+
+	// Using depth=8 we get a total of 798 neighbors
+	d := NeighborsGremlinTraversalStep{
+		maxDepth: 8,
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		d.getNeighbors(g, []*graph.Node{g.GetNode(graph.Identifier("1"))})
+	}
+}

--- a/gremlin/traversal/token.go
+++ b/gremlin/traversal/token.go
@@ -34,4 +34,5 @@ const (
 	traversalGroupToken       traversal.Token = 1012
 	traversalMoreThanToken    traversal.Token = 1013
 	traversalAscendantsToken  traversal.Token = 1014
+	traversalNeighborsToken   traversal.Token = 1015
 )

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -177,6 +177,7 @@ func isGremlinExpr(v interface{}, param string) error {
 	tr.AddTraversalExtension(ge.NewRawPacketsTraversalExtension())
 	tr.AddTraversalExtension(ge.NewDescendantsTraversalExtension())
 	tr.AddTraversalExtension(ge.NewAscendantsTraversalExtension())
+	tr.AddTraversalExtension(ge.NewNeighborsTraversalExtension())
 	tr.AddTraversalExtension(ge.NewNextHopTraversalExtension())
 	tr.AddTraversalExtension(ge.NewGroupTraversalExtension())
 


### PR DESCRIPTION
Like Descendants, but using edges in any direction (Descendants only
uses edges from parent to child, Neighbors uses from parent to child and
from child to parent).

The different with the Both step, is Neighbors accumulate nodes seen.
Example (pseudo-syntax):
A -> B -> C
G.V(A).Out().Out() return: C.

But:
G.V(A).Neighbors(2) return: A,B,C

The parameters allowed are the same as in Descendants.
Example:
G.V('foo').Neighbors('RelationType',Within('ownership','foobar'),2)