### PR TITLE
Improve subgraph performance with persistent backends

### DIFF
--- a/graffiti/graph/cachedbackend.go
+++ b/graffiti/graph/cachedbackend.go
@@ -110,6 +110,17 @@ func (c *CachedBackend) GetNodeEdges(n *Node, t Context, m ElementMatcher) (edge
 	return c.persistent.GetNodeEdges(n, t, m)
 }
 
+// GetNodesEdges return the list of all edges for a list of nodes within time slice, matching metadata
+func (c *CachedBackend) GetNodesEdges(n []*Node, t Context, m ElementMatcher) (edges []*Edge) {
+	mode := c.cacheMode.Load()
+
+	if t.TimeSlice == nil || mode == CacheOnlyMode || c.persistent == nil {
+		return c.memory.GetNodesEdges(n, t, m)
+	}
+
+	return c.persistent.GetNodesEdges(n, t, m)
+}
+
 // EdgeAdded add an edge in the cache
 func (c *CachedBackend) EdgeAdded(e *Edge) error {
 	mode := c.cacheMode.Load()

--- a/graffiti/graph/graph.go
+++ b/graffiti/graph/graph.go
@@ -112,6 +112,7 @@ type Backend interface {
 	NodeDeleted(n *Node) error
 	GetNode(i Identifier, at Context) []*Node
 	GetNodeEdges(n *Node, at Context, m ElementMatcher) []*Edge
+	GetNodesEdges(n []*Node, at Context, m ElementMatcher) []*Edge
 
 	EdgeAdded(e *Edge) error
 	EdgeDeleted(e *Edge) error
@@ -1363,6 +1364,14 @@ func (g *Graph) GetEdgeNodes(e *Edge, parentMetadata, childMetadata ElementMatch
 // GetNodeEdges returns a list of edges of a node
 func (g *Graph) GetNodeEdges(n *Node, m ElementMatcher) []*Edge {
 	return g.backend.GetNodeEdges(n, g.context, m)
+}
+
+// GetNodesEdges returns the list with all edges for a list of nodes
+func (g *Graph) GetNodesEdges(n []*Node, m ElementMatcher) []*Edge {
+	if len(n) == 0 {
+		return []*Edge{}
+	}
+	return g.backend.GetNodesEdges(n, g.context, m)
 }
 
 func (g *Graph) String() string {

--- a/graffiti/graph/memory.go
+++ b/graffiti/graph/memory.go
@@ -153,6 +153,22 @@ func (m *MemoryBackend) GetNodeEdges(n *Node, t Context, meta ElementMatcher) []
 	return edges
 }
 
+// GetNodesEdges returns the list of edges for a list of nodes
+func (m *MemoryBackend) GetNodesEdges(nodeList []*Node, t Context, meta ElementMatcher) []*Edge {
+	edges := []*Edge{}
+	for _, n := range nodeList {
+		if n, ok := m.nodes[n.ID]; ok {
+			for _, e := range n.edges {
+				if e.MatchMetadata(meta) {
+					edges = append(edges, e.Edge)
+				}
+			}
+		}
+	}
+
+	return edges
+}
+
 // EdgeDeleted in the graph backend
 func (m *MemoryBackend) EdgeDeleted(e *Edge) error {
 	if _, ok := m.edges[e.ID]; !ok {

--- a/graffiti/graph/traversal/traversal.go
+++ b/graffiti/graph/traversal/traversal.go
@@ -1415,14 +1415,12 @@ func (tv *GraphTraversalV) SubGraph(ctx StepContext, s ...interface{}) *GraphTra
 
 	// then insert edges, ignore edge insert error since one of the linked node couldn't be part
 	// of the SubGraph
-	for _, n := range tv.nodes {
-		edges := tv.GraphTraversal.Graph.GetNodeEdges(n, nil)
-		for _, e := range edges {
-			switch err := memory.EdgeAdded(e); err {
-			case nil, graph.ErrParentNotFound, graph.ErrChildNotFound, graph.ErrEdgeConflict:
-			default:
-				return &GraphTraversal{error: fmt.Errorf("Error while adding edge to SubGraph: %s", err)}
-			}
+	edges := tv.GraphTraversal.Graph.GetNodesEdges(tv.nodes, nil)
+	for _, e := range edges {
+		switch err := memory.EdgeAdded(e); err {
+		case nil, graph.ErrParentNotFound, graph.ErrChildNotFound, graph.ErrEdgeConflict:
+		default:
+			return &GraphTraversal{error: fmt.Errorf("Error while adding edge to SubGraph: %s", err)}
 		}
 	}
 


### PR DESCRIPTION
Do just one call to get all the edges for the given nodes, instead of
one call for each node.

This new call has been added as a new method to Graph and Backends.
GetNodesEdges, return the list with all edges for a list of nodes.

Batching is used to avoid hitting the max number of clauses set by ES
(is set to the default value of 512).