### PR TITLE
ElasticSearch allow to recover more than 10k documents

### DIFF
--- a/graffiti/graph/elasticsearch.go
+++ b/graffiti/graph/elasticsearch.go
@@ -233,7 +233,7 @@ func (b *ElasticSearchBackend) GetNode(i Identifier, t Context) []*Node {
 			SortBy: "Revision",
 		},
 		TimeFilter: getTimeFilter(t.TimeSlice),
-	})
+	}, false)
 
 	if len(nodes) > 1 && t.TimePoint {
 		return []*Node{nodes[len(nodes)-1]}
@@ -293,7 +293,7 @@ func (b *ElasticSearchBackend) GetEdge(i Identifier, t Context) []*Edge {
 			SortBy: "Revision",
 		},
 		TimeFilter: getTimeFilter(t.TimeSlice),
-	})
+	}, false)
 
 	if len(edges) > 1 && t.TimePoint {
 		return []*Edge{edges[len(edges)-1]}
@@ -335,7 +335,12 @@ func (b *ElasticSearchBackend) MetadataUpdated(i interface{}) error {
 }
 
 // Query the database for a "node" or "edge"
-func (b *ElasticSearchBackend) Query(typ string, tsq *TimedSearchQuery) (sr *elastic.SearchResult, _ error) {
+// Return a channel where the hits will be send.
+// Done channel indicates the query has finished
+func (b *ElasticSearchBackend) Query(typ string, tsq *TimedSearchQuery, scrollAPI bool, hits chan<- *elastic.SearchHit) {
+	// close the channel to notify the consumer that all data has been sent
+	defer close(hits)
+
 	fltrs := []elastic.Query{
 		es.FormatFilter(filters.NewTermStringFilter("_Type", typ), nil),
 	}
@@ -354,48 +359,60 @@ func (b *ElasticSearchBackend) Query(typ string, tsq *TimedSearchQuery) (sr *ela
 
 	mustQuery := elastic.NewBoolQuery().Must(fltrs...)
 
-	return b.client.Search(mustQuery, tsq.SearchQuery, b.liveIndex.Alias(b.indexPrefix), b.archiveIndex.IndexWildcard(b.indexPrefix))
+	if scrollAPI {
+		err := b.client.Scroll(hits, mustQuery, tsq.SearchQuery, b.liveIndex.Alias(b.indexPrefix), b.archiveIndex.IndexWildcard(b.indexPrefix))
+		if err != nil {
+			b.logger.Errorf("Failed to query ElasticSearch Scroll API: %v", err)
+		}
+	} else {
+		out, err := b.client.Search(mustQuery, tsq.SearchQuery, b.liveIndex.Alias(b.indexPrefix), b.archiveIndex.IndexWildcard(b.indexPrefix))
+		if err != nil {
+			b.logger.Errorf("Failed to query ElasticSearch Search API: %v", err)
+			return
+		}
+		// If the seach query is correct, send all the hits to the consumer
+		for _, h := range out.Hits.Hits {
+			hits <- h
+		}
+	}
 }
 
 // searchNodes search nodes matching the query
-func (b *ElasticSearchBackend) searchNodes(tsq *TimedSearchQuery) (nodes []*Node) {
-	out, err := b.Query(nodeType, tsq)
-	if err != nil {
-		b.logger.Errorf("Failed to query nodes: %s", err)
-		return
-	}
+func (b *ElasticSearchBackend) searchNodes(tsq *TimedSearchQuery, scrollAPI bool) (nodes []*Node) {
+	// Channel to get results from the query
+	hits := make(chan *elastic.SearchHit, 100)
 
-	if out != nil && len(out.Hits.Hits) > 0 {
-		for _, d := range out.Hits.Hits {
-			var node Node
-			if err := json.Unmarshal(d.Source, &node); err != nil {
-				b.logger.Errorf("Failed to unmarshal node %s: %s", err, string(d.Source))
-				continue
-			}
-			nodes = append(nodes, &node)
+	// New goroutine to execute the get the data from ElasticSearch
+	go b.Query(nodeType, tsq, scrollAPI, hits)
+
+	// Get all the hits till the channel is closed by the producer (elasticsearch client)
+	for d := range hits {
+		var node Node
+		if err := json.Unmarshal(d.Source, &node); err != nil {
+			b.logger.Errorf("Failed to unmarshal node %s: %s", err, string(d.Source))
+			continue
 		}
+		nodes = append(nodes, &node)
 	}
 
 	return
 }
 
 // searchEdges search edges matching the query
-func (b *ElasticSearchBackend) searchEdges(tsq *TimedSearchQuery) (edges []*Edge) {
-	out, err := b.Query(edgeType, tsq)
-	if err != nil {
-		b.logger.Errorf("Failed to query edges: %s", err)
-		return
-	}
+func (b *ElasticSearchBackend) searchEdges(tsq *TimedSearchQuery, scrollAPI bool) (edges []*Edge) {
+	// Channel to get results from the query
+	hits := make(chan *elastic.SearchHit, 100)
 
-	if out != nil && len(out.Hits.Hits) > 0 {
-		for _, d := range out.Hits.Hits {
-			var edge Edge
-			if err := json.Unmarshal(d.Source, &edge); err != nil {
-				b.logger.Errorf("Failed to unmarshal edge %s: %s", err, string(d.Source))
-				continue
-			}
-			edges = append(edges, &edge)
+	// New goroutine to execute the get the data from ElasticSearch
+	go b.Query(edgeType, tsq, scrollAPI, hits)
+
+	for d := range hits {
+		var edge Edge
+		if err := json.Unmarshal(d.Source, &edge); err != nil {
+			b.logger.Errorf("Failed to unmarshal edge %s: %s", err, string(d.Source))
+			continue
 		}
+		edges = append(edges, &edge)
 	}
 
 	return
@@ -403,6 +420,13 @@ func (b *ElasticSearchBackend) searchEdges(tsq *TimedSearchQuery) (edges []*Edge
 
 // GetEdges returns a list of edges within time slice, matching metadata
 func (b *ElasticSearchBackend) GetEdges(t Context, m ElementMatcher) []*Edge {
+	return b.getEdges(t, m, false)
+}
+
+// getEdges returns a list of edges within time slice, matching metadata
+// It uses the Search API if scrollAPI is false.
+// Otherwise, use the Scroll API.
+func (b *ElasticSearchBackend) getEdges(t Context, m ElementMatcher, scrollAPI bool) []*Edge {
 	var filter *filters.Filter
 	if m != nil {
 		f, err := m.Filter()
@@ -421,7 +445,7 @@ func (b *ElasticSearchBackend) GetEdges(t Context, m ElementMatcher) []*Edge {
 		SearchQuery:   searchQuery,
 		TimeFilter:    getTimeFilter(t.TimeSlice),
 		ElementFilter: filter,
-	})
+	}, scrollAPI)
 
 	if t.TimePoint {
 		edges = dedupEdges(edges)
@@ -432,6 +456,13 @@ func (b *ElasticSearchBackend) GetEdges(t Context, m ElementMatcher) []*Edge {
 
 // GetNodes returns a list of nodes within time slice, matching metadata
 func (b *ElasticSearchBackend) GetNodes(t Context, m ElementMatcher) []*Node {
+	return b.getNodes(t, m, false)
+}
+
+// getNodes returns a list of nodes within time slice, matching metadata.
+// It uses the Search API if scrollAPI is false.
+// Otherwise, use the Scroll API.
+func (b *ElasticSearchBackend) getNodes(t Context, m ElementMatcher, scrollAPI bool) []*Node {
 	var filter *filters.Filter
 	if m != nil {
 		f, err := m.Filter()
@@ -450,7 +481,7 @@ func (b *ElasticSearchBackend) GetNodes(t Context, m ElementMatcher) []*Node {
 		SearchQuery:   searchQuery,
 		TimeFilter:    getTimeFilter(t.TimeSlice),
 		ElementFilter: filter,
-	})
+	}, scrollAPI)
 
 	if len(nodes) > 1 && t.TimePoint {
 		nodes = dedupNodes(nodes)
@@ -497,7 +528,7 @@ func (b *ElasticSearchBackend) GetNodeEdges(n *Node, t Context, m ElementMatcher
 		SearchQuery:   searchQuery,
 		TimeFilter:    getTimeFilter(t.TimeSlice),
 		ElementFilter: filter,
-	})
+	}, false)
 
 	if len(edges) > 1 && t.TimePoint {
 		edges = dedupEdges(edges)
@@ -548,7 +579,7 @@ func (b *ElasticSearchBackend) FlushElements(m ElementMatcher) error {
 // Sync adds all the nodes and edges with the specified filter into an other graph
 func (b *ElasticSearchBackend) Sync(g *Graph, elementFilter *ElementFilter) error {
 	// re-insert valid nodes and edges
-	for _, node := range b.GetNodes(Context{}, elementFilter) {
+	for _, node := range b.getNodes(Context{}, elementFilter, true) {
 		g.NodeAdded(node)
 
 		raw, err := nodeToRaw(node)
@@ -559,7 +590,7 @@ func (b *ElasticSearchBackend) Sync(g *Graph, elementFilter *ElementFilter) erro
 		b.prevRevision[node.ID] = raw
 	}
 
-	for _, edge := range b.GetEdges(Context{}, elementFilter) {
+	for _, edge := range b.getEdges(Context{}, elementFilter, true) {
 		g.EdgeAdded(edge)
 
 		raw, err := edgeToRaw(edge)

--- a/graffiti/graph/elasticsearch_test.go
+++ b/graffiti/graph/elasticsearch_test.go
@@ -40,6 +40,10 @@ type fakeESClient struct {
 	searchResult elastic.SearchResult
 }
 
+func (f *fakeESClient) Scroll(hits chan<- *elastic.SearchHit, query elastic.Query, pagination filters.SearchQuery, indices ...string) error {
+	return nil
+}
+
 func (f *fakeESClient) resetIndices() {
 	f.indices = make(map[string]*fakeESIndex)
 }

--- a/graffiti/storage/elasticsearch/client.go
+++ b/graffiti/storage/elasticsearch/client.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"sort"
@@ -43,6 +44,11 @@ import (
 const (
 	schemaVersion  = "13"
 	minimalVersion = "7.0"
+	// scrollBatchSize is the number of documents in each request of the Scroll API.
+	// We keep the same value as for the search API.
+	// If needed this value could be probably increased at least 10x.
+	// https://www.elastic.co/guide/en/elasticsearch/guide/current/bulk.html#_how_big_is_too_big
+	scrollBatchSize = 10000
 )
 
 var errOutdatedVersion = errors.New("elasticsearch server doesn't match the minimal required version")
@@ -73,6 +79,7 @@ type ClientInterface interface {
 	Delete(index Index, id string) (*elastic.DeleteResponse, error)
 	BulkDelete(index Index, id string) error
 	Search(query elastic.Query, pagination filters.SearchQuery, indices ...string) (*elastic.SearchResult, error)
+	Scroll(hits chan<- *elastic.SearchHit, query elastic.Query, pagination filters.SearchQuery, indices ...string) error
 	Start()
 	AddEventListener(listener storage.EventListener)
 	UpdateByScript(query elastic.Query, script *elastic.Script, indices ...string) error
@@ -509,7 +516,27 @@ func (c *Client) UpdateByScript(query elastic.Query, script *elastic.Script, ind
 	return nil
 }
 
-// Search an object
+// Scroll objects using the Scroll API. Send all hits to the hits channel.
+// Sort options are ignored, they impose a big performace hit.
+func (c *Client) Scroll(hits chan<- *elastic.SearchHit, query elastic.Query, opts filters.SearchQuery, indices ...string) error {
+	scrollQuery := c.esClient.Scroll(indices...).Query(query).Size(scrollBatchSize)
+	for {
+		results, err := scrollQuery.Do(context.Background())
+		if err == io.EOF {
+			return nil // all results retrieved
+		}
+		if err != nil {
+			return err // something went wrong
+		}
+
+		// Send the hits to the hits channel
+		for _, hit := range results.Hits.Hits {
+			hits <- hit
+		}
+	}
+}
+
+// Search an object. Maximum 10000 hits
 func (c *Client) Search(query elastic.Query, opts filters.SearchQuery, indices ...string) (*elastic.SearchResult, error) {
 	searchQuery := c.esClient.
 		Search().


### PR DESCRIPTION
The Sync method for the ElasticSearch backend was limited to a maximum
of 20k documents (10k nodes + 10k edges).
This is a clear limiting factor when the skydive database starts to
growth over 10k nodes (or edges).

To avoid increasing that fixed limit, we move the Sync method to use the
scroll api (https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#scroll-search-results).
This API is used to retrieve large numbers of results, using several
requests.

A pattern of one consumer and one producer in different goroutines is
being used to avoid creating a hige slice with all the results.

Testing with 51k nodes in the live index, using 3.3MB of space, it took
around 2" to sync, receiving from ES around 1MB of data (gzipped) in 6
requests to the scroll API.