### PR TITLE
graffiti: fix event generated by UpdateMetadata

### DIFF
--- a/graffiti/graph/graph.go
+++ b/graffiti/graph/graph.go
@@ -175,8 +175,7 @@ var (
 
 // DefaultGraphListener default implementation of a graph listener, can be used when not implementing
 // the whole set of callbacks
-type DefaultGraphListener struct {
-}
+type DefaultGraphListener struct{}
 
 // OnNodeUpdated event
 func (c *DefaultGraphListener) OnNodeUpdated(n *Node, ops []PartiallyUpdatedOp) {
@@ -875,12 +874,15 @@ func (g *Graph) AddMetadata(i interface{}, k string, v interface{}) error {
 // UpdateMetadata retrieves a value and calls a callback that can modify it then notify listeners of the update
 func (g *Graph) UpdateMetadata(i interface{}, key string, mutator func(obj interface{}) bool) error {
 	var e *graphElement
+	var graphEventType graphEventType
 
 	switch i.(type) {
 	case *Node:
 		e = &i.(*Node).graphElement
+		graphEventType = NodeUpdated
 	case *Edge:
 		e = &i.(*Edge).graphElement
+		graphEventType = EdgeUpdated
 	}
 
 	field, err := e.GetField(key)
@@ -895,7 +897,7 @@ func (g *Graph) UpdateMetadata(i interface{}, key string, mutator func(obj inter
 		if err := g.backend.MetadataUpdated(i); err != nil {
 			return err
 		}
-		g.eventHandler.NotifyEvent(NodeUpdated, i)
+		g.eventHandler.NotifyEvent(graphEventType, i)
 	}
 
 	return nil
@@ -1281,7 +1283,6 @@ func (g *Graph) delEdge(e *Edge, t Time) error {
 	e.DeletedAt = t
 	if err := g.backend.EdgeDeleted(e); err != nil {
 		return err
-
 	}
 
 	g.eventHandler.NotifyEvent(EdgeDeleted, e)


### PR DESCRIPTION
UpdateMetadata was always sending a NodeUpdated event, even when the
updated object was an edge.

That was causing a panic in EventHandler.notifyListeners:
interface conversion: interface {} is *graph.Edge, not *graph.Node