### PR TITLE
Fix missing curl when running the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04 as builder
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update \
-    && apt-get -y install build-essential git-core golang npm openvswitch-common libpcap0.8 libpcap0.8-dev libxml2-dev protobuf-compiler libprotobuf-dev libvirt-dev \
+    && apt-get -y install build-essential git-core golang npm openvswitch-common libpcap0.8 libpcap0.8-dev libxml2-dev protobuf-compiler libprotobuf-dev libvirt-dev curl \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /go/src/github.com/skydive-project/skydive
 COPY . .


### PR DESCRIPTION
Fix this error when running the `Dockefile`

<img width="316" alt="image" src="https://github.com/skydive-project/skydive/assets/996529/075e4c1d-1952-4dd8-9f3b-7ae03598d647">
