### PR TITLE
Update OCP Template resource's apiVersion

### DIFF
--- a/contrib/openshift/skydive-flow-exporter-template.yaml
+++ b/contrib/openshift/skydive-flow-exporter-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: skydive-flow-exporter

--- a/contrib/openshift/skydive-template.yaml
+++ b/contrib/openshift/skydive-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: skydive


### PR DESCRIPTION
Openshift moved the Template resource from api v1 to template.openshift.io/v1 on Openshift V4+. updating the OCP deploying script for the same.

more details: https://access.redhat.com/solutions/7067952